### PR TITLE
Add docs to existing macros

### DIFF
--- a/lib/global-error/src/macros.rs
+++ b/lib/global-error/src/macros.rs
@@ -1,10 +1,47 @@
+/// Constructs a `Location` object with the current file name, line number, and
+/// column number.
+///
+/// # Examples
+///
+/// ```
+/// let loc = location!();
+/// println!("This code is at: {:?}", loc);
+/// ```
 #[macro_export]
 macro_rules! location {
 	() => {
 		$crate::Location::new(file!(), line!(), column!())
 	};
 }
+pub use location;
 
+/// Constructs an error with a specified error code, optional metadata, and context.
+///
+/// The `err_code!` macro provides a way to create errors from predefined error codes,
+/// with the capability to attach metadata and context to the error.
+///
+/// Variants:
+/// - err_code!(code: CodeType) - Minimal form with just an error code.
+/// - err_code!(code: CodeType, key = value, ...) - With context parameters.
+/// - err_code!(code: CodeType { ..metadata.. }) - With a metadata block.
+/// - err_code!(code: CodeType { ..metadata.. }, key = value, ...) - With both metadata block
+///   and context parameters.
+///
+/// # Examples
+///
+/// ```
+/// // Without metadata or context
+/// let error = err_code!(INVALID_INPUT);
+///
+/// // With context
+/// let error = err_code!(INVALID_INPUT, field = "username", reason = "missing");
+///
+/// // With metadata block
+/// let error = err_code!(INVALID_INPUT { info: "Something went wrong" });
+///
+/// // With metadata block and context
+/// let error = err_code!(INVALID_INPUT { info: "Something went wrong" }, field = "username");
+/// ```
 #[macro_export]
 macro_rules! err_code {
 	// Code with a builder body (for metadata) as well as context keys
@@ -39,6 +76,21 @@ macro_rules! err_code {
 }
 pub use err_code;
 
+/// Exits a function early with an error.
+///
+/// The `bail!` macro allows for an early return from a function with an error.
+/// It takes a string message and invokes the `location!` macro to attach file
+/// and line information to the error automatically.
+///
+/// # Examples
+///
+/// ```
+/// let value = some_nullable_value();
+/// if value.is_none() {
+///     bail!("Expected a value, but got none");
+/// }
+/// // Execution will not continue past this point if value is None.
+/// ```
 #[macro_export]
 macro_rules! bail {
 	($msg:expr) => {{
@@ -50,6 +102,13 @@ macro_rules! bail {
 }
 pub use bail;
 
+/// Similar to `bail!` but sets a flag for immediate retry.
+///
+/// # Examples
+///
+/// ```
+/// retry_bail!("This operation should be retried immediately");
+/// ```
 #[macro_export]
 macro_rules! retry_bail {
 	($msg:expr) => {{
@@ -70,6 +129,19 @@ macro_rules! retry_bail {
 }
 pub use retry_bail;
 
+/// Asserts that an expression evaluates to true. If not, an error is returned.
+///
+/// # Examples
+///
+/// ```
+/// ensure!(1 + 1 == 2, "Math is broken.");
+/// ```
+///
+/// With a default message:
+///
+/// ```
+/// ensure!(1 + 1 == 2);
+/// ```
 #[macro_export]
 macro_rules! ensure {
 	($expr:expr, $msg:expr) => {{
@@ -88,6 +160,19 @@ macro_rules! ensure {
 }
 pub use ensure;
 
+/// Asserts that two expressions are equal. If not, an error is returned.
+///
+/// # Examples
+///
+/// ```
+/// ensure_eq!(a, b, "Values must be equal");
+/// ```
+///
+/// With a default message:
+///
+/// ```
+/// ensure_eq!(a, b);
+/// ```
 #[macro_export]
 macro_rules! ensure_eq {
 	($left:expr, $right:expr, $msg:expr) => {{
@@ -110,6 +195,20 @@ macro_rules! ensure_eq {
 }
 pub use ensure_eq;
 
+/// Unwraps an `Option` that has a reference and returns the contained value or
+/// exits early with an error.
+///
+/// # Examples
+///
+/// ```
+/// let value = unwrap_ref!(option, "Value must exist");
+/// ```
+///
+/// With a default message:
+///
+/// ```
+/// let value = unwrap_ref!(option);
+/// ```
 #[macro_export]
 macro_rules! unwrap_ref {
 	($expr:expr, $msg:expr) => {{
@@ -140,6 +239,14 @@ macro_rules! unwrap {
 }
 pub use unwrap;
 
+/// Exits early with an error using specified code and optional metadata and
+/// context, similar to `err_code!`.
+///
+/// # Examples
+///
+/// ```
+/// bail_with!(INVALID_INPUT { .. }, key = "value");
+/// ```
 #[macro_export]
 macro_rules! bail_with {
 	($code:ident $body:tt, $($key:ident = $value:expr),+ $(,)?) => {{
@@ -157,6 +264,14 @@ macro_rules! bail_with {
 }
 pub use bail_with;
 
+/// Asserts that an expression evaluates to true with associated error code and
+/// metadata, otherwise exits with an error.
+///
+/// # Examples
+///
+/// ```
+/// ensure_with!(value.is_valid(), INVALID_INPUT { .. }, key = "value");
+/// ```
 #[macro_export]
 macro_rules! ensure_with {
 	($code:ident $body:tt, $($key:ident = $value:expr),+ $(,)?) => {{
@@ -186,6 +301,14 @@ macro_rules! ensure_with {
 }
 pub use ensure_with;
 
+/// Asserts that two expressions are equal with an associated error code and
+/// metadata, otherwise exits with an error.
+///
+/// # Examples
+///
+/// ```
+/// ensure_eq_with!(a, b, INVALID_INPUT { .. }, key = "value");
+/// ```
 #[macro_export]
 macro_rules! ensure_eq_with {
 	($left:expr, $right:expr, $code:ident $body:tt, $($key:ident = $value:expr),+ $(,)?) => {{
@@ -227,6 +350,14 @@ macro_rules! ensure_eq_with {
 }
 pub use ensure_eq_with;
 
+/// Unwraps an `Option` that has a reference with an associated error code and
+/// metadata if `None`, otherwise returns the contained value.
+///
+/// # Examples
+///
+/// ```
+/// let value = unwrap_with_ref!(option, INVALID_INPUT { .. }, key = "value");
+/// ```
 #[macro_export]
 macro_rules! unwrap_with_ref {
 	($expr:expr, $code:ident $body:tt, $($key:ident = $value:expr),+ $(,)?) => {{
@@ -245,6 +376,14 @@ macro_rules! unwrap_with_ref {
 }
 pub use unwrap_with_ref;
 
+/// Unwraps an `Option` with an associated error code and metadata if `None`,
+/// otherwise returns the contained value.
+///
+/// # Examples
+///
+/// ```
+/// let value = unwrap_with!(option, INVALID_INPUT { .. }, key = "value");
+/// ```
 #[macro_export]
 macro_rules! unwrap_with {
 	($expr:expr, $code:ident $body:tt, $($key:ident = $value:expr),+ $(,)?) => {{


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds new macros and updates existing ones in the `lib/global-error/src/macros.rs` file. The new macros include `location!`, `err_code!`, `bail!`, `retry_bail!`, `ensure!`, `ensure_eq!`, `unwrap_ref!`, `bail_with!`, `ensure_with!`, `ensure_eq_with!`, `unwrap_with_ref!`, and `unwrap_with!`. These macros provide convenient ways to handle errors and exit early with error messages and associated metadata.
> 
> ## What changed
> - Added `location!` macro to construct a `Location` object with file name, line number, and column number.
> - Added `err_code!` macro to construct an error with a specified error code, optional metadata, and context.
> - Added `bail!` macro to exit a function early with an error.
> - Added `retry_bail!` macro to exit a function early with an error and set a flag for immediate retry.
> - Added `ensure!` macro to assert that an expression evaluates to true, otherwise return an error.
> - Added `ensure_eq!` macro to assert that two expressions are equal, otherwise return an error.
> - Added `unwrap_ref!` macro to unwrap an `Option` that has a reference and return the contained value or exit early with an error.
> - Added `bail_with!` macro to exit early with an error using a specified code and optional metadata and context.
> - Added `ensure_with!` macro to assert that an expression evaluates to true with associated error code and metadata, otherwise exit with an error.
> - Added `ensure_eq_with!` macro to assert that two expressions are equal with associated error code and metadata, otherwise exit with an error.
> - Added `unwrap_with_ref!` macro to unwrap an `Option` that has a reference with associated error code and metadata if `None`, otherwise return the contained value.
> - Added `unwrap_with!` macro to unwrap an `Option` with associated error code and metadata if `None`, otherwise return the contained value.
> 
> ## How to test
> To test the changes made in this pull request, follow these steps:
> 1. Build the project.
> 2. Run the test suite.
> 3. Use the new macros in your code and verify their functionality.
> 
> ## Why make this change
> This change introduces new macros and updates existing ones to provide developers with convenient ways to handle errors and exit early with error messages and associated metadata. These macros improve code readability and reduce boilerplate code when dealing with error handling.
</details>