### PR TITLE
fix(mm): require specifying matchmaker config for new game versions

### DIFF
--- a/svc/pkg/game/ops/version-validate/src/lib.rs
+++ b/svc/pkg/game/ops/version-validate/src/lib.rs
@@ -1148,6 +1148,8 @@ async fn handle(
 				}
 			}
 		}
+	} else {
+		errors.push(util::err_path!["config", "matchmaker", "missing",]);
 	}
 
 	// KV config validation


### PR DESCRIPTION
This fixes both:

- accidental `rivet deploy` with unconfigured rivet.yaml (which submits an empty object)
- we don't handle unconfigured matchmaker correctly
