### PR TITLE
Fix cargo deny manifest path

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -19,8 +19,8 @@ jobs:
       - name: cargo deny (svc)
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          arguments: --manifest-path svc/Cargo.toml
+          manifest-path: svc/Cargo.toml
       - name: cargo deny (lib/bolt)
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          arguments: --manifest-path lib/bolt/Cargo.toml
+          manifest-path: lib/bolt/Cargo.toml


### PR DESCRIPTION
The cargo-deny-action made a breaking change that caused our arugments flag to have a duplicate `--manifest-path` arg
