### PR TITLE
Gracefully ignore cookies that can't be decoded

### DIFF
--- a/errors/api/bad-cookie.md
+++ b/errors/api/bad-cookie.md
@@ -1,9 +1,0 @@
----
-name = "API_BAD_COOKIE"
-description = "The \"{cookie}\" cookie could not be deserialized."
-http_status = 400
----
-
-# API Bad Cookie
-
-A request cookie could not be deserialized.

--- a/errors/api/missing-cookie.md
+++ b/errors/api/missing-cookie.md
@@ -1,9 +1,0 @@
----
-name = "API_MISSING_COOKIE"
-description = "Missing cookie: \"{cookie}\"."
-http_status = 400
----
-
-# API Missing Cookie
-
-A request cookie is required but missing.

--- a/lib/api-helper/build/src/macro_util.rs
+++ b/lib/api-helper/build/src/macro_util.rs
@@ -220,11 +220,65 @@ pub fn __deserialize_optional_cookie<T: FromStr + Send>(
 	request: &Request<Body>,
 	cookie_name: &str,
 ) -> GlobalResult<Option<T>> {
-	if let Some(cookie) = request
+	let expected_domain = util::env::domain_main_api();
+	let cookie = request
 		.headers()
+		// Get the cookie header
 		.typed_get::<Cookie>()
-		.and_then(|cookie_header| cookie_header.get(cookie_name).map(ToOwned::to_owned))
-	{
+		.and_then(|cookie_header| {
+			if let Some(expected_domain) = expected_domain {
+				cookie_header
+					.iter()
+					// Find cookie with name
+					.filter(|&(k, _)| k == cookie_name)
+					// Find cookie with the correct domain
+					.filter(|&(k, v)| {
+						// Parse the domain
+						let domain = v
+							.split(";")
+							.map(|x| x.trim())
+							.map(|x| x.to_lowercase())
+							.filter_map(|x| x.strip_prefix("domain=").map(|x| x.to_owned()))
+							.next();
+
+						// Check domain exists
+						if let Some(domain) = domain {
+							// Check domain matches. We do this because there may be cookies on parent
+							// domains. For example, cookies from bar.com would conflict with cookies
+							// from foo.bar.com.
+							//
+							// We have to match both `api.rivet.gg` and `.api.api.rivet.gg`. The
+							// returned cookie does not include a leading dot, but browsers will
+							// add it by default in the response.
+							if domain == expected_domain
+								|| domain
+									.strip_prefix(".")
+									.map_or(false, |x| x == expected_domain)
+							{
+								true
+							} else {
+								tracing::warn!(
+									?k,
+									?v,
+									?domain,
+									?expected_domain,
+									"cookie domain does not match"
+								);
+								false
+							}
+						} else {
+							tracing::warn!(?k, ?v, "cookie domain not provided");
+							false
+						}
+					})
+					.map(|x| x.1.to_owned())
+					.next()
+			} else {
+				cookie_header.get(cookie_name).map(|x| x.to_owned())
+			}
+		});
+
+	if let Some(cookie) = cookie {
 		Ok(Some(T::from_str(cookie.as_str()).map_err(|_| {
 			err_code!(API_BAD_COOKIE, cookie = cookie_name)
 		})?))

--- a/lib/api-helper/macros/src/lib.rs
+++ b/lib/api-helper/macros/src/lib.rs
@@ -24,9 +24,8 @@ const ENDPOINT_ARGUMENTS: &[&str] = &[
 	"body",
 	"body_as_bytes",
 	"body_as_stream",
-	"cookie",
+	"cookies",
 	"raw_remote_addr",
-	"opt_cookie",
 	"header",
 	"opt_auth",
 	"not_using_cloudflare",
@@ -862,33 +861,12 @@ impl EndpointFunction {
 							&router_config.route
 						)?;
 					})
-				} else if arg.label == "opt_cookie" {
-					let value = arg.value.expect_expr()?;
-
+				} else if arg.label == "cookies" {
 					let arg_name = format_ident!("{}_{}", arg.label, i);
 					arg_list.push(arg_name.to_token_stream());
 
-					let associated_type = arg
-						.associated_type
-						.map(|t| quote! { #t })
-						.unwrap_or_else(|| quote! { _ });
-
 					Ok(quote! {
-						let #arg_name = macro_util::__deserialize_optional_cookie::<#associated_type>(&request, #value)?;
-					})
-				} else if arg.label == "cookie" {
-					let value = arg.value.expect_expr()?;
-
-					let arg_name = format_ident!("{}_{}", arg.label, i);
-					arg_list.push(arg_name.to_token_stream());
-
-					let associated_type = arg
-						.associated_type
-						.map(|t| quote! { #t })
-						.unwrap_or_else(|| quote! { _ });
-
-					Ok(quote! {
-						let #arg_name = macro_util::__deserialize_cookie::<#associated_type>(&request, #value)?;
+						let #arg_name = macro_util::__deserialize_cookies(&request);
 					})
 				} else if arg.label == "header" {
 					let value = arg.value.expect_expr()?;

--- a/svc/Cargo.lock
+++ b/svc/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "email-verification-complete",
  "email-verification-create",
  "faker-user",
+ "headers",
  "http",
  "hyper",
  "lazy_static",

--- a/svc/api/auth/Cargo.toml
+++ b/svc/api/auth/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1"
 chirp-client = { path = "../../../lib/chirp/client" }
 rivet-operation = { path = "../../../lib/operation/core" }
 chrono = "0.4"
+headers = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["server", "http1", "stream", "tcp"] }
 lazy_static = "1.4"

--- a/svc/api/auth/src/route/identity.rs
+++ b/svc/api/auth/src/route/identity.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::str::FromStr;
 
 use api_helper::ctx::Ctx;
 use email_verification::complete::response::Status as StatusProto;
@@ -38,7 +37,7 @@ pub async fn start(
 						turnstile: Some(backend::captcha::captcha_config::Turnstile {
 							// Not needed for captcha verification
 							site_key: "".to_string(),
-							secret_key: secret_key,
+							secret_key,
 						}),
 						..Default::default()
 					}),
@@ -62,9 +61,7 @@ pub async fn start(
 
 	let verification_id = unwrap_ref!(res.verification_id).as_uuid();
 
-	Ok(models::AuthIdentityStartEmailVerificationResponse {
-		verification_id: verification_id,
-	})
+	Ok(models::AuthIdentityStartEmailVerificationResponse { verification_id })
 }
 
 // MARK: POST /identity/email/complete-verification

--- a/svc/api/auth/src/route/mod.rs
+++ b/svc/api/auth/src/route/mod.rs
@@ -26,7 +26,7 @@ define_router! {
 			POST: tokens::identity(
 				body: models_old::RefreshIdentityTokenRequest,
 				with_response: true,
-				opt_cookie: tokens::USER_REFRESH_TOKEN_COOKIE,
+				cookies: true,
 				opt_auth: true,
 			),
 		},


### PR DESCRIPTION
Currenlty, Rivet parses the first cookie with the given key in the auth request. However, there are frequently situations (either localhost changing origins or having the wrong `Domain`) where there are residual cookies created by a different cluster.

This PR makes it so it parses all the cookies and finds the first one that can be parsed (i.e. has the correct JWT key). This way, the correct cookie is always parsed.