### PR TITLE
Rename api try from

### DIFF
--- a/lib/convert/src/convert/game.rs
+++ b/lib/convert/src/convert/game.rs
@@ -34,7 +34,7 @@ pub fn summary(
 		banner_url: util::route::game_banner(&game),
 		url: game_url,
 		developer: Box::new(convert::group::handle(dev_team)?),
-		total_player_count: state.total_player_count.try_into()?,
+		total_player_count: ApiTryInto::api_try_into(state.total_player_count)?,
 	})
 }
 

--- a/lib/convert/src/convert/identity.rs
+++ b/lib/convert/src/convert/identity.rs
@@ -237,7 +237,7 @@ pub fn profile(
 			identities
 				.iter()
 				.cloned()
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.collect::<GlobalResult<Vec<_>>>()?
 		} else {
 			Vec::new()

--- a/lib/convert/src/impls/api.rs
+++ b/lib/convert/src/impls/api.rs
@@ -7,7 +7,7 @@ use crate::ApiTryFrom;
 impl ApiTryFrom<models::CaptchaConfig> for backend::captcha::CaptchaClientResponse {
 	type Error = GlobalError;
 
-	fn try_from(
+	fn api_try_from(
 		value: models::CaptchaConfig,
 	) -> GlobalResult<backend::captcha::CaptchaClientResponse> {
 		let kind = if let Some(hcaptcha) = value.hcaptcha {

--- a/lib/convert/src/impls/cloud/mod.rs
+++ b/lib/convert/src/impls/cloud/mod.rs
@@ -27,11 +27,11 @@ pub fn analytics_lobby_summary_from_lobby(
 		is_idle: player_count.total_player_count == 0,
 		is_closed: lobby.is_closed,
 		is_outdated,
-		max_players_normal: lobby.max_players_normal.try_into()?,
-		max_players_direct: lobby.max_players_direct.try_into()?,
-		max_players_party: lobby.max_players_party.try_into()?,
-		total_player_count: player_count.total_player_count.try_into()?,
-		registered_player_count: player_count.registered_player_count.try_into()?,
+		max_players_normal: lobby.max_players_normal.api_try_into()?,
+		max_players_direct: lobby.max_players_direct.api_try_into()?,
+		max_players_party: lobby.max_players_party.api_try_into()?,
+		total_player_count: player_count.total_player_count.api_try_into()?,
+		registered_player_count: player_count.registered_player_count.api_try_into()?,
 	})
 }
 
@@ -41,7 +41,7 @@ pub fn analytics_lobby_summary_from_lobby(
 // {
 // 	type Error = GlobalError;
 
-// 	fn try_from(
+// 	fn api_try_from(
 // 		value: mm::lobby_runtime_aggregate::response::RegionTierTime,
 // 	) -> GlobalResult<Self> {
 // 		let uptime_in_seconds = util::div_up!(value.total_time, 1_000);
@@ -59,7 +59,7 @@ pub fn analytics_lobby_summary_from_lobby(
 impl ApiTryFrom<backend::game::Game> for models::GameHandle {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::game::Game) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::game::Game) -> GlobalResult<Self> {
 		Ok(models::GameHandle {
 			game_id: unwrap_ref!(value.game_id).as_uuid(),
 			name_id: value.name_id.to_owned(),
@@ -73,7 +73,7 @@ impl ApiTryFrom<backend::game::Game> for models::GameHandle {
 impl ApiTryFrom<perf::SvcPerf> for models::CloudSvcPerf {
 	type Error = GlobalError;
 
-	fn try_from(value: perf::SvcPerf) -> GlobalResult<Self> {
+	fn api_try_from(value: perf::SvcPerf) -> GlobalResult<Self> {
 		Ok(models::CloudSvcPerf {
 			svc_name: value.context_name.to_owned(),
 			ts: util::timestamp::to_string(value.ts)?,
@@ -82,12 +82,12 @@ impl ApiTryFrom<perf::SvcPerf> for models::CloudSvcPerf {
 			spans: value
 				.spans
 				.into_iter()
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.collect::<Result<Vec<_>, _>>()?,
 			marks: value
 				.marks
 				.into_iter()
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.collect::<Result<Vec<_>, _>>()?,
 		})
 	}
@@ -96,7 +96,7 @@ impl ApiTryFrom<perf::SvcPerf> for models::CloudSvcPerf {
 impl ApiTryFrom<job_run::metrics_log::response::Metrics> for models::CloudSvcMetrics {
 	type Error = GlobalError;
 
-	fn try_from(value: job_run::metrics_log::response::Metrics) -> GlobalResult<Self> {
+	fn api_try_from(value: job_run::metrics_log::response::Metrics) -> GlobalResult<Self> {
 		Ok(models::CloudSvcMetrics {
 			job: value.job,
 			cpu: value.cpu.into_iter().map(|v| v as f64).collect::<Vec<_>>(),
@@ -113,7 +113,7 @@ impl ApiTryFrom<job_run::metrics_log::response::Metrics> for models::CloudSvcMet
 impl ApiTryFrom<perf::Span> for models::CloudLogsPerfSpan {
 	type Error = GlobalError;
 
-	fn try_from(value: perf::Span) -> GlobalResult<Self> {
+	fn api_try_from(value: perf::Span) -> GlobalResult<Self> {
 		Ok(models::CloudLogsPerfSpan {
 			label: value.label.to_owned(),
 			start_ts: util::timestamp::to_string(value.start_ts)?,
@@ -129,7 +129,7 @@ impl ApiTryFrom<perf::Span> for models::CloudLogsPerfSpan {
 impl ApiTryFrom<perf::Mark> for models::CloudLogsPerfMark {
 	type Error = GlobalError;
 
-	fn try_from(value: perf::Mark) -> GlobalResult<Self> {
+	fn api_try_from(value: perf::Mark) -> GlobalResult<Self> {
 		Ok(models::CloudLogsPerfMark {
 			label: value.label.to_owned(),
 			ts: util::timestamp::to_string(value.ts)?,
@@ -142,7 +142,7 @@ impl ApiTryFrom<perf::Mark> for models::CloudLogsPerfMark {
 impl ApiTryFrom<backend::upload::PresignedUploadRequest> for models::UploadPresignedRequest {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::upload::PresignedUploadRequest) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::upload::PresignedUploadRequest) -> GlobalResult<Self> {
 		Ok(models::UploadPresignedRequest {
 			path: value.path,
 			url: value.url,
@@ -155,7 +155,7 @@ impl ApiTryFrom<backend::upload::PresignedUploadRequest> for models::UploadPresi
 impl ApiTryFrom<models::UploadPrepareFile> for backend::upload::PrepareFile {
 	type Error = GlobalError;
 
-	fn try_from(value: models::UploadPrepareFile) -> GlobalResult<Self> {
+	fn api_try_from(value: models::UploadPrepareFile) -> GlobalResult<Self> {
 		ensure_with!(
 			value.content_length >= 0,
 			MATCHMAKER_INVALID_VERSION_CONFIG,
@@ -214,15 +214,15 @@ impl ApiFrom<mm_config::namespace_config_validate::response::Error> for models::
 impl ApiTryFrom<backend::region::Tier> for models::CloudRegionTier {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::region::Tier) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::region::Tier) -> GlobalResult<Self> {
 		Ok(models::CloudRegionTier {
 			tier_name_id: value.tier_name_id.to_owned(),
-			rivet_cores_numerator: value.rivet_cores_numerator.try_into()?,
-			rivet_cores_denominator: value.rivet_cores_denominator.try_into()?,
-			cpu: value.cpu.try_into()?,
-			memory: value.memory.try_into()?,
-			disk: value.disk.try_into()?,
-			bandwidth: value.bandwidth.try_into()?,
+			rivet_cores_numerator: value.rivet_cores_numerator.api_try_into()?,
+			rivet_cores_denominator: value.rivet_cores_denominator.api_try_into()?,
+			cpu: value.cpu.api_try_into()?,
+			memory: value.memory.api_try_into()?,
+			disk: value.disk.api_try_into()?,
+			bandwidth: value.bandwidth.api_try_into()?,
 
 			price_per_second: 0,
 		})

--- a/lib/convert/src/impls/cloud/namespace/matchmaker.rs
+++ b/lib/convert/src/impls/cloud/namespace/matchmaker.rs
@@ -9,7 +9,7 @@ use crate::ApiTryFrom;
 impl ApiTryFrom<backend::matchmaker::NamespaceConfig> for models::CloudMatchmakerNamespaceConfig {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::NamespaceConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::NamespaceConfig) -> GlobalResult<Self> {
 		Ok(models::CloudMatchmakerNamespaceConfig {
 			lobby_count_max: value.lobby_count_max.try_into()?,
 			max_players_per_client: value.max_players_per_client.try_into()?,

--- a/lib/convert/src/impls/cloud/namespace/mod.rs
+++ b/lib/convert/src/impls/cloud/namespace/mod.rs
@@ -12,7 +12,7 @@ pub mod matchmaker;
 impl ApiTryFrom<backend::game::Namespace> for models::CloudNamespaceSummary {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::game::Namespace) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::game::Namespace) -> GlobalResult<Self> {
 		Ok(models::CloudNamespaceSummary {
 			namespace_id: unwrap!(value.namespace_id).as_uuid(),
 			create_ts: util::timestamp::to_string(value.create_ts)?,

--- a/lib/convert/src/impls/cloud/version/cdn.rs
+++ b/lib/convert/src/impls/cloud/version/cdn.rs
@@ -7,14 +7,14 @@ use crate::{ApiTryFrom, ApiTryInto};
 impl ApiTryFrom<models::CloudVersionCdnConfig> for backend::cdn::VersionConfig {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionCdnConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionCdnConfig) -> GlobalResult<Self> {
 		Ok(backend::cdn::VersionConfig {
 			site_id: value.site_id.map(Into::into),
 			routes: value
 				.routes
 				.unwrap_or_default()
 				.into_iter()
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.collect::<GlobalResult<Vec<_>>>()?,
 		})
 	}
@@ -23,7 +23,7 @@ impl ApiTryFrom<models::CloudVersionCdnConfig> for backend::cdn::VersionConfig {
 impl ApiTryFrom<models::CloudVersionCdnRoute> for backend::cdn::Route {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionCdnRoute) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionCdnRoute) -> GlobalResult<Self> {
 		ensure!(value.priority >= 0);
 
 		let glob = match util::glob::Glob::parse(&value.glob) {
@@ -43,7 +43,7 @@ impl ApiTryFrom<models::CloudVersionCdnRoute> for backend::cdn::Route {
 			middlewares: value
 				.middlewares
 				.into_iter()
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.collect::<GlobalResult<Vec<_>>>()?,
 		})
 	}
@@ -52,11 +52,11 @@ impl ApiTryFrom<models::CloudVersionCdnRoute> for backend::cdn::Route {
 impl ApiTryFrom<models::CloudVersionCdnMiddleware> for backend::cdn::Middleware {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionCdnMiddleware) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionCdnMiddleware) -> GlobalResult<Self> {
 		if let Some(custom_headers) = value.kind.custom_headers {
 			Ok(backend::cdn::Middleware {
 				kind: Some(backend::cdn::middleware::Kind::CustomHeaders(
-					(*custom_headers).try_into()?,
+					(*custom_headers).api_try_into()?,
 				)),
 			})
 		} else {
@@ -70,12 +70,12 @@ impl ApiTryFrom<models::CloudVersionCdnCustomHeadersMiddleware>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionCdnCustomHeadersMiddleware) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionCdnCustomHeadersMiddleware) -> GlobalResult<Self> {
 		Ok(backend::cdn::CustomHeadersMiddleware {
 			headers: value
 				.headers
 				.into_iter()
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.collect::<GlobalResult<Vec<_>>>()?,
 		})
 	}
@@ -84,7 +84,7 @@ impl ApiTryFrom<models::CloudVersionCdnCustomHeadersMiddleware>
 impl ApiTryFrom<models::CloudVersionCdnHeader> for backend::cdn::custom_headers_middleware::Header {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionCdnHeader) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionCdnHeader) -> GlobalResult<Self> {
 		Ok(backend::cdn::custom_headers_middleware::Header {
 			name: value.name,
 			value: value.value,
@@ -95,7 +95,7 @@ impl ApiTryFrom<models::CloudVersionCdnHeader> for backend::cdn::custom_headers_
 impl ApiTryFrom<backend::cdn::VersionConfig> for models::CloudVersionCdnConfig {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::cdn::VersionConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::cdn::VersionConfig) -> GlobalResult<Self> {
 		let site_id = unwrap_ref!(value.site_id).as_uuid();
 
 		Ok(models::CloudVersionCdnConfig {
@@ -107,7 +107,7 @@ impl ApiTryFrom<backend::cdn::VersionConfig> for models::CloudVersionCdnConfig {
 				value
 					.routes
 					.into_iter()
-					.map(ApiTryInto::try_into)
+					.map(ApiTryInto::api_try_into)
 					.collect::<GlobalResult<Vec<_>>>()?,
 			),
 		})
@@ -117,7 +117,7 @@ impl ApiTryFrom<backend::cdn::VersionConfig> for models::CloudVersionCdnConfig {
 impl ApiTryFrom<backend::cdn::Route> for models::CloudVersionCdnRoute {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::cdn::Route) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::cdn::Route) -> GlobalResult<Self> {
 		Ok(models::CloudVersionCdnRoute {
 			glob: std::convert::TryInto::<util::glob::Glob>::try_into(unwrap!(value.glob.clone()))?
 				.to_string(),
@@ -125,7 +125,7 @@ impl ApiTryFrom<backend::cdn::Route> for models::CloudVersionCdnRoute {
 			middlewares: value
 				.middlewares
 				.into_iter()
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.collect::<GlobalResult<Vec<_>>>()?,
 		})
 	}
@@ -134,14 +134,14 @@ impl ApiTryFrom<backend::cdn::Route> for models::CloudVersionCdnRoute {
 impl ApiTryFrom<backend::cdn::Middleware> for models::CloudVersionCdnMiddleware {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::cdn::Middleware) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::cdn::Middleware) -> GlobalResult<Self> {
 		let kind = unwrap_ref!(value.kind).clone();
 
 		match kind {
 			backend::cdn::middleware::Kind::CustomHeaders(custom_headers) => {
 				Ok(models::CloudVersionCdnMiddleware {
 					kind: Box::new(models::CloudVersionCdnMiddlewareKind {
-						custom_headers: Some(Box::new(custom_headers.try_into()?)),
+						custom_headers: Some(Box::new(custom_headers.api_try_into()?)),
 					}),
 				})
 			}
@@ -154,12 +154,12 @@ impl ApiTryFrom<backend::cdn::CustomHeadersMiddleware>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::cdn::CustomHeadersMiddleware) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::cdn::CustomHeadersMiddleware) -> GlobalResult<Self> {
 		Ok(models::CloudVersionCdnCustomHeadersMiddleware {
 			headers: value
 				.headers
 				.into_iter()
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.collect::<GlobalResult<Vec<_>>>()?,
 		})
 	}
@@ -168,7 +168,7 @@ impl ApiTryFrom<backend::cdn::CustomHeadersMiddleware>
 impl ApiTryFrom<backend::cdn::custom_headers_middleware::Header> for models::CloudVersionCdnHeader {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::cdn::custom_headers_middleware::Header) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::cdn::custom_headers_middleware::Header) -> GlobalResult<Self> {
 		Ok(models::CloudVersionCdnHeader {
 			name: value.name.clone(),
 			value: value.value,

--- a/lib/convert/src/impls/cloud/version/identity.rs
+++ b/lib/convert/src/impls/cloud/version/identity.rs
@@ -7,12 +7,12 @@ use crate::{ApiTryFrom, ApiTryInto};
 impl ApiTryFrom<models::CloudVersionIdentityConfig> for backend::identity::VersionConfig {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionIdentityConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionIdentityConfig) -> GlobalResult<Self> {
 		Ok(backend::identity::VersionConfig {
 			custom_display_names: value
 				.custom_display_names
 				.into_iter()
-				.flat_map(|x| x.into_iter().map(ApiTryInto::try_into))
+				.flat_map(|x| x.into_iter().map(ApiTryInto::api_try_into))
 				.chain(value.display_names.into_iter().flat_map(|x| {
 					x.into_iter().map(|display_name| {
 						GlobalResult::Ok(backend::identity::CustomDisplayName { display_name })
@@ -22,7 +22,7 @@ impl ApiTryFrom<models::CloudVersionIdentityConfig> for backend::identity::Versi
 			custom_avatars: value
 				.custom_avatars
 				.into_iter()
-				.flat_map(|x| x.into_iter().map(ApiTryInto::try_into))
+				.flat_map(|x| x.into_iter().map(ApiTryInto::api_try_into))
 				.chain(value.avatars.into_iter().flat_map(|x| {
 					x.into_iter().map(|upload_id| {
 						GlobalResult::Ok(backend::identity::CustomAvatar {
@@ -40,7 +40,7 @@ impl ApiTryFrom<models::CloudVersionIdentityCustomDisplayName>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionIdentityCustomDisplayName) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionIdentityCustomDisplayName) -> GlobalResult<Self> {
 		Ok(backend::identity::CustomDisplayName {
 			display_name: value.display_name,
 		})
@@ -50,7 +50,7 @@ impl ApiTryFrom<models::CloudVersionIdentityCustomDisplayName>
 impl ApiTryFrom<models::CloudVersionIdentityCustomAvatar> for backend::identity::CustomAvatar {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionIdentityCustomAvatar) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionIdentityCustomAvatar) -> GlobalResult<Self> {
 		Ok(backend::identity::CustomAvatar {
 			upload_id: Some(value.upload_id.into()),
 		})
@@ -60,7 +60,7 @@ impl ApiTryFrom<models::CloudVersionIdentityCustomAvatar> for backend::identity:
 impl ApiTryFrom<backend::identity::VersionConfig> for models::CloudVersionIdentityConfig {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::identity::VersionConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::identity::VersionConfig) -> GlobalResult<Self> {
 		Ok(models::CloudVersionIdentityConfig {
 			display_names: Some(
 				value
@@ -83,14 +83,14 @@ impl ApiTryFrom<backend::identity::VersionConfig> for models::CloudVersionIdenti
 				value
 					.custom_display_names
 					.into_iter()
-					.map(ApiTryInto::try_into)
+					.map(ApiTryInto::api_try_into)
 					.collect::<Result<Vec<_>, _>>()?,
 			),
 			custom_avatars: Some(
 				value
 					.custom_avatars
 					.into_iter()
-					.map(ApiTryInto::try_into)
+					.map(ApiTryInto::api_try_into)
 					.collect::<Result<Vec<_>, _>>()?,
 			),
 		})
@@ -102,7 +102,7 @@ impl ApiTryFrom<backend::identity::CustomDisplayName>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::identity::CustomDisplayName) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::identity::CustomDisplayName) -> GlobalResult<Self> {
 		Ok(models::CloudVersionIdentityCustomDisplayName {
 			display_name: value.display_name,
 		})
@@ -112,7 +112,7 @@ impl ApiTryFrom<backend::identity::CustomDisplayName>
 impl ApiTryFrom<backend::identity::CustomAvatar> for models::CloudVersionIdentityCustomAvatar {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::identity::CustomAvatar) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::identity::CustomAvatar) -> GlobalResult<Self> {
 		Ok(models::CloudVersionIdentityCustomAvatar {
 			upload_id: unwrap!(value.upload_id).as_uuid(),
 		})

--- a/lib/convert/src/impls/cloud/version/matchmaker/game_mode.rs
+++ b/lib/convert/src/impls/cloud/version/matchmaker/game_mode.rs
@@ -119,12 +119,12 @@ pub fn game_mode_to_proto(
 												error = "`port` out of bounds"
 											);
 
-											Ok(x.try_into()?)
+											Ok(x.api_try_into()?)
 										})
 										.transpose()?,
 									port_range: value
 										.port_range
-										.map(|x| (*x).try_into())
+										.map(|x| (*x).api_try_into())
 										.transpose()?,
 									proxy_protocol: ApiInto::<
 										backend::matchmaker::lobby_runtime::ProxyProtocol,
@@ -149,9 +149,9 @@ pub fn game_mode_to_proto(
 			.iter()
 			.map(|(k, v)| region_to_proto(k.clone(), v, game_mode, matchmaker, all_regions))
 			.collect::<GlobalResult<_>>()?,
-		max_players_normal: max_players_normal.try_into()?,
-		max_players_direct: max_players_direct.try_into()?,
-		max_players_party: max_players_party.try_into()?,
+		max_players_normal: max_players_normal.api_try_into()?,
+		max_players_direct: max_players_direct.api_try_into()?,
+		max_players_party: max_players_party.api_try_into()?,
 		listable: game_mode.listable.unwrap_or(true),
 		taggable: game_mode.taggable.unwrap_or(false),
 		allow_dynamic_max_players: game_mode.allow_dynamic_max_players.unwrap_or(false),
@@ -161,7 +161,7 @@ pub fn game_mode_to_proto(
 		actions: game_mode
 			.actions
 			.clone()
-			.map(|x| ApiTryInto::try_into(*x))
+			.map(|x| (*x).api_try_into())
 			.transpose()?,
 	})
 }
@@ -201,11 +201,11 @@ pub fn game_mode_to_openapi(
 							GlobalResult::Ok((
 								x.label.clone(),
 								models::CloudVersionMatchmakerGameModeRuntimeDockerPort {
-									port: x.target_port.map(|x| x.try_into()).transpose()?,
+									port: x.target_port.map(|x| x.api_try_into()).transpose()?,
 									port_range: x
 										.port_range
 										.clone()
-										.map(ApiTryInto::try_into)
+										.map(ApiTryInto::api_try_into)
 										.transpose()?
 										.map(Box::new),
 									protocol: Some(
@@ -252,9 +252,9 @@ pub fn game_mode_to_openapi(
 					.map(|x| region_to_openapi(x, regions_data))
 					.collect::<GlobalResult<HashMap<_, _>>>()?,
 			),
-			max_players: Some(value.max_players_normal.try_into()?),
-			max_players_direct: Some(value.max_players_direct.try_into()?),
-			max_players_party: Some(value.max_players_party.try_into()?),
+			max_players: Some(value.max_players_normal.api_try_into()?),
+			max_players_direct: Some(value.max_players_direct.api_try_into()?),
+			max_players_party: Some(value.max_players_party.api_try_into()?),
 			listable: Some(value.listable),
 			taggable: Some(value.taggable),
 			allow_dynamic_max_players: Some(value.allow_dynamic_max_players),
@@ -263,7 +263,7 @@ pub fn game_mode_to_openapi(
 
 			actions: value
 				.actions
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 
@@ -299,7 +299,7 @@ fn region_to_proto(
 		.or_else(|| game_mode.idle_lobbies.clone())
 		.or_else(|| matchmaker.idle_lobbies.clone())
 		.map(|x| *x)
-		.map(ApiTryInto::try_into)
+		.map(ApiTryInto::api_try_into)
 		.transpose()?;
 
 	Ok(backend::matchmaker::lobby_group::Region {
@@ -329,7 +329,7 @@ fn region_to_openapi(
 			tier: Some(region.tier_name_id.to_owned()),
 			idle_lobbies: region
 				.idle_lobbies
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 		},
@@ -341,7 +341,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerGameModeIdleLobbiesConfig>
 {
 	type Error = GlobalError;
 
-	fn try_from(
+	fn api_try_from(
 		value: models::CloudVersionMatchmakerGameModeIdleLobbiesConfig,
 	) -> GlobalResult<Self> {
 		ensure_with!(
@@ -356,8 +356,8 @@ impl ApiTryFrom<models::CloudVersionMatchmakerGameModeIdleLobbiesConfig>
 		);
 
 		Ok(backend::matchmaker::lobby_group::IdleLobbies {
-			min_idle_lobbies: value.min.try_into()?,
-			max_idle_lobbies: value.max.try_into()?,
+			min_idle_lobbies: value.min.api_try_into()?,
+			max_idle_lobbies: value.max.api_try_into()?,
 		})
 	}
 }
@@ -367,10 +367,10 @@ impl ApiTryFrom<backend::matchmaker::lobby_group::IdleLobbies>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::lobby_group::IdleLobbies) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::lobby_group::IdleLobbies) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerGameModeIdleLobbiesConfig {
-			min: value.min_idle_lobbies.try_into()?,
-			max: value.max_idle_lobbies.try_into()?,
+			min: value.min_idle_lobbies.api_try_into()?,
+			max: value.max_idle_lobbies.api_try_into()?,
 		})
 	}
 }
@@ -418,22 +418,22 @@ impl ApiTryFrom<models::CloudVersionMatchmakerGameModeActions>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionMatchmakerGameModeActions) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionMatchmakerGameModeActions) -> GlobalResult<Self> {
 		Ok(backend::matchmaker::lobby_group::Actions {
 			find: value
 				.find
 				.clone()
-				.map(|x| ApiTryInto::try_into(*x))
+				.map(|x| (*x).api_try_into())
 				.transpose()?,
 			join: value
 				.join
 				.clone()
-				.map(|x| ApiTryInto::try_into(*x))
+				.map(|x| (*x).api_try_into())
 				.transpose()?,
 			create: value
 				.create
 				.clone()
-				.map(|x| ApiTryInto::try_into(*x))
+				.map(|x| (*x).api_try_into())
 				.transpose()?,
 		})
 	}
@@ -444,21 +444,21 @@ impl ApiTryFrom<backend::matchmaker::lobby_group::Actions>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::lobby_group::Actions) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::lobby_group::Actions) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerGameModeActions {
 			find: value
 				.find
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 			join: value
 				.join
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 			create: value
 				.create
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 		})
@@ -470,7 +470,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerGameModeVerificationConfig>
 {
 	type Error = GlobalError;
 
-	fn try_from(
+	fn api_try_from(
 		value: models::CloudVersionMatchmakerGameModeVerificationConfig,
 	) -> GlobalResult<Self> {
 		Ok(backend::matchmaker::VerificationConfig {
@@ -485,7 +485,7 @@ impl ApiTryFrom<backend::matchmaker::VerificationConfig>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::VerificationConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::VerificationConfig) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerGameModeVerificationConfig {
 			url: value.url,
 			headers: value.headers,
@@ -498,7 +498,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerGameModeFindConfig>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionMatchmakerGameModeFindConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionMatchmakerGameModeFindConfig) -> GlobalResult<Self> {
 		Ok(backend::matchmaker::FindConfig {
 			enabled: value.enabled,
 			identity_requirement: value
@@ -507,7 +507,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerGameModeFindConfig>
 				.unwrap_or(backend::matchmaker::IdentityRequirement::None) as i32,
 			verification: value
 				.verification
-				.map(|x| ApiTryInto::try_into(*x))
+				.map(|x| (*x).api_try_into())
 				.transpose()?,
 		})
 	}
@@ -518,7 +518,7 @@ impl ApiTryFrom<backend::matchmaker::FindConfig>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::FindConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::FindConfig) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerGameModeFindConfig {
 			enabled: value.enabled,
 			identity_requirement: Some(
@@ -530,7 +530,7 @@ impl ApiTryFrom<backend::matchmaker::FindConfig>
 			),
 			verification: value
 				.verification
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 		})
@@ -542,7 +542,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerGameModeJoinConfig>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionMatchmakerGameModeJoinConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionMatchmakerGameModeJoinConfig) -> GlobalResult<Self> {
 		Ok(backend::matchmaker::JoinConfig {
 			enabled: value.enabled,
 			identity_requirement: value
@@ -551,7 +551,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerGameModeJoinConfig>
 				.unwrap_or(backend::matchmaker::IdentityRequirement::None) as i32,
 			verification: value
 				.verification
-				.map(|x| ApiTryInto::try_into(*x))
+				.map(|x| (*x).api_try_into())
 				.transpose()?,
 		})
 	}
@@ -562,7 +562,7 @@ impl ApiTryFrom<backend::matchmaker::JoinConfig>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::JoinConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::JoinConfig) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerGameModeJoinConfig {
 			enabled: value.enabled,
 			identity_requirement: Some(
@@ -574,7 +574,7 @@ impl ApiTryFrom<backend::matchmaker::JoinConfig>
 			),
 			verification: value
 				.verification
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 		})
@@ -586,7 +586,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerGameModeCreateConfig>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionMatchmakerGameModeCreateConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionMatchmakerGameModeCreateConfig) -> GlobalResult<Self> {
 		if let Some(max_lobbies_per_identity) = value.max_lobbies_per_identity {
 			ensure_with!(
 				max_lobbies_per_identity >= 0,
@@ -603,13 +603,13 @@ impl ApiTryFrom<models::CloudVersionMatchmakerGameModeCreateConfig>
 				.unwrap_or(backend::matchmaker::IdentityRequirement::None) as i32,
 			verification: value
 				.verification
-				.map(|x| ApiTryInto::try_into(*x))
+				.map(|x| (*x).api_try_into())
 				.transpose()?,
 			enable_public: value.enable_public.unwrap_or(false),
 			enable_private: value.enable_private.unwrap_or(true),
 			max_lobbies_per_identity: value
 				.max_lobbies_per_identity
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?,
 		})
 	}
@@ -620,7 +620,7 @@ impl ApiTryFrom<backend::matchmaker::CreateConfig>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::CreateConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::CreateConfig) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerGameModeCreateConfig {
 			enabled: value.enabled,
 			identity_requirement: Some(
@@ -632,14 +632,14 @@ impl ApiTryFrom<backend::matchmaker::CreateConfig>
 			),
 			verification: value
 				.verification
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 			enable_public: Some(value.enable_public),
 			enable_private: Some(value.enable_private),
 			max_lobbies_per_identity: value
 				.max_lobbies_per_identity
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?,
 		})
 	}

--- a/lib/convert/src/impls/cloud/version/matchmaker/lobby_group.rs
+++ b/lib/convert/src/impls/cloud/version/matchmaker/lobby_group.rs
@@ -7,7 +7,7 @@ use crate::{ApiFrom, ApiInto, ApiTryFrom, ApiTryInto};
 impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroup> for backend::matchmaker::LobbyGroup {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionMatchmakerLobbyGroup) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionMatchmakerLobbyGroup) -> GlobalResult<Self> {
 		ensure_with!(
 			value.max_players_normal >= 0,
 			MATCHMAKER_INVALID_VERSION_CONFIG,
@@ -30,7 +30,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroup> for backend::matchmake
 			regions: value
 				.regions
 				.into_iter()
-				.map(|x| x.try_into())
+				.map(|x| x.api_try_into())
 				.collect::<GlobalResult<_>>()?,
 			max_players_normal: value.max_players_normal as u32,
 			max_players_direct: value.max_players_direct as u32,
@@ -39,7 +39,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroup> for backend::matchmake
 			taggable: false,
 			allow_dynamic_max_players: false,
 
-			runtime: Some((*value.runtime).try_into()?),
+			runtime: Some((*value.runtime).api_try_into()?),
 
 			actions: None,
 		})
@@ -49,20 +49,20 @@ impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroup> for backend::matchmake
 impl ApiTryFrom<backend::matchmaker::LobbyGroup> for models::CloudVersionMatchmakerLobbyGroup {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::LobbyGroup) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::LobbyGroup) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerLobbyGroup {
 			name_id: value.name_id.clone(),
 
 			regions: value
 				.regions
 				.into_iter()
-				.map(ApiTryFrom::try_from)
+				.map(ApiTryFrom::api_try_from)
 				.collect::<Result<Vec<_>, _>>()?,
-			max_players_normal: value.max_players_normal.try_into()?,
-			max_players_direct: value.max_players_direct.try_into()?,
-			max_players_party: value.max_players_party.try_into()?,
+			max_players_normal: value.max_players_normal.api_try_into()?,
+			max_players_direct: value.max_players_direct.api_try_into()?,
+			max_players_party: value.max_players_party.api_try_into()?,
 
-			runtime: Box::new(unwrap!(value.runtime).try_into()?),
+			runtime: Box::new(unwrap!(value.runtime).api_try_into()?),
 		})
 	}
 }
@@ -72,11 +72,11 @@ impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroupRegion>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionMatchmakerLobbyGroupRegion) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionMatchmakerLobbyGroupRegion) -> GlobalResult<Self> {
 		Ok(backend::matchmaker::lobby_group::Region {
 			region_id: Some(value.region_id.into()),
 			tier_name_id: value.tier_name_id.to_owned(),
-			idle_lobbies: value.idle_lobbies.map(|x| (*x).try_into()).transpose()?,
+			idle_lobbies: value.idle_lobbies.map(|x| (*x).api_try_into()).transpose()?,
 		})
 	}
 }
@@ -86,13 +86,13 @@ impl ApiTryFrom<backend::matchmaker::lobby_group::Region>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::lobby_group::Region) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::lobby_group::Region) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerLobbyGroupRegion {
 			region_id: unwrap!(value.region_id).as_uuid(),
 			tier_name_id: value.tier_name_id.to_owned(),
 			idle_lobbies: value
 				.idle_lobbies
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 		})
@@ -104,7 +104,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroupIdleLobbiesConfig>
 {
 	type Error = GlobalError;
 
-	fn try_from(
+	fn api_try_from(
 		value: models::CloudVersionMatchmakerLobbyGroupIdleLobbiesConfig,
 	) -> GlobalResult<Self> {
 		ensure_with!(
@@ -119,8 +119,8 @@ impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroupIdleLobbiesConfig>
 		);
 
 		Ok(backend::matchmaker::lobby_group::IdleLobbies {
-			min_idle_lobbies: value.min_idle_lobbies.try_into()?,
-			max_idle_lobbies: value.max_idle_lobbies.try_into()?,
+			min_idle_lobbies: value.min_idle_lobbies.api_try_into()?,
+			max_idle_lobbies: value.max_idle_lobbies.api_try_into()?,
 		})
 	}
 }
@@ -130,10 +130,10 @@ impl ApiTryFrom<backend::matchmaker::lobby_group::IdleLobbies>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::lobby_group::IdleLobbies) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::lobby_group::IdleLobbies) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerLobbyGroupIdleLobbiesConfig {
-			min_idle_lobbies: value.min_idle_lobbies.try_into()?,
-			max_idle_lobbies: value.max_idle_lobbies.try_into()?,
+			min_idle_lobbies: value.min_idle_lobbies.api_try_into()?,
+			max_idle_lobbies: value.max_idle_lobbies.api_try_into()?,
 		})
 	}
 }
@@ -143,7 +143,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroupRuntime>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionMatchmakerLobbyGroupRuntime) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionMatchmakerLobbyGroupRuntime) -> GlobalResult<Self> {
 		Ok(backend::matchmaker::LobbyRuntime {
 			runtime: value
 				.docker
@@ -166,7 +166,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroupRuntime>
 							ports: runtime
 								.ports
 								.into_iter()
-								.map(ApiTryInto::try_into)
+								.map(ApiTryInto::api_try_into)
 								.collect::<GlobalResult<_>>()?,
 						},
 					))
@@ -181,7 +181,7 @@ impl ApiTryFrom<backend::matchmaker::LobbyRuntime>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::LobbyRuntime) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::LobbyRuntime) -> GlobalResult<Self> {
 		let runtime = unwrap!(value.runtime);
 
 		Ok(match runtime {
@@ -194,7 +194,7 @@ impl ApiTryFrom<backend::matchmaker::LobbyRuntime>
 							env_vars: runtime
 								.env_vars
 								.into_iter()
-								.map(ApiTryFrom::try_from)
+								.map(ApiTryFrom::api_try_from)
 								.collect::<Result<Vec<_>, _>>()?,
 							network_mode: Some(
 								unwrap!(backend::matchmaker::lobby_runtime::NetworkMode::from_i32(
@@ -205,7 +205,7 @@ impl ApiTryFrom<backend::matchmaker::LobbyRuntime>
 							ports: runtime
 								.ports
 								.into_iter()
-								.map(ApiTryFrom::try_from)
+								.map(ApiTryFrom::api_try_from)
 								.collect::<Result<Vec<_>, _>>()?,
 						},
 					)),
@@ -220,7 +220,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroupRuntimeDockerPort>
 {
 	type Error = GlobalError;
 
-	fn try_from(
+	fn api_try_from(
 		value: models::CloudVersionMatchmakerLobbyGroupRuntimeDockerPort,
 	) -> GlobalResult<Self> {
 		if let Some(target_port) = value.target_port {
@@ -244,10 +244,10 @@ impl ApiTryFrom<models::CloudVersionMatchmakerLobbyGroupRuntimeDockerPort>
 						error = "`target_port` out of bounds"
 					);
 
-					Ok(x.try_into()?)
+					Ok(x.api_try_into()?)
 				})
 				.transpose()?,
-			port_range: value.port_range.map(|x| (*x).try_into()).transpose()?,
+			port_range: value.port_range.map(|x| (*x).api_try_into()).transpose()?,
 			proxy_protocol: (ApiInto::<backend::matchmaker::lobby_runtime::ProxyProtocol>::api_into(
 				value.proxy_protocol,
 			)) as i32,
@@ -261,13 +261,13 @@ impl ApiTryFrom<backend::matchmaker::lobby_runtime::Port>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::lobby_runtime::Port) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::lobby_runtime::Port) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerLobbyGroupRuntimeDockerPort {
 			label: value.label,
-			target_port: value.target_port.map(|x| x.try_into()).transpose()?,
+			target_port: value.target_port.map(|x| x.api_try_into()).transpose()?,
 			port_range: value
 				.port_range
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 			proxy_protocol: unwrap!(backend::matchmaker::lobby_runtime::ProxyProtocol::from_i32(
@@ -296,7 +296,7 @@ impl ApiTryFrom<backend::matchmaker::lobby_runtime::EnvVar>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::lobby_runtime::EnvVar) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::lobby_runtime::EnvVar) -> GlobalResult<Self> {
 		Ok(
 			models::CloudVersionMatchmakerLobbyGroupRuntimeDockerEnvVar {
 				key: value.key,

--- a/lib/convert/src/impls/cloud/version/matchmaker/mod.rs
+++ b/lib/convert/src/impls/cloud/version/matchmaker/mod.rs
@@ -34,7 +34,7 @@ pub async fn config_to_proto(
 
 	let lobby_groups = if let Some(x) = value.lobby_groups {
 		x.into_iter()
-			.map(ApiTryInto::try_into)
+			.map(ApiTryInto::api_try_into)
 			.collect::<GlobalResult<Vec<_>>>()?
 	} else if let Some(x) = value.game_modes.as_ref() {
 		x.iter()
@@ -46,7 +46,7 @@ pub async fn config_to_proto(
 
 	Ok(backend::matchmaker::VersionConfig {
 		lobby_groups,
-		captcha: value.captcha.map(|x| (*x).try_into()).transpose()?,
+		captcha: value.captcha.map(|x| (*x).api_try_into()).transpose()?,
 	})
 }
 
@@ -80,7 +80,7 @@ pub async fn config_to_openapi(
 		),
 		captcha: value
 			.captcha
-			.map(ApiTryInto::try_into)
+			.map(ApiTryInto::api_try_into)
 			.transpose()?
 			.map(Box::new),
 
@@ -102,7 +102,7 @@ pub async fn config_to_openapi(
 				.lobby_groups
 				.iter()
 				.cloned()
-				.map(ApiTryFrom::try_from)
+				.map(ApiTryFrom::api_try_from)
 				.collect::<Result<Vec<_>, _>>()?,
 		),
 	})
@@ -113,7 +113,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerPortRange>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionMatchmakerPortRange) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionMatchmakerPortRange) -> GlobalResult<Self> {
 		ensure_with!(
 			value.min >= 0,
 			MATCHMAKER_INVALID_VERSION_CONFIG,
@@ -126,8 +126,8 @@ impl ApiTryFrom<models::CloudVersionMatchmakerPortRange>
 		);
 
 		Ok(backend::matchmaker::lobby_runtime::PortRange {
-			min: value.min.try_into()?,
-			max: value.max.try_into()?,
+			min: value.min.api_try_into()?,
+			max: value.max.api_try_into()?,
 		})
 	}
 }
@@ -137,10 +137,10 @@ impl ApiTryFrom<backend::matchmaker::lobby_runtime::PortRange>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::matchmaker::lobby_runtime::PortRange) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::matchmaker::lobby_runtime::PortRange) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerPortRange {
-			min: value.min.try_into()?,
-			max: value.max.try_into()?,
+			min: value.min.api_try_into()?,
+			max: value.max.api_try_into()?,
 		})
 	}
 }
@@ -262,7 +262,7 @@ impl ApiFrom<backend::matchmaker::lobby_runtime::ProxyKind>
 impl ApiTryFrom<models::CloudVersionMatchmakerCaptcha> for backend::captcha::CaptchaConfig {
 	type Error = GlobalError;
 
-	fn try_from(value: models::CloudVersionMatchmakerCaptcha) -> GlobalResult<Self> {
+	fn api_try_from(value: models::CloudVersionMatchmakerCaptcha) -> GlobalResult<Self> {
 		ensure_with!(
 			value.requests_before_reverify >= 0,
 			MATCHMAKER_INVALID_VERSION_CONFIG,
@@ -275,7 +275,7 @@ impl ApiTryFrom<models::CloudVersionMatchmakerCaptcha> for backend::captcha::Cap
 		);
 
 		Ok(backend::captcha::CaptchaConfig {
-			requests_before_reverify: value.requests_before_reverify.try_into()?,
+			requests_before_reverify: value.requests_before_reverify.api_try_into()?,
 			verification_ttl: value.verification_ttl,
 			hcaptcha: value.hcaptcha.map(|x| (*x).api_into()),
 			turnstile: value.turnstile.map(|x| (*x).api_into()),
@@ -286,18 +286,18 @@ impl ApiTryFrom<models::CloudVersionMatchmakerCaptcha> for backend::captcha::Cap
 impl ApiTryFrom<backend::captcha::CaptchaConfig> for models::CloudVersionMatchmakerCaptcha {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::captcha::CaptchaConfig) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::captcha::CaptchaConfig) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerCaptcha {
-			requests_before_reverify: value.requests_before_reverify.try_into()?,
+			requests_before_reverify: value.requests_before_reverify.api_try_into()?,
 			verification_ttl: value.verification_ttl,
 			hcaptcha: value
 				.hcaptcha
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 			turnstile: value
 				.turnstile
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.transpose()?
 				.map(Box::new),
 		})
@@ -323,7 +323,7 @@ impl ApiTryFrom<backend::captcha::captcha_config::Hcaptcha>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::captcha::captcha_config::Hcaptcha) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::captcha::captcha_config::Hcaptcha) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerCaptchaHcaptcha {
 			level: unwrap!(backend::captcha::captcha_config::hcaptcha::Level::from_i32(
 				value.level
@@ -395,7 +395,7 @@ impl ApiTryFrom<backend::captcha::captcha_config::Turnstile>
 {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::captcha::captcha_config::Turnstile) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::captcha::captcha_config::Turnstile) -> GlobalResult<Self> {
 		Ok(models::CloudVersionMatchmakerCaptchaTurnstile {
 			site_key: value.site_key,
 			secret_key: value.secret_key,

--- a/lib/convert/src/impls/cloud/version/mod.rs
+++ b/lib/convert/src/impls/cloud/version/mod.rs
@@ -12,7 +12,7 @@ pub mod matchmaker;
 impl ApiTryFrom<backend::game::Version> for models::CloudVersionSummary {
 	type Error = GlobalError;
 
-	fn try_from(value: backend::game::Version) -> GlobalResult<Self> {
+	fn api_try_from(value: backend::game::Version) -> GlobalResult<Self> {
 		Ok(models::CloudVersionSummary {
 			version_id: unwrap!(value.version_id).as_uuid(),
 			create_ts: util::timestamp::to_string(value.create_ts)?,
@@ -25,14 +25,14 @@ pub async fn config_to_proto(
 	value: models::CloudVersionConfig,
 ) -> GlobalResult<backend::cloud::VersionConfig> {
 	Ok(backend::cloud::VersionConfig {
-		cdn: value.cdn.map(|x| (*x).try_into()).transpose()?,
+		cdn: value.cdn.map(|x| (*x).api_try_into()).transpose()?,
 		matchmaker: if let Some(matchmaker) = value.matchmaker {
 			Some(matchmaker::config_to_proto(ctx, *matchmaker).await?)
 		} else {
 			None
 		},
 		kv: value.kv.map(|_| backend::kv::VersionConfig {}),
-		identity: value.identity.map(|x| (*x).try_into()).transpose()?,
+		identity: value.identity.map(|x| (*x).api_try_into()).transpose()?,
 		// TODO:
 		module: None,
 	})
@@ -47,7 +47,7 @@ pub async fn config_to_openapi(
 		engine: None, // CLient side only
 		cdn: value
 			.cdn
-			.map(ApiTryFrom::try_from)
+			.map(ApiTryFrom::api_try_from)
 			.transpose()?
 			.map(Box::new),
 		matchmaker: if let Some(matchmaker) = value.matchmaker {
@@ -60,7 +60,7 @@ pub async fn config_to_openapi(
 		kv: value.kv.map(|_| serde_json::json!({})),
 		identity: value
 			.identity
-			.map(ApiTryFrom::try_from)
+			.map(ApiTryFrom::api_try_from)
 			.transpose()?
 			.map(Box::new),
 	})

--- a/lib/convert/src/impls/identity.rs
+++ b/lib/convert/src/impls/identity.rs
@@ -7,7 +7,7 @@ use crate::{ApiFrom, ApiTryFrom};
 impl ApiTryFrom<backend::user_identity::Identity> for models::IdentityLinkedAccount {
 	type Error = GlobalError;
 
-	fn try_from(
+	fn api_try_from(
 		value: backend::user_identity::Identity,
 	) -> GlobalResult<models::IdentityLinkedAccount> {
 		match unwrap_ref!(value.kind) {

--- a/lib/convert/src/impls/kv.rs
+++ b/lib/convert/src/impls/kv.rs
@@ -14,7 +14,7 @@ pub struct DestructuredKvEntry {
 impl ApiTryFrom<kv::list::response::Entry> for models::KvEntry {
 	type Error = GlobalError;
 
-	fn try_from(value: kv::list::response::Entry) -> GlobalResult<models::KvEntry> {
+	fn api_try_from(value: kv::list::response::Entry) -> GlobalResult<models::KvEntry> {
 		Ok(models::KvEntry {
 			key: value.key,
 			value: value
@@ -29,7 +29,7 @@ impl ApiTryFrom<kv::list::response::Entry> for models::KvEntry {
 impl ApiTryFrom<kv::msg::update::Message> for models::KvEntry {
 	type Error = GlobalError;
 
-	fn try_from(value: kv::msg::update::Message) -> GlobalResult<models::KvEntry> {
+	fn api_try_from(value: kv::msg::update::Message) -> GlobalResult<models::KvEntry> {
 		let deleted = value.value.is_some().then(|| true);
 
 		Ok(models::KvEntry {
@@ -46,7 +46,7 @@ impl ApiTryFrom<kv::msg::update::Message> for models::KvEntry {
 impl ApiTryFrom<DestructuredKvEntry> for models::KvEntry {
 	type Error = GlobalError;
 
-	fn try_from(value: DestructuredKvEntry) -> GlobalResult<models::KvEntry> {
+	fn api_try_from(value: DestructuredKvEntry) -> GlobalResult<models::KvEntry> {
 		let deleted = value.value.is_some().then(|| true);
 
 		Ok(models::KvEntry {

--- a/lib/convert/src/impls/mod.rs
+++ b/lib/convert/src/impls/mod.rs
@@ -13,7 +13,7 @@ mod num {
 	impl ApiTryFrom<i32> for u32 {
 		type Error = std::num::TryFromIntError;
 
-		fn try_from(v: i32) -> Result<Self, Self::Error> {
+		fn api_try_from(v: i32) -> Result<Self, Self::Error> {
 			std::convert::TryInto::try_into(v)
 		}
 	}
@@ -21,7 +21,7 @@ mod num {
 	impl ApiTryFrom<u32> for i32 {
 		type Error = std::num::TryFromIntError;
 
-		fn try_from(v: u32) -> Result<Self, Self::Error> {
+		fn api_try_from(v: u32) -> Result<Self, Self::Error> {
 			std::convert::TryInto::try_into(v)
 		}
 	}
@@ -29,7 +29,7 @@ mod num {
 	impl ApiTryFrom<u64> for i64 {
 		type Error = std::num::TryFromIntError;
 
-		fn try_from(v: u64) -> Result<Self, Self::Error> {
+		fn api_try_from(v: u64) -> Result<Self, Self::Error> {
 			std::convert::TryInto::try_into(v)
 		}
 	}
@@ -37,7 +37,7 @@ mod num {
 	impl ApiTryFrom<i64> for u64 {
 		type Error = std::num::TryFromIntError;
 
-		fn try_from(v: i64) -> Result<Self, Self::Error> {
+		fn api_try_from(v: i64) -> Result<Self, Self::Error> {
 			std::convert::TryInto::try_into(v)
 		}
 	}
@@ -45,7 +45,7 @@ mod num {
 	impl ApiTryFrom<u64> for i32 {
 		type Error = std::num::TryFromIntError;
 
-		fn try_from(v: u64) -> Result<Self, Self::Error> {
+		fn api_try_from(v: u64) -> Result<Self, Self::Error> {
 			std::convert::TryInto::try_into(v)
 		}
 	}
@@ -53,7 +53,7 @@ mod num {
 	impl ApiTryFrom<i32> for u64 {
 		type Error = std::num::TryFromIntError;
 
-		fn try_from(v: i32) -> Result<Self, Self::Error> {
+		fn api_try_from(v: i32) -> Result<Self, Self::Error> {
 			std::convert::TryInto::try_into(v)
 		}
 	}

--- a/lib/convert/src/lib.rs
+++ b/lib/convert/src/lib.rs
@@ -8,7 +8,7 @@ pub trait ApiTryFrom<T>: Sized {
 	type Error;
 
 	/// Performs the conversion.
-	fn try_from(value: T) -> Result<Self, Self::Error>;
+	fn api_try_from(value: T) -> Result<Self, Self::Error>;
 }
 
 pub trait ApiTryInto<T>: Sized {
@@ -16,7 +16,7 @@ pub trait ApiTryInto<T>: Sized {
 	type Error;
 
 	/// Performs the conversion.
-	fn try_into(self) -> Result<T, Self::Error>;
+	fn api_try_into(self) -> Result<T, Self::Error>;
 }
 
 impl<T, U> ApiTryInto<U> for T
@@ -25,8 +25,8 @@ where
 {
 	type Error = U::Error;
 
-	fn try_into(self) -> Result<U, U::Error> {
-		U::try_from(self)
+	fn api_try_into(self) -> Result<U, U::Error> {
+		U::api_try_from(self)
 	}
 }
 

--- a/svc/api/auth/src/route/identity.rs
+++ b/svc/api/auth/src/route/identity.rs
@@ -41,7 +41,7 @@ pub async fn start(
 						}),
 						..Default::default()
 					}),
-					client_response: Some((*captcha).try_into()?),
+					client_response: Some((*captcha).api_try_into()?),
 					user_id: Some(user_ent.user_id.into()),
 				})
 				.await?;

--- a/svc/api/cloud/src/route/games/avatars.rs
+++ b/svc/api/cloud/src/route/games/avatars.rs
@@ -133,7 +133,7 @@ pub async fn prepare_avatar_upload(
 			backend::upload::PrepareFile {
 				path: format!("image.{ext}"),
 				mime: Some(format!("image/{ext}")),
-				content_length: body.content_length.try_into()?,
+				content_length: body.content_length.api_try_into()?,
 				nsfw_score_threshold: Some(util_nsfw::score_thresholds::USER_AVATAR),
 				..Default::default()
 			},
@@ -147,7 +147,7 @@ pub async fn prepare_avatar_upload(
 
 	Ok(models::CloudGamesPrepareCustomAvatarUploadResponse {
 		upload_id,
-		presigned_request: Box::new(presigned_request.clone().try_into()?),
+		presigned_request: Box::new(presigned_request.clone().api_try_into()?),
 	})
 }
 

--- a/svc/api/cloud/src/route/games/builds.rs
+++ b/svc/api/cloud/src/route/games/builds.rs
@@ -57,7 +57,7 @@ pub async fn get_builds(
 					create_ts: util::timestamp::to_string(build.create_ts)?,
 					content_length: upload
 						.map_or(0, |upload| upload.content_length)
-						.try_into()?,
+						.api_try_into()?,
 					complete: upload.map_or(true, |upload| upload.complete_ts.is_some()),
 				},
 			))
@@ -105,7 +105,7 @@ pub async fn create_build(
 		game_id: Some(game_id.into()),
 		display_name: body.display_name,
 		image_tag: Some(body.image_tag),
-		image_file: Some((*body.image_file).try_into()?),
+		image_file: Some((*body.image_file).api_try_into()?),
 		multipart: multipart_upload,
 		kind: kind as i32,
 		compression: compression as i32,
@@ -117,7 +117,7 @@ pub async fn create_build(
 		Some(Box::new(
 			unwrap!(create_res.image_presigned_requests.first())
 				.clone()
-				.try_into()?,
+				.api_try_into()?,
 		))
 	} else {
 		None
@@ -129,7 +129,7 @@ pub async fn create_build(
 				.image_presigned_requests
 				.iter()
 				.cloned()
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.collect::<GlobalResult<Vec<_>>>()?,
 		)
 	} else {

--- a/svc/api/cloud/src/route/games/cdn.rs
+++ b/svc/api/cloud/src/route/games/cdn.rs
@@ -59,7 +59,7 @@ pub async fn get_sites(
 				create_ts: util::timestamp::to_string(site.create_ts)?,
 				content_length: upload
 					.map_or(0, |upload| upload.content_length)
-					.try_into()?,
+					.api_try_into()?,
 				complete: upload.map_or(true, |upload| upload.complete_ts.is_some()),
 			})
 		})
@@ -84,7 +84,7 @@ pub async fn create_site(
 		files: body
 			.files
 			.into_iter()
-			.map(ApiTryInto::try_into)
+			.map(ApiTryInto::api_try_into)
 			.collect::<GlobalResult<_>>()?,
 	})
 	.await?;
@@ -96,7 +96,7 @@ pub async fn create_site(
 			.presigned_requests
 			.iter()
 			.cloned()
-			.map(ApiTryInto::try_into)
+			.map(ApiTryInto::api_try_into)
 			.collect::<GlobalResult<Vec<_>>>()?,
 	})
 }

--- a/svc/api/cloud/src/route/games/mod.rs
+++ b/svc/api/cloud/src/route/games/mod.rs
@@ -403,7 +403,7 @@ pub async fn get(
 			continue;
 		};
 
-		namespaces.push(models::CloudNamespaceSummary::try_from(ns.clone())?);
+		namespaces.push(models::CloudNamespaceSummary::api_try_from(ns.clone())?);
 	}
 	namespaces.sort_by(|a, b| a.display_name.cmp(&b.display_name));
 
@@ -426,7 +426,7 @@ pub async fn get(
 	versions.sort_by_key(|v| v.create_ts);
 	let versions = versions
 		.into_iter()
-		.map(ApiTryInto::try_into)
+		.map(ApiTryInto::api_try_into)
 		.collect::<GlobalResult<Vec<_>>>()?;
 
 	let regions = fetch::game::region_summaries(ctx.op_ctx()).await?;
@@ -438,7 +438,7 @@ pub async fn get(
 			name_id: game.name_id.to_owned(),
 			display_name: game.display_name.to_owned(),
 			developer_group_id: unwrap_ref!(dev_team.team_id).as_uuid(),
-			total_player_count: state.total_player_count.try_into()?,
+			total_player_count: state.total_player_count.api_try_into()?,
 			logo_url: util::route::game_logo(&game),
 			banner_url: util::route::game_banner(&game),
 
@@ -504,7 +504,7 @@ pub async fn prepare_logo_upload(
 			backend::upload::PrepareFile {
 				path: format!("logo.{ext}"),
 				mime: Some(format!("image/{ext}")),
-				content_length: body.content_length.try_into()?,
+				content_length: body.content_length.api_try_into()?,
 				nsfw_score_threshold: Some(util_nsfw::score_thresholds::GAME_LOGO),
 				..Default::default()
 			},
@@ -518,7 +518,7 @@ pub async fn prepare_logo_upload(
 
 	Ok(models::CloudGamesGameLogoUploadPrepareResponse {
 		upload_id,
-		presigned_request: Box::new(presigned_request.clone().try_into()?),
+		presigned_request: Box::new(presigned_request.clone().api_try_into()?),
 	})
 }
 
@@ -579,7 +579,7 @@ pub async fn prepare_banner_upload(
 			backend::upload::PrepareFile {
 				path: format!("banner.{ext}"),
 				mime: Some(format!("image/{ext}")),
-				content_length: body.content_length.try_into()?,
+				content_length: body.content_length.api_try_into()?,
 				nsfw_score_threshold: Some(util_nsfw::score_thresholds::GAME_BANNER),
 				..Default::default()
 			},
@@ -593,7 +593,7 @@ pub async fn prepare_banner_upload(
 
 	Ok(models::CloudGamesGameBannerUploadPrepareResponse {
 		upload_id,
-		presigned_request: Box::new(presigned_request.clone().try_into()?),
+		presigned_request: Box::new(presigned_request.clone().api_try_into()?),
 	})
 }
 

--- a/svc/api/cloud/src/route/games/namespaces/logs.rs
+++ b/svc/api/cloud/src/route/games/namespaces/logs.rs
@@ -115,7 +115,10 @@ pub async fn get_lobby(
 	Ok(models::CloudGamesNamespacesGetNamespaceLobbyResponse {
 		lobby: Box::new(lobby.summary),
 		perf_lists: Vec::new(),
-		metrics: metrics.map(ApiTryInto::try_into).transpose()?.map(Box::new),
+		metrics: metrics
+			.map(ApiTryInto::api_try_into)
+			.transpose()?
+			.map(Box::new),
 
 		// Deprecated
 		stdout_presigned_urls: Vec::new(),
@@ -201,7 +204,7 @@ async fn fetch_lobby_logs(ctx: &Ctx<Auth>, lobby_ids: Vec<Uuid>) -> GlobalResult
 							stopped: Some(Box::new(models::CloudLogsLobbyStatusStopped {
 								stop_ts: util::timestamp::to_string(stop_ts)?,
 								failed,
-								exit_code: exit_code.try_into()?,
+								exit_code: exit_code.api_try_into()?,
 							})),
 							..Default::default()
 						})

--- a/svc/api/cloud/src/route/games/namespaces/mod.rs
+++ b/svc/api/cloud/src/route/games/namespaces/mod.rs
@@ -170,7 +170,7 @@ pub async fn get(
 		}
 	};
 
-	let summary = ApiTryInto::<models::CloudNamespaceSummary>::try_into(game_namespace)?;
+	let summary = ApiTryInto::<models::CloudNamespaceSummary>::api_try_into(game_namespace)?;
 	let namespace = models::CloudNamespaceFull {
 		namespace_id: summary.namespace_id,
 		create_ts: summary.create_ts,
@@ -180,7 +180,7 @@ pub async fn get(
 
 		config: Box::new(models::CloudNamespaceConfig {
 			cdn: Box::new(cdn_ns_config),
-			matchmaker: Box::new(unwrap_ref!(ns_config.matchmaker).clone().try_into()?),
+			matchmaker: Box::new(unwrap_ref!(ns_config.matchmaker).clone().api_try_into()?),
 			kv: serde_json::json!({}),
 			identity: serde_json::json!({}),
 		}),
@@ -303,7 +303,7 @@ pub async fn create_token_development(
 							error = "`port` out of bounds"
 						);
 
-						Some(port.try_into()?)
+						Some(port.api_try_into()?)
 					} else {
 						None
 					},
@@ -320,8 +320,8 @@ pub async fn create_token_development(
 						);
 
 						Some(backend::matchmaker::lobby_runtime::PortRange {
-							min: port_range.min.try_into()?,
-							max: port_range.max.try_into()?,
+							min: port_range.min.api_try_into()?,
+							max: port_range.max.api_try_into()?,
 						})
 					} else {
 						None
@@ -352,7 +352,7 @@ pub async fn create_token_development(
 
 					Ok(backend::matchmaker::lobby_runtime::Port {
 						label: port.label,
-						target_port: Some(target_port.try_into()?),
+						target_port: Some(target_port.api_try_into()?),
 						port_range: None,
 						proxy_protocol:
 							(ApiInto::<backend::matchmaker::lobby_runtime::ProxyProtocol>::api_into(
@@ -533,12 +533,12 @@ pub async fn update_mm_config(
 
 	let _res = op!([ctx] mm_config_namespace_config_set {
 		namespace_id: Some(namespace_id.into()),
-		lobby_count_max: body.lobby_count_max.try_into()?,
-		max_players_per_client: body.max_players.try_into()?,
-		max_players_per_client_vpn: body.max_players.try_into()?,
-		max_players_per_client_proxy: body.max_players.try_into()?,
-		max_players_per_client_tor: body.max_players.try_into()?,
-		max_players_per_client_hosting: body.max_players.try_into()?,
+		lobby_count_max: body.lobby_count_max.api_try_into()?,
+		max_players_per_client: body.max_players.api_try_into()?,
+		max_players_per_client_vpn: body.max_players.api_try_into()?,
+		max_players_per_client_proxy: body.max_players.api_try_into()?,
+		max_players_per_client_tor: body.max_players.api_try_into()?,
+		max_players_per_client_hosting: body.max_players.api_try_into()?,
 	})
 	.await?;
 
@@ -627,7 +627,7 @@ pub async fn validate_token_development(
 		lobby_ports: body.lobby_ports
 			.clone()
 				.into_iter()
-				.map(ApiTryInto::try_into)
+				.map(ApiTryInto::api_try_into)
 				.collect::<GlobalResult<_>>()?,
 	})
 	.await?;
@@ -665,12 +665,12 @@ pub async fn validate_mm_config(
 
 	let res = op!([ctx] mm_config_namespace_config_validate {
 		namespace_id: Some(namespace_id.into()),
-		lobby_count_max: body.lobby_count_max.try_into()?,
-		max_players_per_client: body.max_players.try_into()?,
-		max_players_per_client_vpn: body.max_players.try_into()?,
-		max_players_per_client_proxy: body.max_players.try_into()?,
-		max_players_per_client_tor: body.max_players.try_into()?,
-		max_players_per_client_hosting: body.max_players.try_into()?,
+		lobby_count_max: body.lobby_count_max.api_try_into()?,
+		max_players_per_client: body.max_players.api_try_into()?,
+		max_players_per_client_vpn: body.max_players.api_try_into()?,
+		max_players_per_client_proxy: body.max_players.api_try_into()?,
+		max_players_per_client_tor: body.max_players.api_try_into()?,
+		max_players_per_client_hosting: body.max_players.api_try_into()?,
 	})
 	.await?;
 

--- a/svc/api/cloud/src/route/games/versions.rs
+++ b/svc/api/cloud/src/route/games/versions.rs
@@ -26,7 +26,7 @@ pub async fn get(
 	let cloud_version = unwrap!(cloud_version_res.versions.first());
 	let cloud_version_config = unwrap_ref!(cloud_version.config);
 
-	let summary = models::CloudVersionSummary::try_from(game_version)?;
+	let summary = models::CloudVersionSummary::api_try_from(game_version)?;
 	let openapi_version = rivet_convert::cloud::version::config_to_openapi(
 		ctx.op_ctx(),
 		cloud_version_config.clone(),

--- a/svc/api/cloud/src/route/logs.rs
+++ b/svc/api/cloud/src/route/logs.rs
@@ -26,7 +26,7 @@ pub async fn get_ray_perf(
 	Ok(models::CloudGetRayPerfLogsResponse {
 		perf_lists: perf_lists
 			.into_iter()
-			.map(ApiTryInto::try_into)
+			.map(ApiTryInto::api_try_into)
 			.collect::<Result<Vec<_>, _>>()?,
 	})
 }

--- a/svc/api/cloud/src/route/tiers.rs
+++ b/svc/api/cloud/src/route/tiers.rs
@@ -23,7 +23,7 @@ pub async fn list_tiers(
 			.tiers
 			.clone()
 			.into_iter()
-			.map(ApiTryInto::try_into)
+			.map(ApiTryInto::api_try_into)
 			.collect::<GlobalResult<Vec<_>>>()?,
 	})
 }

--- a/svc/api/group/src/convert/group.rs
+++ b/svc/api/group/src/convert/group.rs
@@ -45,7 +45,7 @@ pub fn summary(
 
 		is_current_identity_member,
 		publicity: unwrap!(backend::team::Publicity::from_i32(team.publicity)).api_into(),
-		member_count: member_count.try_into()?,
+		member_count: member_count.api_try_into()?,
 		owner_identity_id: owner_user_id.to_string(),
 		is_developer: true,
 	})

--- a/svc/api/group/src/route/groups.rs
+++ b/svc/api/group/src/route/groups.rs
@@ -902,7 +902,7 @@ pub async fn prepare_avatar_upload(
 			backend::upload::PrepareFile {
 				path: format!("image.{}", ext),
 				mime: Some(format!("image/{}", ext)),
-				content_length: body.content_length.try_into()?,
+				content_length: body.content_length.api_try_into()?,
 				nsfw_score_threshold: Some(util_nsfw::score_thresholds::TEAM_AVATAR),
 				..Default::default()
 			},
@@ -916,7 +916,7 @@ pub async fn prepare_avatar_upload(
 
 	Ok(new_models::GroupPrepareAvatarUploadResponse {
 		upload_id,
-		presigned_request: Box::new(presigned_request.clone().try_into()?),
+		presigned_request: Box::new(presigned_request.clone().api_try_into()?),
 	})
 }
 
@@ -984,7 +984,7 @@ pub async fn create_invite(
 	let res = msg!([ctx] team_invite::msg::create(group_id) -> team_invite::msg::create_complete {
 		team_id: Some(group_id.into()),
 		ttl: body.ttl,
-		max_use_count: body.use_count.map(|v| v.try_into()).transpose()?,
+		max_use_count: body.use_count.map(|v| v.api_try_into()).transpose()?,
 	})
 	.await?;
 

--- a/svc/api/identity/src/route/events.rs
+++ b/svc/api/identity/src/route/events.rs
@@ -409,8 +409,8 @@ fn build_port(
 				hostname: node_public_ipv4.clone(),
 				port: None,
 				port_range: Some(Box::new(models::MatchmakerJoinPortRange {
-					min: port_range.min.try_into()?,
-					max: port_range.max.try_into()?,
+					min: port_range.min.api_try_into()?,
+					max: port_range.max.api_try_into()?,
 				})),
 				is_tls: false,
 			})

--- a/svc/api/identity/src/route/identities.rs
+++ b/svc/api/identity/src/route/identities.rs
@@ -432,7 +432,7 @@ pub async fn update_profile(
 	msg!([ctx] user::msg::profile_set(user_ent.user_id) -> user::msg::update {
 		user_id: Some(user_ent.user_id.into()),
 		display_name: body.display_name.clone(),
-		account_number: body.account_number.map(|n| n.try_into()).transpose()?,
+		account_number: body.account_number.map(|n| n.api_try_into()).transpose()?,
 		bio: body.bio.clone(),
 	})
 	.await?;
@@ -598,7 +598,7 @@ pub async fn validate_profile(
 		display_name: body.display_name.clone(),
 		account_number:
 			body.account_number
-				.map(|n| n.try_into())
+				.map(|n| n.api_try_into())
 				.transpose()?,
 		bio: body.bio.clone(),
 	})
@@ -642,7 +642,7 @@ pub async fn prepare_avatar_upload(
 			backend::upload::PrepareFile {
 				path: format!("image.{}", ext),
 				mime: Some(format!("image/{}", ext)),
-				content_length: body.content_length.try_into()?,
+				content_length: body.content_length.api_try_into()?,
 				nsfw_score_threshold: Some(util_nsfw::score_thresholds::USER_AVATAR),
 				..Default::default()
 			},
@@ -656,7 +656,7 @@ pub async fn prepare_avatar_upload(
 
 	Ok(models::IdentityPrepareAvatarUploadResponse {
 		upload_id,
-		presigned_request: Box::new(presigned_request.clone().try_into()?),
+		presigned_request: Box::new(presigned_request.clone().api_try_into()?),
 	})
 }
 

--- a/svc/api/kv/src/route/batch_operations.rs
+++ b/svc/api/kv/src/route/batch_operations.rs
@@ -259,7 +259,7 @@ async fn watch_batch_immediate(
 		Ok(ImmediateResult::Complete((
 			entries
 				.into_iter()
-				.map(ApiTryInto::<models::KvEntry>::try_into)
+				.map(ApiTryInto::<models::KvEntry>::api_try_into)
 				.collect::<GlobalResult<Vec<_>>>()?,
 			latest_update_ts,
 		)))
@@ -324,7 +324,7 @@ async fn watch_batch_merge_subs(
 	Ok((
 		entries
 			.into_iter()
-			.map(ApiTryInto::try_into)
+			.map(ApiTryInto::api_try_into)
 			.collect::<GlobalResult<Vec<_>>>()?,
 		latest_update_ts,
 	))

--- a/svc/api/matchmaker/src/route/lobbies.rs
+++ b/svc/api/matchmaker/src/route/lobbies.rs
@@ -378,7 +378,7 @@ pub async fn create(
 		}
 	};
 
-	let dynamic_max_players = body.max_players.map(ApiTryInto::try_into).transpose()?;
+	let dynamic_max_players = body.max_players.map(ApiTryInto::api_try_into).transpose()?;
 
 	// Verify that lobby creation is enabled and user can create a lobby
 	util_mm::verification::verify_config(
@@ -581,10 +581,10 @@ pub async fn list(
 				region_id: region.name_id.clone(),
 				game_mode_id: lobby_group.name_id.clone(),
 				lobby_id: unwrap_ref!(lobby.lobby.lobby_id).as_uuid(),
-				max_players_normal: ApiTryInto::try_into(lobby.lobby.max_players_normal)?,
-				max_players_direct: ApiTryInto::try_into(lobby.lobby.max_players_direct)?,
-				max_players_party: ApiTryInto::try_into(lobby.lobby.max_players_party)?,
-				total_player_count: ApiTryInto::try_into(
+				max_players_normal: ApiTryInto::api_try_into(lobby.lobby.max_players_normal)?,
+				max_players_direct: ApiTryInto::api_try_into(lobby.lobby.max_players_direct)?,
+				max_players_party: ApiTryInto::api_try_into(lobby.lobby.max_players_party)?,
+				total_player_count: ApiTryInto::api_try_into(
 					lobby.player_count.registered_player_count,
 				)?,
 				state: lobby.state.map(Some),
@@ -914,7 +914,7 @@ async fn find_inner(
 				remote_address: unwrap_ref!(ctx.remote_address()).to_string(),
 				origin_host: origin_host,
 				captcha_config: Some(captcha_config.clone()),
-				client_response: Some((*captcha).try_into()?),
+				client_response: Some((*captcha).api_try_into()?),
 				namespace_id: Some(game_ns.namespace_id.into()),
 			})
 			.await?;
@@ -1023,7 +1023,7 @@ async fn find_inner(
 		bypass_verification: matches!(verification, VerificationType::Bypass),
 		tags: tags.clone(),
 		dynamic_max_players: dynamic_max_players
-			.map(ApiTryInto::try_into)
+			.map(ApiTryInto::api_try_into)
 			.transpose()?,
 		debug: None,
 	})
@@ -1264,14 +1264,14 @@ async fn dev_mock_lobby(
 						.target_port
 						.map(|port| format!("{}:{port}", ns_dev_ent.hostname)),
 					hostname: ns_dev_ent.hostname.clone(),
-					port: port.target_port.map(|x| x.try_into()).transpose()?,
+					port: port.target_port.map(|x| x.api_try_into()).transpose()?,
 					port_range: port
 						.port_range
 						.as_ref()
 						.map(|x| {
 							GlobalResult::Ok(models::MatchmakerJoinPortRange {
-								min: x.min.try_into()?,
-								max: x.max.try_into()?,
+								min: x.min.api_try_into()?,
+								max: x.max.api_try_into()?,
 							})
 						})
 						.transpose()?
@@ -1429,7 +1429,7 @@ fn build_port(
 					GlobalResult::Ok(models::MatchmakerJoinPort {
 						host: Some(format!("{}:{}", hostname, proxied_port.ingress_port)),
 						hostname: hostname.clone(),
-						port: Some(proxied_port.ingress_port.try_into()?),
+						port: Some(proxied_port.ingress_port.api_try_into()?),
 						port_range: None,
 						is_tls: matches!(
 							mm_proxy_protocol,
@@ -1454,8 +1454,8 @@ fn build_port(
 				hostname: node_public_ipv4.clone(),
 				port: None,
 				port_range: Some(Box::new(models::MatchmakerJoinPortRange {
-					min: port_range.min.try_into()?,
-					max: port_range.max.try_into()?,
+					min: port_range.min.api_try_into()?,
+					max: port_range.max.api_try_into()?,
 				})),
 				is_tls: false,
 			})

--- a/svc/api/portal/src/build.rs
+++ b/svc/api/portal/src/build.rs
@@ -57,7 +57,7 @@ pub async fn group_summaries(
 				is_current_identity_member: is_current_user_member,
 				publicity: unwrap!(backend::team::Publicity::from_i32(team_data.publicity))
 					.api_into(),
-				member_count: member_count.try_into()?,
+				member_count: member_count.api_try_into()?,
 				owner_identity_id: owner_user_id.to_string(),
 				is_developer: true,
 			})


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

The 2021 Rust edition [added TryFrom and TryInto into the Prelude](https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html). This means that when `ApiTryInto` is imported, it's ambiguous which one is being referred to. This renames it to disambiguate.
