### PR TITLE
Import fmt changes

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-

--- a/scripts/cargo_fmt/fmt.sh
+++ b/scripts/cargo_fmt/fmt.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Save the original rustfmt.toml content
+original_content="hard_tabs = true"
+
+# New content to be added
+new_content="
+# https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=import#Crate%5C%3A
+imports_granularity = \"Crate\"
+
+# https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=import#StdExternalCrate%5C%3A
+group_imports = \"StdExternalCrate\""
+
+# Switch to nightly toolchain
+rustup default nightly
+
+# Modify the rustfmt.toml file in the root directory
+echo "$original_content$new_content" > rustfmt.toml
+
+# Find all Cargo.toml files in subdirectories
+for cargo_toml in $(find . -name "Cargo.toml"); do
+    # Ignore anything in gen/ and /lib/smithy-output
+    if [[ $cargo_toml == *"gen"* ]] || [[ $cargo_toml == *"lib/smithy-output"* ]]; then
+        continue
+    fi
+
+    # Run rustfmt with the --manifest-path option in the background
+    echo "Formatting $cargo_toml"
+    cargo fmt --manifest-path $cargo_toml &
+done
+
+# Wait for all background jobs to finish
+wait
+
+# Revert the rustfmt.toml file in the root directory
+echo "$original_content" > rustfmt.toml
+
+# Switch back to stable toolchain
+rustup default stable


### PR DESCRIPTION
## Changes

This makes some changes to `rustfmt.toml` that I think align with our ideas of how things should be formatted. Most importantly is `StdExternalCrate` ([link](https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=import#StdExternalCrate%5C%3A)) for imports:

> Discard existing import groups, and create three groups for:

> std, core and alloc,
    external crates,
    self, super and crate imports.

```
use alloc::alloc::Layout;
use core::f32;
use std::sync::Arc;

use broker::database::PooledConnection;
use chrono::Utc;
use juniper::{FieldError, FieldResult};
use uuid::Uuid;

use super::schema::{Context, Payload};
use super::update::convert_publish_payload;
use crate::models::Event;
```

Change to `rustfmt.toml` (though it should be commented out, see below)

```
hard_tabs = true

# https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=import#Crate%5C%3A
imports_granularity = "Crate"

# https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=import#StdExternalCrate%5C%3A
group_imports = "StdExternalCrate"
```

## Example

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XiP77c3NM4Q27xw9sqIb/af0a4f14-4425-4e1b-abac-d63083d40b07.png)

## Issues

These changes require nightly to run `fmt`. This means it probably won't be good to leave it uncommented all the time, since we probably don't want to switch to nightly just for this.