### PR TITLE
fix: only select primary hostname in mm endpoints

### DIFF
--- a/svc/api/matchmaker/src/route/lobbies.rs
+++ b/svc/api/matchmaker/src/route/lobbies.rs
@@ -1422,7 +1422,9 @@ fn build_port(
 				.filter_map(|(proxied_port, _)| {
 					proxied_port
 						.ingress_hostnames
-						.first()
+						.iter()
+						// NOTE: Selects the primary ingress hostname (has no path segments)
+						.find(|hostname| !hostname.contains('/'))
 						.map(|hostname| (proxied_port, hostname))
 				})
 				.map(|(proxied_port, hostname)| {


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->
Fixes RVT-3691
## Changes

<!-- If there are frontend changes, please include screenshots. -->
