### PR TITLE
Make user event decoding infallible in api-identity

### DIFF
--- a/lib/convert/src/impls/cloud/version/mod.rs
+++ b/lib/convert/src/impls/cloud/version/mod.rs
@@ -41,6 +41,7 @@ pub async fn config_to_openapi(
 	value: backend::cloud::VersionConfig,
 ) -> GlobalResult<models::CloudVersionConfig> {
 	Ok(models::CloudVersionConfig {
+		engine: None, // CLient side only
 		cdn: value
 			.cdn
 			.map(ApiTryFrom::try_from)

--- a/svc/api/cloud/default-site/index.html
+++ b/svc/api/cloud/default-site/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 	<head>
 		<title>__DISPLAY_NAME__</title>

--- a/svc/api/identity/src/route/events.rs
+++ b/svc/api/identity/src/route/events.rs
@@ -166,33 +166,38 @@ async fn events_wait(
 	let mut user_update_ts = None;
 	for msg in thread_tail.messages {
 		let event = internal_unwrap!(msg.event);
-		match internal_unwrap!(event.kind) {
-			backend::user::event::event::Kind::ChatMessage(chat_msg) => {
-				let chat_message = internal_unwrap!(chat_msg.chat_message).clone();
-				new_messages.push(chat_message);
+
+		if let Some(event) = &event.kind {
+			match event {
+				backend::user::event::event::Kind::ChatMessage(chat_msg) => {
+					let chat_message = internal_unwrap!(chat_msg.chat_message).clone();
+					new_messages.push(chat_message);
+				}
+				backend::user::event::event::Kind::ChatRead(chat_read) => {
+					new_chat_reads.push((
+						internal_unwrap!(chat_read.thread_id).as_uuid(),
+						chat_read.clone(),
+					));
+				}
+				backend::user::event::event::Kind::PartyUpdate(_) => {
+					party_update_ts = Some(msg.msg_ts());
+				}
+				backend::user::event::event::Kind::MatchmakerLobbyJoin(mm_lobby_join) => {
+					new_mm_lobby_joins.push((msg.msg_ts(), mm_lobby_join.clone()));
+				}
+				backend::user::event::event::Kind::UserUpdate(_) => {
+					user_update_ts = Some(msg.msg_ts());
+				}
+				backend::user::event::event::Kind::PresenceUpdate(_) => {
+					user_update_ts = Some(msg.msg_ts());
+				}
+				backend::user::event::event::Kind::TeamMemberRemove(team) => {
+					removed_team_ids.push((msg.msg_ts(), internal_unwrap!(team.team_id).as_uuid()));
+				}
 			}
-			backend::user::event::event::Kind::ChatRead(chat_read) => {
-				new_chat_reads.push((
-					internal_unwrap!(chat_read.thread_id).as_uuid(),
-					chat_read.clone(),
-				));
-			}
-			backend::user::event::event::Kind::PartyUpdate(_) => {
-				party_update_ts = Some(msg.msg_ts());
-			}
-			backend::user::event::event::Kind::MatchmakerLobbyJoin(mm_lobby_join) => {
-				new_mm_lobby_joins.push((msg.msg_ts(), mm_lobby_join.clone()));
-			}
-			backend::user::event::event::Kind::UserUpdate(_) => {
-				user_update_ts = Some(msg.msg_ts());
-			}
-			backend::user::event::event::Kind::PresenceUpdate(_) => {
-				user_update_ts = Some(msg.msg_ts());
-			}
-			backend::user::event::event::Kind::TeamMemberRemove(team) => {
-				removed_team_ids.push((msg.msg_ts(), internal_unwrap!(team.team_id).as_uuid()));
-			}
-		};
+		} else {
+			tracing::warn!("unknown user event kind");
+		}
 	}
 
 	Ok(EventsWaitResponse {

--- a/svc/api/identity/src/route/events.rs
+++ b/svc/api/identity/src/route/events.rs
@@ -196,7 +196,7 @@ async fn events_wait(
 				}
 			}
 		} else {
-			tracing::warn!("unknown user event kind");
+			tracing::warn!(?event, "unknown user event kind");
 		}
 	}
 


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes
Make user event decoding infallible in api-identity
<!-- If there are frontend changes, please include screenshots. -->
