### PR TITLE
:herb: Typescript client is named `RivetApiClient`

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -7,7 +7,6 @@ groups:
       - name: fernapi/fern-typescript-node-sdk
         version: 0.7.2
         config:
-          namespaceExport: Rivet
           bundle: true
         output:
           location: npm


### PR DESCRIPTION
This PR removes the namespace export so that `RivetClient` -> `RivetApiClient`. 
