### PR TITLE
Add missing database to api-identity, new bolt command

### DIFF
--- a/svc/api/identity/Service.toml
+++ b/svc/api/identity/Service.toml
@@ -10,3 +10,5 @@ kind = "rust"
 path = "/v1"
 subdomain = "identity.api"
 
+[databases]
+db-team-dev = {}


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes
- Add `bolt output service-databases` command to view all recursive database dependencies
- Fix api-identity database dependencies
<!-- If there are frontend changes, please include screenshots. -->
