### PR TITLE
Add protobuf-src flag to global-error & types

### DIFF
--- a/lib/global-error/Cargo.toml
+++ b/lib/global-error/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Rivet Gaming, LLC <developer@rivet.gg>"]
 edition = "2018"
 license = "Apache-2.0"
 
+[features]
+protobuf-src = ["types/protobuf-src"]
+
 [dependencies]
 formatted-error = { path = "../formatted-error" }
 types = { path = "../types/core" }

--- a/lib/types/build/Cargo.toml
+++ b/lib/types/build/Cargo.toml
@@ -10,6 +10,7 @@ bolt-config = { path = "../../bolt/config" }
 heck = "0.3"
 indoc = "1.0"
 prost-build = "0.11"
+protobuf-src = { version = "1.1.0", optional = true }
 regex = "1.5"
 schemac = { path = "../../schemac" }
 serde = { version = "1.0", features = ["derive"] }

--- a/lib/types/build/src/lib.rs
+++ b/lib/types/build/src/lib.rs
@@ -4,6 +4,13 @@ use std::{
 };
 
 pub fn compile() -> io::Result<()> {
+	// Include protobuf binaries
+	#[cfg(feature = "protobuf-src")]
+	{
+		std::env::set_var("PROTOC", protobuf_src::protoc());
+		std::env::set_var("PROTOC_INCLUDE", protobuf_src::include());
+	}
+
 	compile_with_base(|| Ok(schemac::CompileOpts::default()))
 }
 

--- a/lib/types/core/Cargo.toml
+++ b/lib/types/core/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 authors = ["Rivet Gaming, LLC <developer@rivet.gg>"]
 license = "Apache-2.0"
 
+[features]
+protobuf-src = ["types-build/protobuf-src"]
+
 [dependencies]
 chirp-types = { path = "../../chirp/types" }
 prost = "0.10"


### PR DESCRIPTION
Allows compiling `global-error` without having protobuf installed on your host machine.
