### PR TITLE
Reformat worker mod files

### DIFF
--- a/lib/chirp/worker/src/macros.rs
+++ b/lib/chirp/worker/src/macros.rs
@@ -4,10 +4,6 @@ macro_rules! workers {
 		use ::chirp_worker::prelude::*;
 		use chirp_types::message::Message;
 
-		$(
-			pub mod $worker;
-		)*
-
 		pub fn spawn_workers(shared_client: chirp_client::SharedClientHandle, pools: rivet_pools::Pools, cache: rivet_cache::Cache, join_set: &mut tokio::task::JoinSet<GlobalResult<()>>) -> GlobalResult<()> {
 			// Spawn a manager for each worker
 			$(

--- a/svc/pkg/analytics/worker/src/workers/mod.rs
+++ b/svc/pkg/analytics/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod event_create;
+
 chirp_worker::workers![event_create,];

--- a/svc/pkg/cdn/worker/src/workers/mod.rs
+++ b/svc/pkg/cdn/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod ns_config_populate;
+
 chirp_worker::workers![ns_config_populate,];

--- a/svc/pkg/cf-custom-hostname/worker/src/workers/mod.rs
+++ b/svc/pkg/cf-custom-hostname/worker/src/workers/mod.rs
@@ -1,1 +1,5 @@
+mod create;
+mod delete;
+mod status_set;
+
 chirp_worker::workers![create, delete, status_set,];

--- a/svc/pkg/cloud/worker/src/workers/mod.rs
+++ b/svc/pkg/cloud/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod device_link_complete;
+
 chirp_worker::workers![device_link_complete,];

--- a/svc/pkg/external/worker/src/workers/mod.rs
+++ b/svc/pkg/external/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod request_call;
+
 chirp_worker::workers![request_call,];

--- a/svc/pkg/game-user/worker/src/workers/mod.rs
+++ b/svc/pkg/game-user/worker/src/workers/mod.rs
@@ -1,1 +1,4 @@
+mod link_complete;
+mod session_create;
+
 chirp_worker::workers![link_complete, session_create,];

--- a/svc/pkg/job-log/worker/src/workers/mod.rs
+++ b/svc/pkg/job-log/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod export;
+
 chirp_worker::workers![export];

--- a/svc/pkg/job-run/worker/src/workers/mod.rs
+++ b/svc/pkg/job-run/worker/src/workers/mod.rs
@@ -1,3 +1,10 @@
+mod cleanup;
+mod create;
+mod nomad_monitor_alloc_plan;
+mod nomad_monitor_alloc_update;
+mod nomad_monitor_eval_update;
+mod stop;
+
 chirp_worker::workers![
 	cleanup,
 	create,

--- a/svc/pkg/kv/worker/src/workers/mod.rs
+++ b/svc/pkg/kv/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod write;
+
 chirp_worker::workers![write,];

--- a/svc/pkg/mm/worker/src/workers/lobby_find/find.rs
+++ b/svc/pkg/mm/worker/src/workers/lobby_find/find.rs
@@ -22,7 +22,7 @@ lazy_static::lazy_static! {
 /// Query that will be passed to the Redis find script as JSON.
 mod redis_query {
 	use std::collections::HashMap;
-	
+
 	use chirp_worker::prelude::*;
 	use serde::Serialize;
 
@@ -196,8 +196,10 @@ pub async fn find(
 						namespace_id,
 						region_id,
 						lobby_group_id,
-						max_players_normal: dynamic_max_players.unwrap_or(lobby_group.max_players_normal),
-						max_players_direct: dynamic_max_players.unwrap_or(lobby_group.max_players_direct),
+						max_players_normal: dynamic_max_players
+							.unwrap_or(lobby_group.max_players_normal),
+						max_players_direct: dynamic_max_players
+							.unwrap_or(lobby_group.max_players_direct),
 						max_players_party: lobby_group.max_players_party,
 						preemptive: true,
 						ready_ts: None,

--- a/svc/pkg/mm/worker/src/workers/mod.rs
+++ b/svc/pkg/mm/worker/src/workers/mod.rs
@@ -1,3 +1,19 @@
+mod lobby_cleanup;
+mod lobby_closed_set;
+mod lobby_create;
+mod lobby_find;
+mod lobby_find_job_run_fail;
+mod lobby_find_lobby_cleanup;
+mod lobby_find_lobby_create_fail;
+mod lobby_find_lobby_ready;
+mod lobby_history_export;
+mod lobby_job_run_cleanup;
+mod lobby_ready_set;
+mod lobby_state_set;
+mod lobby_stop;
+mod player_register;
+mod player_remove;
+
 chirp_worker::workers![
 	lobby_cleanup,
 	lobby_closed_set,

--- a/svc/pkg/module/worker/src/workers/mod.rs
+++ b/svc/pkg/module/worker/src/workers/mod.rs
@@ -1,3 +1,10 @@
+mod create;
+mod instance_create;
+mod instance_destroy;
+mod instance_version_set;
+mod ns_version_set;
+mod version_create;
+
 chirp_worker::workers![
 	create,
 	instance_create,

--- a/svc/pkg/push-notification/worker/src/workers/mod.rs
+++ b/svc/pkg/push-notification/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod send;
+
 chirp_worker::workers![send,];

--- a/svc/pkg/team-dev/worker/src/workers/mod.rs
+++ b/svc/pkg/team-dev/worker/src/workers/mod.rs
@@ -1,1 +1,5 @@
+mod create;
+mod halt_team_dev_update;
+mod status_update;
+
 chirp_worker::workers![create, halt_team_dev_update, status_update,];

--- a/svc/pkg/team-invite/worker/src/workers/mod.rs
+++ b/svc/pkg/team-invite/worker/src/workers/mod.rs
@@ -1,1 +1,4 @@
+mod consume;
+mod create;
+
 chirp_worker::workers![consume, create,];

--- a/svc/pkg/team/worker/src/workers/mod.rs
+++ b/svc/pkg/team/worker/src/workers/mod.rs
@@ -1,3 +1,14 @@
+mod create;
+mod join_request_create;
+mod join_request_resolve;
+mod member_create;
+mod member_kick;
+mod member_remove;
+mod owner_transfer;
+mod profile_set;
+mod user_ban;
+mod user_unban;
+
 chirp_worker::workers![
 	create,
 	join_request_create,

--- a/svc/pkg/upload/worker/src/workers/mod.rs
+++ b/svc/pkg/upload/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod delete;
+
 chirp_worker::workers![delete,];

--- a/svc/pkg/user-dev/worker/src/workers/mod.rs
+++ b/svc/pkg/user-dev/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod game_update;
+
 chirp_worker::workers![game_update,];

--- a/svc/pkg/user-follow/worker/src/workers/mod.rs
+++ b/svc/pkg/user-follow/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod request_ignore;
+
 chirp_worker::workers![request_ignore,];

--- a/svc/pkg/user-presence/worker/src/workers/mod.rs
+++ b/svc/pkg/user-presence/worker/src/workers/mod.rs
@@ -1,1 +1,6 @@
+mod arrive;
+mod game_activity_set;
+mod leave;
+mod status_set;
+
 chirp_worker::workers![arrive, game_activity_set, leave, status_set,];

--- a/svc/pkg/user-report/worker/src/workers/mod.rs
+++ b/svc/pkg/user-report/worker/src/workers/mod.rs
@@ -1,1 +1,3 @@
+mod create;
+
 chirp_worker::workers![create,];

--- a/svc/pkg/user/worker/src/workers/mod.rs
+++ b/svc/pkg/user/worker/src/workers/mod.rs
@@ -1,3 +1,19 @@
+mod admin_set;
+mod create;
+mod delete;
+mod event_team_member_remove;
+mod event_user_mm_lobby_join;
+mod event_user_presence_update;
+mod event_user_update;
+mod profile_set;
+mod search_update;
+mod search_update_user_follow_create;
+mod search_update_user_update;
+mod updated_user_follow_create;
+mod updated_user_follow_delete;
+mod updated_user_presence_update;
+mod updated_user_update;
+
 chirp_worker::workers![
 	admin_set,
 	create,


### PR DESCRIPTION
Fixes RVT-3504

Script:

```python
import os
import re

def modify_rust_files(directory):
    for root, _, files in os.walk(directory):
        for file in files:
            if file.endswith('.rs'):
                file_path = os.path.join(root, file)
                with open(file_path, 'r') as f:
                    content = f.read()

                matches = re.findall(r'chirp_worker::workers!\[(.*?)\];', content, re.DOTALL)
                if matches:
                    mods = '\n'.join([f'mod {name.strip()};' for name in matches[0].split(',') if name.strip()])
                    content = mods + '\n\n' + content
                    with open(file_path, 'w') as f:
                        f.write(content)

modify_rust_files('.')
```

