### PR TITLE
Revert SameSite cookie to None

### DIFF
--- a/docs/infrastructure/k3s/TROUBLESHOOTING.md
+++ b/docs/infrastructure/k3s/TROUBLESHOOTING.md
@@ -19,4 +19,3 @@ Run `kubectl describe` on the pod. Your machine likely ran out of storage or mem
 Once you have cleaned up disk space, run `kubectl describe nodes` to see if the node show the error still there. You may have to run `k3d cluster stop <cluster name> && k3d cluster start <cluster name>` to restart the cluster.
 
 If you see `Unschedulable: true`, fix it by running: `kubectl uncordon <node name>`
-


### PR DESCRIPTION
Reverts changes to `SameSite` on hub cookies to use `None`. This is because the hub is on a different domain than the API endpoints.