### PR TITLE
Ship logs with a single instance of Vector, fix not shipping logs on immediate exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   **Matchmaker** Allow excluding `matchmaker.regions` in order to enable all regions
+-   **Matchmaker** Lowered internal overhead of log shipping for lobbies
 
 ### Security
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   **Infra** runc rootfs is now a writable file system
+-   **Matchmaker** Fix logs not shipping if lobby exits immediately
 
 ## [23.2.0-rc1] - 2023-12-01
 


### PR DESCRIPTION
Preivously, we used an instance of Vector for stdout and stderr
individually in order to determine the stream type. Now, we prefix each
stream with metadata and parse it inside of Vector in order to only run
one Vector instance.

Adding a sleep after the runc command lets Vector capture the logs. This
fixes applications not shipping logs if they exit immediately.

Fixes RVT-3509

