### PR TITLE
Fix Prometheus Node Exporter pod

### DIFF
--- a/docs/getting_started/DEBUGGING.md
+++ b/docs/getting_started/DEBUGGING.md
@@ -120,3 +120,16 @@ Rivet exposes extensive Prometheus metrics on our internal services. Look for th
 ## Alerting
 
 Rivet uses Alert Manager extensively for catching errors before they happen & quickly narrowing down the source of errors. Alerts can be pushed to Slack if the `alertmanager/slack/url` and `alertmanager/slack/channel` secrets are provided. See _infra/tf/k8s_infra/prometheus.tf_.
+
+## Prometheus Node Exporter pod `CreateContainerError`
+
+If you are using the development environment and the `prometheus-node-exporter`
+pod is failing with the `CreateContainerError` error, you'll need to run the
+following script to fix it:
+
+```bash
+scripts/k3s/fix_-_node_-_exporter.sh
+```
+
+You can find more details in [this
+issue](https://github.com/rivet-gg/rivet/issues/208)

--- a/scripts/k3s/fix_node_exporter.sh
+++ b/scripts/k3s/fix_node_exporter.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -euf
+
+# This needs to be run after a system reboot if you are using k3d in k3d as the
+# development environment. See more details here:
+# https://github.com/rivet-gg/rivet/issues/208
+
+docker exec k3d-rivet-dev-server-0 \
+    mount --make-rshared /


### PR DESCRIPTION
This will close #208.

<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

This adds a post-cluster-creation script to the k3d cluser Terraform config to make sure that the filesystem root has shared mount propagation. Prometheus Node Exporter requires being mounted to the root, so this is needed.

A script is also added that can be run if the dev system is rebooted, since `mount --make-rshared /` won't persist after a container reboots. I haven't found a better way to handle this, since it would require being built into the Docker image itself. I added to DEBUGGING.md to describe how to resolve this.