### PR TITLE
Redis fallback in mm-player-remove

### DIFF
--- a/svc/api/matchmaker/src/route/lobbies.rs
+++ b/svc/api/matchmaker/src/route/lobbies.rs
@@ -929,6 +929,7 @@ async fn find_inner(
 				None
 			},
 		bypass_verification: matches!(verification, VerificationType::Bypass),
+		debug: None,
 	})
 	.await?;
 	let lobby_id = match find_res

--- a/svc/pkg/mm/types/msg/lobby-find.proto
+++ b/svc/pkg/mm/types/msg/lobby-find.proto
@@ -42,5 +42,13 @@ message Message {
 	optional string verification_data_json = 202;
 	// Bypasses user data verification (if the give lobby group has any).
 	bool bypass_verification = 203;
+
+	optional Debug debug = 301;
 }
 
+message Debug {
+	// Intentionally throw an error between inserting in to Redis an
+	// inserting in to SQL in order to test how this failure is
+	// handled.
+	bool fail_sql = 301;
+}

--- a/svc/pkg/mm/worker/src/workers/lobby_find/mod.rs
+++ b/svc/pkg/mm/worker/src/workers/lobby_find/mod.rs
@@ -29,7 +29,7 @@ async fn fail(
 	error_code: ErrorCode,
 	force_fail: bool,
 ) -> GlobalResult<()> {
-	tracing::warn!(%namespace_id, ?query_id, ?error_code, ?force_fail, "player create failed");
+	tracing::warn!(%namespace_id, ?query_id, ?error_code, ?force_fail, "lobby create failed");
 
 	let ctx = ctx.base();
 	tokio::task::Builder::new()
@@ -288,6 +288,9 @@ async fn worker(ctx: &OperationContext<mm::msg::lobby_find::Message>) -> GlobalR
 		now_ts: ctx.ts(),
 		ray_id: ctx.ray_id(),
 	};
+	if ctx.debug.as_ref().map_or(false, |x| x.fail_sql) {
+		bail!("debug fail sql");
+	}
 	rivet_pools::utils::crdb::tx(&crdb, |tx| {
 		let ctx = ctx.clone();
 		Box::pin(insert_to_crdb(ctx, tx, insert_opts.clone()))
@@ -586,6 +589,8 @@ async fn insert_to_crdb(
 		ray_id,
 	}: InsertCrdbOpts,
 ) -> GlobalResult<()> {
+	// These queries are idempotent
+
 	// Insert preemptive lobby row if needed
 	if auto_create_lobby {
 		// Lobby group will exist if the lobby was auto created
@@ -595,7 +600,7 @@ async fn insert_to_crdb(
 		sql_execute!(
 			[ctx, @tx tx]
 			"
-			INSERT INTO db_mm_state.lobbies (
+			UPSERT INTO db_mm_state.lobbies (
 				lobby_id,
 				namespace_id,
 				region_id,
@@ -630,7 +635,7 @@ async fn insert_to_crdb(
 	sql_execute!(
 		[ctx, @tx tx]
 		"
-		INSERT INTO db_mm_state.find_queries (
+		UPSERT INTO db_mm_state.find_queries (
 			query_id,
 			namespace_id,
 			join_kind,
@@ -654,7 +659,7 @@ async fn insert_to_crdb(
 		sql_execute!(
 			[ctx, @tx tx]
 			"
-			INSERT INTO db_mm_state.players (
+			UPSERT INTO db_mm_state.players (
 				player_id,
 				lobby_id,
 				find_query_id,

--- a/svc/pkg/mm/worker/src/workers/player_remove.rs
+++ b/svc/pkg/mm/worker/src/workers/player_remove.rs
@@ -1,5 +1,6 @@
 use chirp_worker::prelude::*;
 use proto::backend::pkg::*;
+use redis::AsyncCommands;
 use serde_json::json;
 use tracing::Instrument;
 
@@ -11,7 +12,7 @@ lazy_static::lazy_static! {
 struct PlayerRow {
 	// Lobby may not exist for this ID if mm-lobby-create didn't succeed
 	lobby_id: Uuid,
-	create_ts: i64,
+	create_ts: Option<i64>,
 	register_ts: Option<i64>,
 	remote_address: Option<String>,
 	remove_ts: Option<i64>,
@@ -25,14 +26,9 @@ struct PlayerRow {
 	max_players_party: i64,
 }
 
-#[derive(Debug, sqlx::FromRow)]
-struct LobbyRow {}
-
 #[worker(name = "mm-player-remove")]
 async fn worker(ctx: &OperationContext<mm::msg::player_remove::Message>) -> GlobalResult<()> {
 	// NOTE: Idempotent
-
-	let crdb = ctx.crdb().await?;
 
 	let player_id = unwrap_ref!(ctx.player_id).as_uuid();
 	let lobby_id = ctx.lobby_id.map(|x| x.as_uuid());
@@ -79,13 +75,15 @@ async fn worker(ctx: &OperationContext<mm::msg::player_remove::Message>) -> Glob
 	.await?;
 	tracing::info!(?player_row, "player row");
 
-	let Some(player_row) = player_row else {
-		if ctx.req_dt() > util::duration::minutes(5) {
-			tracing::error!("discarding stale message");
-			return Ok(());
-		} else {
-			retry_bail!("player not found, may be race condition with insertion");
-		}
+	let player_row = if let Some(player_row) = player_row {
+		player_row
+	} else if let Some(player_row) = fallback_fetch_player_from_redis(&ctx, player_id).await? {
+		player_row
+	} else if ctx.req_dt() > util::duration::minutes(5) {
+		tracing::error!("discarding stale message");
+		return Ok(());
+	} else {
+		retry_bail!("player not found, may be race condition with insertion");
 	};
 
 	// Validate lobby
@@ -269,4 +267,82 @@ async fn fail(
 	.await?;
 
 	Ok(())
+}
+
+/// If the player does not exist in Cockraoch, then attempt to fetch it from Redis.
+///
+/// This happens when the SQL query to insert in to the database fails after the player was already
+/// preemptively inserted in to Redis. It's a rare edge case, but has cascading implications for
+/// player counts.
+#[tracing::instrument(skip(ctx))]
+async fn fallback_fetch_player_from_redis(
+	ctx: &OperationContext<mm::msg::player_remove::Message>,
+	player_id: Uuid,
+) -> GlobalResult<Option<PlayerRow>> {
+	tracing::warn!("player not found in cockroach, falling back to fetching from redis");
+
+	let mut redis = ctx.redis_mm().await?;
+
+	// Read player config
+	let mut player_config_iter = redis
+		.hget::<_, _, Vec<Option<String>>>(
+			util_mm::key::player_config(player_id),
+			&[
+				util_mm::key::player_config::LOBBY_ID,
+				util_mm::key::player_config::REMOTE_ADDRESS,
+			],
+		)
+		.await?
+		.into_iter();
+
+	// If the first value is nil, then there is no player config in Redis
+	let Some(lobby_id_str) = unwrap!(player_config_iter.next()) else {
+		tracing::warn!(?player_id, "player does not exist in redis");
+		return Ok(None);
+	};
+
+	let lobby_id = lobby_id_str.parse::<Uuid>()?;
+	let remote_address = unwrap!(player_config_iter.next());
+
+	// Read lobby config
+	let mut lobby_config_iter = redis
+		.hget::<_, _, Vec<Option<String>>>(
+			util_mm::key::lobby_config(lobby_id),
+			&[
+				util_mm::key::lobby_config::NAMESPACE_ID,
+				util_mm::key::lobby_config::REGION_ID,
+				util_mm::key::lobby_config::LOBBY_GROUP_ID,
+				util_mm::key::lobby_config::MAX_PLAYERS_NORMAL,
+			],
+		)
+		.await?
+		.into_iter();
+	let Some(namespace_id_str) = unwrap!(lobby_config_iter.next()) else {
+		tracing::warn!(?lobby_id, "lobby does not exist in redis");
+		return Ok(None);
+	};
+	let namespace_id = namespace_id_str.parse::<Uuid>()?;
+	let region_id = unwrap!(unwrap!(lobby_config_iter.next())).parse::<Uuid>()?;
+	let lobby_group_id = unwrap!(unwrap!(lobby_config_iter.next())).parse::<Uuid>()?;
+	let max_players_normal = unwrap!(unwrap!(lobby_config_iter.next())).parse::<i64>()?;
+
+	// Build row with the information we have
+	let row = PlayerRow {
+		// Lobby may not exist for this ID if mm-lobby-create didn't succeed
+		lobby_id,
+		create_ts: None,
+		register_ts: None,
+		remote_address,
+		remove_ts: None,
+
+		// Lobby
+		namespace_id,
+		region_id,
+		lobby_group_id,
+		lobby_stop_ts: None,
+		max_players_normal,
+		max_players_party: max_players_normal,
+	};
+
+	Ok(Some(row))
 }

--- a/svc/pkg/mm/worker/tests/lobby_find.rs
+++ b/svc/pkg/mm/worker/tests/lobby_find.rs
@@ -1021,6 +1021,8 @@ async fn find(
 		user_id: req.user_id.map(Into::into),
 		verification_data_json: req.verification_data_json,
 		bypass_verification: req.bypass_verification,
+
+		debug: None,
 	})
 	.await
 	.unwrap()


### PR DESCRIPTION
mm-lobby-find creates players premptively in Redis before inserting in to Cockroach. If the Cockroach insertion fails, then the players are not able to be removed from Redis.

Now we can fallback to reading the plyaer's state from Redis to remove the player if the player does not exist in Cockroach.