### PR TITLE
Remove duplicated code in monolith-worker

### DIFF
--- a/svc/pkg/monolith/standalone/worker/src/lib.rs
+++ b/svc/pkg/monolith/standalone/worker/src/lib.rs
@@ -18,18 +18,6 @@ pub async fn run_from_env(pools: rivet_pools::Pools) -> GlobalResult<()> {
 	let shared_client = chirp_client::SharedClient::from_env(pools.clone())?;
 	let cache = rivet_cache::CacheInner::from_env(pools.clone())?;
 
-	tokio::task::Builder::new()
-		.name("monolith_worker::health_checks")
-		.spawn(rivet_health_checks::run_standalone(
-			rivet_health_checks::Config {
-				pools: Some(pools.clone()),
-			},
-		))?;
-
-	tokio::task::Builder::new()
-		.name("monolith_worker::metrics")
-		.spawn(rivet_metrics::run_standalone())?;
-
 	// Start workers
 	let mut join_set = tokio::task::JoinSet::new();
 	spawn_workers![

--- a/svc/pkg/monolith/standalone/worker/src/main.rs
+++ b/svc/pkg/monolith/standalone/worker/src/main.rs
@@ -7,18 +7,6 @@ fn main() -> GlobalResult<()> {
 async fn start() -> GlobalResult<()> {
 	let pools = rivet_pools::from_env("monolith-worker").await?;
 
-	tokio::task::Builder::new()
-		.name("monolith_worker::health_checks")
-		.spawn(rivet_health_checks::run_standalone(
-			rivet_health_checks::Config {
-				pools: Some(pools.clone()),
-			},
-		))?;
-
-	tokio::task::Builder::new()
-		.name("monolith_worker::metrics")
-		.spawn(rivet_metrics::run_standalone())?;
-
 	monolith_worker::run_from_env(pools).await?;
 
 	Ok(())

--- a/svc/pkg/monolith/standalone/worker/src/main.rs
+++ b/svc/pkg/monolith/standalone/worker/src/main.rs
@@ -7,6 +7,18 @@ fn main() -> GlobalResult<()> {
 async fn start() -> GlobalResult<()> {
 	let pools = rivet_pools::from_env("monolith-worker").await?;
 
+	tokio::task::Builder::new()
+		.name("monolith_worker::health_checks")
+		.spawn(rivet_health_checks::run_standalone(
+			rivet_health_checks::Config {
+				pools: Some(pools.clone()),
+			},
+		))?;
+
+	tokio::task::Builder::new()
+		.name("monolith_worker::metrics")
+		.spawn(rivet_metrics::run_standalone())?;
+
 	monolith_worker::run_from_env(pools).await?;
 
 	Ok(())


### PR DESCRIPTION
This closes #211.

## Changes

As mentioned in the issue, the duplicated code is in the main and lib files. I opted to remove the code from lib and keep the one in main, since that seems to be what most other services do.