### PR TITLE
Allow admin access to cloud endpoints, add token errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   **Bolt** Add Docker `RUN` cache to distributed deploys to improve deploy speeds
 -   **Infra** Prometheus VPA
 -   **Infra** Apache Traffic Server VPA
+-   **api-cloud** Admins can view all teams & games in a cluster
 
 ### Changed
 
 -   **api-status** More comprehensive status check that both creates a lobby & connects to it
+-   More details in `CLAIMS_MISSING_ENTITLEMENT` error
 
 ### Fixed
 
 -   **Bolt** Prompt prod won't prompt if does not have user control
 -   **Bolt** Exclude copying bloat from `infra/tf/` to distributed Docker builds
+-   Invalid JWT tokens now return explicit `TOKEN_INVALID` error instead of 500
 
 ### Security
 

--- a/errors/claims/missing-entitlement.md
+++ b/errors/claims/missing-entitlement.md
@@ -1,6 +1,6 @@
 ---
 name = "CLAIMS_MISSING_ENTITLEMENT"
-description = "Missing \"{entitlement}\" entitlement."
+description = "Token is missing one of the following entitlements: {entitlements}"
 description_basic = "A required entitlement is missing."
 http_status = 401
 ---

--- a/errors/token/invalid.md
+++ b/errors/token/invalid.md
@@ -8,3 +8,27 @@ http_status = 400
 # Token Invalid
 
 The given token could not be parsed.
+
+## Token is invalid: invalid signature
+
+The given token does not match the official Rivet signature for signing tokens. If you are using the Rivet CLI, ensure that the token you are using belongs to the same cluster that it was created from.
+
+## Token is invalid: invalid separator count
+
+The given token has an invalid amount of separators (`.`). Inspect your token to make sure it has either 2 or 3 segments separated by `.`'s. This can be caused by improperly copying and pasting the token when using it.
+
+## Token is invalid: invalid algorithm
+
+The algorithm specified in the token is not allowed by Rivet. This likely signified a breaking change with how tokens are parsed and should never show up.
+
+<!-- TODO: Move to a dedicated page for tokens -->
+
+## Token structure
+
+A token will look something like this:
+
+`label.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
+
+where every `x` is a random base64 valid character.
+
+The label has no functionality and only serves to differentiate tokens easily for the user. It and the following `.` are optional.

--- a/svc/api/cloud/src/route/auth.rs
+++ b/svc/api/cloud/src/route/auth.rs
@@ -27,10 +27,7 @@ pub async fn inspect(
 			..Default::default()
 		}
 	} else {
-		bail_with!(
-			API_UNAUTHORIZED,
-			reason = "Token is missing one of the following entitlements: user, game_cloud"
-		);
+		bail_with!(CLAIMS_MISSING_ENTITLEMENT, entitlements = "User, GameCloud");
 	};
 
 	Ok(models::CloudInspectResponse {

--- a/svc/api/cloud/src/route/devices/links.rs
+++ b/svc/api/cloud/src/route/devices/links.rs
@@ -85,7 +85,7 @@ pub async fn complete(
 
 	// Verify has access to game
 	ctx.auth()
-		.check_game_write(ctx.op_ctx(), body.game_id)
+		.check_game_write_or_admin(ctx.op_ctx(), body.game_id)
 		.await?;
 
 	// Decode device link token

--- a/svc/api/cloud/src/route/games/avatars.rs
+++ b/svc/api/cloud/src/route/games/avatars.rs
@@ -16,7 +16,9 @@ pub async fn get_custom_avatars(
 	game_id: Uuid,
 	_watch_index: WatchIndexQuery,
 ) -> GlobalResult<models::CloudGamesListGameCustomAvatarsResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let custom_avatars_res = op!([ctx] custom_user_avatar_list_for_game {
 		game_id: Some(game_id.into()),
@@ -100,7 +102,9 @@ pub async fn prepare_avatar_upload(
 	game_id: Uuid,
 	body: models::CloudGamesPrepareCustomAvatarUploadRequest,
 ) -> GlobalResult<models::CloudGamesPrepareCustomAvatarUploadResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let user_id = ctx.auth().claims()?.as_user().ok().map(|x| x.user_id);
 
@@ -154,7 +158,9 @@ pub async fn complete_avatar_upload(
 	upload_id: Uuid,
 	_body: serde_json::Value,
 ) -> GlobalResult<serde_json::Value> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	op!([ctx] custom_user_avatar_upload_complete {
 		game_id: Some(game_id.into()),

--- a/svc/api/cloud/src/route/games/builds.rs
+++ b/svc/api/cloud/src/route/games/builds.rs
@@ -12,7 +12,9 @@ pub async fn get_builds(
 	game_id: Uuid,
 	_watch_index: WatchIndexQuery,
 ) -> GlobalResult<models::CloudGamesListGameBuildsResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let list_res = op!([ctx] build_list_for_game {
 		game_id: Some(game_id.into()),
@@ -77,7 +79,9 @@ pub async fn create_build(
 	game_id: Uuid,
 	body: models::CloudGamesCreateGameBuildRequest,
 ) -> GlobalResult<models::CloudGamesCreateGameBuildResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	// TODO: Read and validate image file
 

--- a/svc/api/cloud/src/route/games/cdn.rs
+++ b/svc/api/cloud/src/route/games/cdn.rs
@@ -11,7 +11,9 @@ pub async fn get_sites(
 	game_id: Uuid,
 	_watch_index: WatchIndexQuery,
 ) -> GlobalResult<models::CloudGamesListGameCdnSitesResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let list_res = op!([ctx] cdn_site_list_for_game {
 		game_id: Some(game_id.into()),
@@ -72,7 +74,9 @@ pub async fn create_site(
 	game_id: Uuid,
 	body: models::CloudGamesCreateGameCdnSiteRequest,
 ) -> GlobalResult<models::CloudGamesCreateGameCdnSiteResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let create_res = op!([ctx] cdn_site_create {
 		game_id: Some(game_id.into()),

--- a/svc/api/cloud/src/route/games/matchmaker.rs
+++ b/svc/api/cloud/src/route/games/matchmaker.rs
@@ -17,7 +17,9 @@ pub async fn delete_lobby(
 	game_id: Uuid,
 	lobby_id: Uuid,
 ) -> GlobalResult<models::CloudGamesDeleteMatchmakerLobbyResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	// Do this before getting the lobby for race conditions
 	let mut complete_sub = subscribe!([ctx] mm::msg::lobby_cleanup_complete(lobby_id)).await?;
@@ -66,7 +68,9 @@ pub async fn export_history(
 	game_id: Uuid,
 	body: models::CloudGamesExportMatchmakerLobbyHistoryRequest,
 ) -> GlobalResult<models::CloudGamesExportMatchmakerLobbyHistoryResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let namespaces_res = op!([ctx] game_namespace_list {
 		game_ids: vec![game_id.into()],
@@ -134,7 +138,9 @@ pub async fn get_lobby_logs(
 	watch_index: WatchIndexQuery,
 	query: GetLobbyLogsQuery,
 ) -> GlobalResult<models::CloudGamesGetLobbyLogsResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	// Get start ts
 	// If no watch: read logs
@@ -258,7 +264,9 @@ pub async fn export_lobby_logs(
 	lobby_id: Uuid,
 	body: models::CloudGamesExportLobbyLogsRequest,
 ) -> GlobalResult<models::CloudGamesExportLobbyLogsResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let stream_type = match body.stream {
 		models::CloudGamesLogStream::StdOut => backend::job::log::StreamType::StdOut,

--- a/svc/api/cloud/src/route/games/mod.rs
+++ b/svc/api/cloud/src/route/games/mod.rs
@@ -337,7 +337,9 @@ pub async fn get(
 	game_id: Uuid,
 	watch_index: WatchIndexQuery,
 ) -> GlobalResult<models::CloudGamesGetGameByIdResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	// Wait for an update if needed
 	let update_ts = if let Some(anchor) = watch_index.to_consumer()? {
@@ -474,7 +476,9 @@ pub async fn prepare_logo_upload(
 	game_id: Uuid,
 	body: models::CloudGamesGameLogoUploadPrepareRequest,
 ) -> GlobalResult<models::CloudGamesGameLogoUploadPrepareResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let user_id = ctx.auth().claims()?.as_user().ok().map(|x| x.user_id);
 
@@ -525,7 +529,9 @@ pub async fn complete_logo_upload(
 	upload_id: Uuid,
 	_body: serde_json::Value,
 ) -> GlobalResult<serde_json::Value> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	op!([ctx] game_logo_upload_complete {
 		game_id: Some(game_id.into()),
@@ -542,7 +548,9 @@ pub async fn prepare_banner_upload(
 	game_id: Uuid,
 	body: models::CloudGamesGameBannerUploadPrepareRequest,
 ) -> GlobalResult<models::CloudGamesGameBannerUploadPrepareResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let user_id = ctx.auth().claims()?.as_user().ok().map(|x| x.user_id);
 
@@ -596,7 +604,9 @@ pub async fn complete_banner_upload(
 	upload_id: Uuid,
 	_body: serde_json::Value,
 ) -> GlobalResult<serde_json::Value> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	op!([ctx] game_banner_upload_complete {
 		game_id: Some(game_id.into()),

--- a/svc/api/cloud/src/route/games/namespaces/analytics.rs
+++ b/svc/api/cloud/src/route/games/namespaces/analytics.rs
@@ -14,7 +14,9 @@ pub async fn matchmaker_live(
 	namespace_id: Uuid,
 	_watch_index: WatchIndexQuery,
 ) -> GlobalResult<models::CloudGamesNamespacesGetAnalyticsMatchmakerLiveResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let game_ns = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	// Fetch lobby IDs

--- a/svc/api/cloud/src/route/games/namespaces/logs.rs
+++ b/svc/api/cloud/src/route/games/namespaces/logs.rs
@@ -35,7 +35,9 @@ pub async fn list_lobbies(
 	_watch_index: WatchIndexQuery,
 	query: ListNamespaceLobbiesQuery,
 ) -> GlobalResult<models::CloudGamesNamespacesListNamespaceLobbiesResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let _game_ns = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	// Fetch lobby list
@@ -71,7 +73,9 @@ pub async fn get_lobby(
 	lobby_id: Uuid,
 	_watch_index: WatchIndexQuery,
 ) -> GlobalResult<models::CloudGamesNamespacesGetNamespaceLobbyResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let _game_ns = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	let lobby = unwrap!(fetch_lobby_logs(&ctx, vec![lobby_id])

--- a/svc/api/cloud/src/route/games/namespaces/mod.rs
+++ b/svc/api/cloud/src/route/games/namespaces/mod.rs
@@ -19,7 +19,9 @@ pub async fn get(
 	namespace_id: Uuid,
 	_watch_index: WatchIndexQuery,
 ) -> GlobalResult<models::CloudGamesNamespacesGetGameNamespaceByIdResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let game_namespace = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	// Fetch the namespace with config
@@ -195,7 +197,9 @@ pub async fn create(
 	game_id: Uuid,
 	body: models::CloudGamesNamespacesCreateGameNamespaceRequest,
 ) -> GlobalResult<models::CloudGamesNamespacesCreateGameNamespaceResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	assert::version_for_game(&ctx, game_id, body.version_id).await?;
 
 	let create_ns_res = op!([ctx] game_namespace_create {
@@ -222,7 +226,9 @@ pub async fn update_version(
 	namespace_id: Uuid,
 	body: models::CloudGamesNamespacesUpdateGameNamespaceVersionRequest,
 ) -> GlobalResult<serde_json::Value> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let ns_data = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 	assert::version_for_game(&ctx, game_id, body.version_id).await?;
 
@@ -251,7 +257,9 @@ pub async fn create_token_public(
 	namespace_id: Uuid,
 	_body: serde_json::Value,
 ) -> GlobalResult<models::CloudGamesNamespacesCreateGameNamespaceTokenPublicResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let _ns_data = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	let create_res = op!([ctx] cloud_namespace_token_public_create {
@@ -273,7 +281,9 @@ pub async fn create_token_development(
 	namespace_id: Uuid,
 	body: models::CloudGamesNamespacesCreateGameNamespaceTokenDevelopmentRequest,
 ) -> GlobalResult<models::CloudGamesNamespacesCreateGameNamespaceTokenDevelopmentResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let _ns_data = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	let lobby_ports = match (body.ports, body.lobby_ports) {
@@ -379,7 +389,9 @@ pub async fn add_namespace_domain(
 	namespace_id: Uuid,
 	body: models::CloudGamesNamespacesAddNamespaceDomainRequest,
 ) -> GlobalResult<serde_json::Value> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let _ns_data = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	op!([ctx] cdn_namespace_domain_create {
@@ -398,7 +410,9 @@ pub async fn remove_namespace_domain(
 	namespace_id: Uuid,
 	domain: String,
 ) -> GlobalResult<serde_json::Value> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let _ns_data = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	op!([ctx] cdn_namespace_domain_remove {
@@ -417,7 +431,9 @@ pub async fn toggle_domain_public_auth(
 	namespace_id: Uuid,
 	body: models::CloudGamesNamespacesToggleNamespaceDomainPublicAuthRequest,
 ) -> GlobalResult<serde_json::Value> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let ns_data = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	op!([ctx] cdn_ns_enable_domain_public_auth_set {
@@ -436,7 +452,9 @@ pub async fn update_namespace_cdn_auth_user(
 	namespace_id: Uuid,
 	body: models::CloudGamesNamespacesUpdateNamespaceCdnAuthUserRequest,
 ) -> GlobalResult<serde_json::Value> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let _ns_data = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	op!([ctx] cdn_namespace_auth_user_update {
@@ -456,7 +474,9 @@ pub async fn remove_namespace_cdn_auth_user(
 	namespace_id: Uuid,
 	auth_user: String,
 ) -> GlobalResult<serde_json::Value> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let _ns_data = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	op!([ctx] cdn_namespace_auth_user_remove {
@@ -475,7 +495,9 @@ pub async fn set_cdn_auth_type(
 	namespace_id: Uuid,
 	body: models::CloudGamesNamespacesSetNamespaceCdnAuthTypeRequest,
 ) -> GlobalResult<serde_json::Value> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let ns_data = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	op!([ctx] cdn_ns_auth_type_set {
@@ -537,7 +559,9 @@ pub async fn get_version_history(
 	_watch_index: WatchIndexQuery,
 	query: GetGameNamespaceGetVersionHistoryQuery,
 ) -> GlobalResult<models::CloudGamesNamespacesGetGameNamespaceVersionHistoryResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let _ns_data = assert::namespace_for_game(&ctx, game_id, namespace_id).await?;
 
 	let version_history_res = op!([ctx] game_namespace_version_history_list {

--- a/svc/api/cloud/src/route/games/tokens.rs
+++ b/svc/api/cloud/src/route/games/tokens.rs
@@ -10,7 +10,9 @@ pub async fn create_cloud_token(
 	game_id: Uuid,
 	_body: serde_json::Value,
 ) -> GlobalResult<models::CloudGamesCreateCloudTokenResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let token_res = op!([ctx] cloud_game_token_create {
 		game_id: Some(game_id.into()),

--- a/svc/api/cloud/src/route/games/versions.rs
+++ b/svc/api/cloud/src/route/games/versions.rs
@@ -14,7 +14,9 @@ pub async fn get(
 	version_id: Uuid,
 	_watch_index: WatchIndexQuery,
 ) -> GlobalResult<models::CloudGamesGetGameVersionByIdResponse> {
-	ctx.auth().check_game_read(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_read_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 	let game_version = assert::version_for_game(&ctx, game_id, version_id).await?;
 
 	let cloud_version_res = op!([ctx] cloud_version_get {
@@ -48,7 +50,9 @@ pub async fn create(
 	game_id: Uuid,
 	body: models::CloudGamesCreateGameVersionRequest,
 ) -> GlobalResult<models::CloudGamesCreateGameVersionResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let user_id = ctx.auth().claims()?.as_user().ok();
 
@@ -72,7 +76,9 @@ pub async fn reserve_name(
 	game_id: Uuid,
 	body: serde_json::Value,
 ) -> GlobalResult<models::CloudGamesReserveVersionNameResponse> {
-	ctx.auth().check_game_write(ctx.op_ctx(), game_id).await?;
+	ctx.auth()
+		.check_game_write_or_admin(ctx.op_ctx(), game_id)
+		.await?;
 
 	let request_id = uuid::Uuid::new_v4();
 	let res = msg!([ctx] cloud::msg::version_name_reserve(game_id, request_id) -> cloud::msg::version_name_reserve_complete {

--- a/svc/api/group/src/auth.rs
+++ b/svc/api/group/src/auth.rs
@@ -83,8 +83,8 @@ impl Auth {
 			Ok(())
 		} else {
 			bail_with!(
-				API_UNAUTHORIZED,
-				reason = "token is missing one of the following entitlements: user"
+				CLAIMS_MISSING_ENTITLEMENT,
+				entitlements = "User"
 			);
 		}
 	}

--- a/svc/api/identity/src/auth.rs
+++ b/svc/api/identity/src/auth.rs
@@ -96,7 +96,7 @@ impl Auth {
 		// Return default error
 		bail_with!(
 			CLAIMS_MISSING_ENTITLEMENT,
-			entitlement = "GameNamespacePublic"
+			entitlements = "GameNamespacePublic"
 		)
 	}
 
@@ -223,8 +223,8 @@ impl Auth {
 			))
 		} else {
 			bail_with!(
-				API_UNAUTHORIZED,
-				reason = "Token is missing one of the following entitlements: user, game_user"
+				CLAIMS_MISSING_ENTITLEMENT,
+				entitlements = "User, GameUser"
 			);
 		}
 	}

--- a/svc/api/kv/src/auth.rs
+++ b/svc/api/kv/src/auth.rs
@@ -133,11 +133,11 @@ impl Auth {
 			*unwrap_ref!(game_user.namespace_id)
 		} else {
 			bail_with!(
-				API_UNAUTHORIZED,
-				reason = if allow_users {
-					"token is missing one of the following entitlements: user, lobby"
+				CLAIMS_MISSING_ENTITLEMENT,
+				entitlements = if allow_users {
+					"User, Lobby"
 				} else {
-					"token is missing one of the following entitlements: lobby"
+					"Lobby"
 				}
 			);
 		};
@@ -164,8 +164,8 @@ impl Auth {
 			(None, Some(ent))
 		} else {
 			bail_with!(
-				API_UNAUTHORIZED,
-				reason = "token is missing one of the following entitlements: user, game_cloud"
+				CLAIMS_MISSING_ENTITLEMENT,
+				entitlements = "User, GameCloud"
 			);
 		};
 

--- a/svc/api/matchmaker/src/auth.rs
+++ b/svc/api/matchmaker/src/auth.rs
@@ -89,7 +89,7 @@ impl Auth {
 		// Return default error
 		bail_with!(
 			CLAIMS_MISSING_ENTITLEMENT,
-			entitlement = "GameNamespacePublic"
+			entitlements = "GameNamespacePublic"
 		)
 	}
 


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->
**MERGE WITH** https://app.graphite.dev/github/pr/rivet-gg/rivet-ee/25/Allow-admin-access-to-cloud-endpoints

Fixes RVT-3604
Fixes RVT-3603
## Changes
- Allow admin users to access all dashboard pages
- Improved errors for invalid tokens
<!-- If there are frontend changes, please include screenshots. -->
