### PR TITLE
chore: change devcontainer user off root

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"context": "."
 	},
-	"remoteUser": "root",
+	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,


### PR DESCRIPTION
This might cause some issues with existing files created with vscode (say when using the GUI Git to do certain things). But it's better that it's off root, since most of the time the host won't be root.