### PR TITLE
chore: update devcontainer docker base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/base:bullseye
+FROM mcr.microsoft.com/devcontainers/base:bookworm
 
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Since nix uses a newer version of glibc, this matches it more closely (so proc macros don't have trouble generating)