### PR TITLE
Add infra-artifcats bucket, upload job-runner to artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   **Infra** New `job-runner` crate responsible for managing the OCI bundle runtime & log shipping on the machine
 -   **Infra** Jobs now log an explicit rate message when logs are rate limited & truncated
+-   **Infra** `infra-artifacts` Terraform plan & S3 bucket used for automating building & uploading internal binaries, etc.
 
 ### Changed
 

--- a/infra/tf/infra_artifacts/README.md
+++ b/infra/tf/infra_artifacts/README.md
@@ -1,0 +1,7 @@
+# infra-artifacts
+
+Used to store assets required within the infrastructure. At the moment, this is
+only used for storing Rust executables that are ran on servers.
+
+This should not be used for anything that runs within Kubernetes, those can be
+built and uploaded to Docker. This is intended for Docker-less environments.

--- a/infra/tf/infra_artifacts/job_runner.tf
+++ b/infra/tf/infra_artifacts/job_runner.tf
@@ -1,0 +1,53 @@
+locals {
+	job_runner_src_dir = "${path.module}/../../../lib/job-runner"
+
+	job_runner_src_files = flatten([
+		["${local.job_runner_src_dir}/Cargo.toml", "${local.job_runner_src_dir}/Cargo.lock"],
+		[for f in fileset("${local.job_runner_src_dir}/src/", "**/*"): "${local.job_runner_src_dir}/src/${f}"],
+	])
+	job_runner_src_hash = md5(join("", [
+		for f in local.job_runner_src_files: filemd5(f)
+	]))
+	job_runner_dst_binary_path = "/tmp/job-runner-${local.job_runner_src_hash}"
+}
+
+resource "null_resource" "job_runner_build" {
+	triggers = {
+		job_runner_src_hash = local.job_runner_src_hash
+		job_runner_dst_binary_path = local.job_runner_dst_binary_path
+	}
+
+	provisioner "local-exec" {
+		command = <<-EOT
+		#!/bin/bash
+		set -euf
+
+		# Variables
+		IMAGE_NAME="job-runner:${local.job_runner_src_hash}"
+		CONTAINER_NAME="temp-job-runner-${local.job_runner_src_hash}"
+		BINARY_PATH_IN_CONTAINER="/app/target/x86_64-unknown-linux-musl/release/job-runner"
+		DST_BINARY_PATH="${local.job_runner_dst_binary_path}"
+
+		# Build the Docker image
+		docker build -t $IMAGE_NAME '${local.job_runner_src_dir}'
+
+		# Create a temporary container
+		docker create --name $CONTAINER_NAME $IMAGE_NAME
+
+		# Copy the binary from the container to the host
+		docker cp $CONTAINER_NAME:$BINARY_PATH_IN_CONTAINER $DST_BINARY_PATH
+
+		# Remove the temporary container
+		docker rm $CONTAINER_NAME
+		EOT
+	}
+}
+
+resource "aws_s3_object" "job_runner_binary_upload" {
+	depends_on = [null_resource.job_runner_build]
+
+	bucket = "${var.namespace}-bucket-infra-artifacts"
+	key = "job-runner/job-runner"
+	source = local.job_runner_dst_binary_path
+}
+

--- a/infra/tf/infra_artifacts/main.tf
+++ b/infra/tf/infra_artifacts/main.tf
@@ -1,0 +1,23 @@
+terraform {
+	required_providers {
+		aws = {
+			source = "hashicorp/aws"
+			version = "5.1.0"
+		}
+	}
+}
+
+locals {
+	s3_provider = var.s3_providers[var.s3_default_provider]
+}
+
+
+module "secrets" {
+    source = "../modules/secrets"
+
+    keys = [
+        "s3/${var.s3_default_provider}/terraform/key_id",
+        "s3/${var.s3_default_provider}/terraform/key",
+    ]
+}
+

--- a/infra/tf/infra_artifacts/providers.tf
+++ b/infra/tf/infra_artifacts/providers.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+	region = local.s3_provider.region
+	access_key = module.secrets.values["s3/${var.s3_default_provider}/terraform/key_id"]
+	secret_key = module.secrets.values["s3/${var.s3_default_provider}/terraform/key"]
+
+	# Config specifically for custom endpoints
+	s3_use_path_style = true
+	skip_credentials_validation = true
+	skip_metadata_api_check = true
+	skip_requesting_account_id = true
+
+	endpoints {
+		s3 = local.s3_provider.endpoint_external
+	}
+}
+

--- a/infra/tf/infra_artifacts/vars.tf
+++ b/infra/tf/infra_artifacts/vars.tf
@@ -1,0 +1,17 @@
+variable "namespace" {
+	type = string
+}
+
+# MARK: S3
+variable "s3_default_provider" {
+	type = string
+}
+
+variable "s3_providers" {
+	type = map(object({
+		endpoint_internal = string
+		endpoint_external = string
+		region = string
+	}))
+}
+

--- a/lib/bolt/core/src/tasks/infra/mod.rs
+++ b/lib/bolt/core/src/tasks/infra/mod.rs
@@ -297,6 +297,14 @@ pub fn build_plan(
 	}
 
 	plan.push(PlanStep {
+		name_id: "infra-artifacts",
+		kind: PlanStepKind::Terraform {
+			plan_id: "infra_artifacts".into(),
+			needs_destroy: false,
+		},
+	});
+
+	plan.push(PlanStep {
 		name_id: "migrate",
 		kind: PlanStepKind::Migrate,
 	});

--- a/lib/job-runner/.dockerignore
+++ b/lib/job-runner/.dockerignore
@@ -1,0 +1,5 @@
+/target
+**/target
+.dockerignore
+Dockerfile
+

--- a/lib/job-runner/Dockerfile
+++ b/lib/job-runner/Dockerfile
@@ -1,0 +1,7 @@
+FROM clux/muslrust:1.73.0
+
+WORKDIR /app
+COPY Cargo.toml Cargo.lock .
+COPY src/ src/
+RUN cargo build --release
+

--- a/svc/pkg/infra/buckets/artifacts/Service.toml
+++ b/svc/pkg/infra/buckets/artifacts/Service.toml
@@ -1,0 +1,8 @@
+[service]
+name = "bucket-infra-artifacts"
+
+[runtime]
+kind = "s3"
+upload_policy = "none"
+
+[database]

--- a/svc/pkg/mm/worker/src/workers/lobby_create/scripts/setup_job_runner.sh
+++ b/svc/pkg/mm/worker/src/workers/lobby_create/scripts/setup_job_runner.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euf -o pipefail
+
+log() {
+    local timestamp=$(date +"%Y-%m-%d %H:%M:%S.%3N")
+    echo "[$timestamp] [setup_job_runner] $@"
+}
+
+# Download job runner binary
+curl -Lf "$NOMAD_META_job_runner_binary_url" -o "${NOMAD_ALLOC_DIR}/job-runner"
+chmod +x "${NOMAD_ALLOC_DIR}/job-runner"
+log "Finished downloading job-runner"
+


### PR DESCRIPTION
## Summary

Allows for creating and storing artifacts required in our infrastructure outside of Kubernetes.

## Motivation

We have a lot of complex logic running outside of the comfort of Kubernetes. We've been hacking this logic together with shell scripts and it's reached a breaking point. This allows us to write these components in Rust and ship them to S3 where they can be distributed to our infrastructure reliably.