### PR TITLE
Configurable sccache for service Docker builds

### DIFF
--- a/.github/actions/pre-init/action.yaml
+++ b/.github/actions/pre-init/action.yaml
@@ -8,9 +8,9 @@ description: "Set up Nix and Bolt"
 #     shell: bash -e {0}
 
 inputs:
-  sscache_aws_secret_access_key:
+  sccache_aws_secret_access_key:
     required: true
-  sscache_aws_access_key_id:
+  sccache_aws_access_key_id:
     required: true
 
 runs:
@@ -34,10 +34,10 @@ runs:
         # Expose sccache config for all future calls of nix-shell, which configures sccache respectively
         echo 'USE_SCCACHE=1' >> $GITHUB_ENV
         echo 'SCCACHE_BUCKET=rivet-sccache' >> $GITHUB_ENV
-        echo 'SCCACHE_ENDPOINT=https://2a94c6a0ced8d35ea63cddc86c2681e7.r2.cloudflarestorage.com/rivet-sscache' >> $GITHUB_ENV
+        echo 'SCCACHE_ENDPOINT=https://2a94c6a0ced8d35ea63cddc86c2681e7.r2.cloudflarestorage.com/rivet-sccache' >> $GITHUB_ENV
         echo 'SCCACHE_REGION=auto' >> $GITHUB_ENV
-        echo 'AWS_SECRET_ACCESS_KEY=${{ inputs.sscache_aws_secret_access_key }}' >> $GITHUB_ENV
-        echo 'AWS_ACCESS_KEY_ID=${{ inputs.sscache_aws_access_key_id }}' >> $GITHUB_ENV
+        echo 'AWS_SECRET_ACCESS_KEY=${{ inputs.sccache_aws_secret_access_key }}' >> $GITHUB_ENV
+        echo 'AWS_ACCESS_KEY_ID=${{ inputs.sccache_aws_access_key_id }}' >> $GITHUB_ENV
 
     # Cache generated Bolt files in order to prevent needless rebuilding
     - name: Bolt Cache

--- a/.github/workflows/bolt-check.yaml
+++ b/.github/workflows/bolt-check.yaml
@@ -28,8 +28,8 @@ jobs:
 
       - uses: ./.github/actions/pre-init
         with:
-          sscache_aws_secret_access_key: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
-          sscache_aws_access_key_id: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+          sccache_aws_secret_access_key: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
+          sccache_aws_access_key_id: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
 
       - name: Bolt Generate Project
         run: nix-shell --pure --run "bolt gen project"

--- a/.github/workflows/bolt-test.yaml
+++ b/.github/workflows/bolt-test.yaml
@@ -28,8 +28,8 @@ jobs:
 
       - uses: ./.github/actions/pre-init
         with:
-          sscache_aws_secret_access_key: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
-          sscache_aws_access_key_id: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+          sccache_aws_secret_access_key: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
+          sccache_aws_access_key_id: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
 
       - name: Bolt Init
         run: nix-shell --pure --run "bolt init --yes ci"

--- a/lib/bolt/config/src/ns.rs
+++ b/lib/bolt/config/src/ns.rs
@@ -502,6 +502,21 @@ impl Default for Traefik {
 pub struct Rust {
 	#[serde(default)]
 	pub build_opt: RustBuildOpt,
+
+	/// Enables using sccache to speed up Docker builds since we cannot use a shared Docker file.
+	///
+	/// Does not support `bolt check`. This will cause `bolt up` to error on single node
+	/// installations if sccache is not installed.
+	#[serde(default)]
+	pub sccache: Option<RustSccache>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RustSccache {
+	pub bucket: String,
+	pub endpoint: String,
+	pub region: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]


### PR DESCRIPTION
Docker builds take a long time to build. sccache has already sped up CI significantly by making bolt check run faster. Adding sccache to Docker builds cuts ~50% off the build time.

Fixes SVC-3427

Depends on #194 