### PR TITLE
fix(job-run): fix leaking jobs with wrong param order

### DIFF
--- a/svc/pkg/job-run/worker/src/workers/nomad_monitor_eval_update.rs
+++ b/svc/pkg/job-run/worker/src/workers/nomad_monitor_eval_update.rs
@@ -137,8 +137,8 @@ async fn worker(
 			match nomad_client_new::apis::jobs_api::delete_job(
 				&NEW_NOMAD_CONFIG,
 				job_id,
-				None,
 				Some(&region.nomad_region),
+				None,
 				None,
 				None,
 				Some(false),

--- a/svc/pkg/job-run/worker/src/workers/stop.rs
+++ b/svc/pkg/job-run/worker/src/workers/stop.rs
@@ -74,8 +74,8 @@ async fn worker(ctx: &OperationContext<job_run::msg::stop::Message>) -> GlobalRe
 		match nomad_client_new::apis::jobs_api::delete_job(
 			&NEW_NOMAD_CONFIG,
 			dispatched_job_id,
-			None,
 			Some(&region.nomad_region),
+			None,
 			None,
 			None,
 			Some(false), // TODO: Maybe change back to true for performance?


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
