### PR TITLE
Change unwrap!() to handle results

### DIFF
--- a/lib/global-error/src/ext.rs
+++ b/lib/global-error/src/ext.rs
@@ -3,10 +3,7 @@ use crate::Location;
 #[derive(Debug, thiserror::Error)]
 pub enum AssertionError {
 	#[error("{location} panic: {message}")]
-	Panic {
-		message: &'static str,
-		location: Location,
-	},
+	Panic { message: String, location: Location },
 
 	#[error("{location} {val}: {message}")]
 	Assert {
@@ -24,10 +21,7 @@ pub enum AssertionError {
 	},
 
 	#[error("{location} unwrap: {message}")]
-	Unwrap {
-		message: &'static str,
-		location: Location,
-	},
+	Unwrap { message: String, location: Location },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -35,4 +29,96 @@ pub enum AssertionError {
 pub struct RetryError {
 	pub message: &'static str,
 	pub location: Location,
+}
+
+/// `UnwrapOrAssertError` is a trait used for handling unwrapping of `Result`
+/// and `Option` types.
+///
+/// This trait provides a method `assertion_error_unwrap` that takes a `Result`
+/// or `Option` and returns a `Result`. If the original `Result` or `Option` is
+/// `Ok` or `Some`, it returns `Ok` with the unwrapped value. If it's `Err` or
+/// `None`, it returns `Err` with an `AssertionError::Unwrap` that includes a
+/// message and location.
+pub trait UnwrapOrAssertError {
+	type WrappedType;
+
+	fn assertion_error_unwrap(
+		self,
+		message: String,
+		location: Location,
+	) -> Result<Self::WrappedType, crate::ext::AssertionError>;
+}
+
+impl<T, E: core::fmt::Debug> UnwrapOrAssertError for Result<T, E> {
+	type WrappedType = T;
+
+	fn assertion_error_unwrap(
+		self,
+		message: String,
+		location: Location,
+	) -> Result<T, crate::ext::AssertionError> {
+		match self {
+			Ok(t) => Ok(t),
+			Err(e) => Err(crate::ext::AssertionError::Unwrap {
+				message: format!("{}: {:?}", message, e),
+				location,
+			}),
+		}
+	}
+}
+
+impl<T> UnwrapOrAssertError for Option<T> {
+	type WrappedType = T;
+
+	fn assertion_error_unwrap(
+		self,
+		message: String,
+		location: Location,
+	) -> Result<T, crate::ext::AssertionError> {
+		match self {
+			Some(t) => Ok(t),
+			None => Err(Into::into(crate::ext::AssertionError::Unwrap {
+				message,
+				location,
+			})),
+		}
+	}
+}
+
+// TODO(forest): Can we handle this type with a blanket impl?
+impl<'a, T> UnwrapOrAssertError for &'a Option<T> {
+	type WrappedType = &'a T;
+
+	fn assertion_error_unwrap(
+		self,
+		message: String,
+		location: Location,
+	) -> Result<&'a T, crate::ext::AssertionError> {
+		match self {
+			Some(t) => Ok(t),
+			None => Err(Into::into(crate::ext::AssertionError::Unwrap {
+				message,
+				location
+			})),
+		}
+	}
+}
+
+// TODO(forest): Can we handle this type with a blanket impl?
+impl<'a, T> UnwrapOrAssertError for &'a &'a Option<T> {
+	type WrappedType = &'a T;
+
+	fn assertion_error_unwrap(
+		self,
+		message: String,
+		location: Location,
+	) -> Result<&'a T, crate::ext::AssertionError> {
+		match self {
+			Some(t) => Ok(t),
+			None => Err(Into::into(crate::ext::AssertionError::Unwrap {
+				message,
+				location
+			})),
+		}
+	}
 }


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds a new macro called `AssertionErrorUnwrap` and a new macro called `location` to the `macros` module of the `global-error` library. The code changes also include the addition of various error handling macros and examples of how to use them.
> 
> ## What changed
> - Added a new macro called `AssertionErrorUnwrap` to the `macros` module of the `global-error` library.
> - Added a new macro called `location` that constructs a `Location` object with the current file name, line number, and column number.
> - Added various error handling macros and examples of how to use them.
> 
> ## How to test
> - Compile and run the code with the new macros.
> - Test each macro by providing different inputs and verifying the expected behavior.
> - Verify that the `AssertionErrorUnwrap` macro correctly handles unwrapping of `Result` and `Option` types.
> 
> ## Why make this change
> - The new macros and error handling functionality provide a more convenient and expressive way to handle errors and control flow in Rust.
> - The addition of the `AssertionErrorUnwrap` macro improves the readability and maintainability of code by providing a concise way to handle unwrapping of `Result` and `Option` types.
> - The `location` macro enhances debugging capabilities by providing information about the file name, line number, and column number where an error occurred.
</details>