### PR TITLE
Fix runc rootfs not being read/write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Resolve [RUSTSEC-2023-0044](https://rustsec.org/advisories/RUSTSEC-2023-0074)
 
+### Fixed
+
+-   **Infra** runc rootfs is now a writable file system
+
 ## [23.2.0-rc1] - 2023-12-01
 
 ### Added

--- a/svc/pkg/mm/worker/src/workers/lobby_create/oci_config.rs
+++ b/svc/pkg/mm/worker/src/workers/lobby_create/oci_config.rs
@@ -68,7 +68,8 @@ pub fn config(cpu: u64, memory: u64, memory_max: u64, env: Vec<String>) -> serde
 		},
 		"root": {
 			"path": "rootfs",
-			"readonly": true
+			// This means we can't reuse the oci-bundle since the rootfs is writable.
+			"readonly": false
 		},
 		"mounts": mounts(),
 		"linux": {


### PR DESCRIPTION
For 100% compatability with Docker, the rootfs needs to be writable.
