### PR TITLE
feat(workflows): add tags

### DIFF
--- a/lib/chirp-workflow/core/src/ctx/test.rs
+++ b/lib/chirp-workflow/core/src/ctx/test.rs
@@ -90,7 +90,33 @@ impl TestCtx {
 			.map_err(GlobalError::raw)?;
 
 		self.db
-			.dispatch_workflow(self.ray_id, id, &name, input_val)
+			.dispatch_workflow(self.ray_id, id, &name, None, input_val)
+			.await
+			.map_err(GlobalError::raw)?;
+
+		tracing::info!(%name, ?id, "workflow dispatched");
+
+		Ok(id)
+	}
+
+	pub async fn dispatch_tagged_workflow<I>(&self, tags: &serde_json::Value, input: I) -> GlobalResult<Uuid>
+	where
+		I: WorkflowInput,
+		<I as WorkflowInput>::Workflow: Workflow<Input = I>,
+	{
+		let name = I::Workflow::NAME;
+
+		tracing::debug!(%name, ?tags, ?input, "dispatching tagged workflow");
+
+		let id = Uuid::new_v4();
+
+		// Serialize input
+		let input_val = serde_json::to_value(input)
+			.map_err(WorkflowError::SerializeWorkflowOutput)
+			.map_err(GlobalError::raw)?;
+
+		self.db
+			.dispatch_workflow(self.ray_id, id, &name, Some(tags), input_val)
 			.await
 			.map_err(GlobalError::raw)?;
 
@@ -137,6 +163,20 @@ impl TestCtx {
 		Ok(output)
 	}
 
+	pub async fn tagged_workflow<I>(
+		&self,
+		tags: &serde_json::Value,
+		input: I,
+	) -> GlobalResult<<<I as WorkflowInput>::Workflow as Workflow>::Output>
+	where
+		I: WorkflowInput,
+		<I as WorkflowInput>::Workflow: Workflow<Input = I>,
+	{
+		let workflow_id = self.dispatch_tagged_workflow(tags, input).await?;
+		let output = self.wait_for_workflow::<I::Workflow>(workflow_id).await?;
+		Ok(output)
+	}
+
 	pub async fn signal<T: Signal + Serialize>(
 		&self,
 		workflow_id: Uuid,
@@ -153,6 +193,28 @@ impl TestCtx {
 
 		self.db
 			.publish_signal(self.ray_id, workflow_id, signal_id, T::NAME, input_val)
+			.await
+			.map_err(GlobalError::raw)?;
+
+		Ok(signal_id)
+	}
+
+	pub async fn tagged_signal<T: Signal + Serialize>(
+		&self,
+		tags: &serde_json::Value,
+		input: T,
+	) -> GlobalResult<Uuid> {
+		tracing::debug!(name=%T::NAME, ?tags, "dispatching tagged signal");
+
+		let signal_id = Uuid::new_v4();
+
+		// Serialize input
+		let input_val = serde_json::to_value(input)
+			.map_err(WorkflowError::SerializeSignalBody)
+			.map_err(GlobalError::raw)?;
+
+		self.db
+			.publish_tagged_signal(self.ray_id, tags, signal_id, T::NAME, input_val)
 			.await
 			.map_err(GlobalError::raw)?;
 

--- a/lib/chirp-workflow/core/src/db/mod.rs
+++ b/lib/chirp-workflow/core/src/db/mod.rs
@@ -16,6 +16,7 @@ pub trait Database: Send {
 		ray_id: Uuid,
 		workflow_id: Uuid,
 		workflow_name: &str,
+		tags: Option<&serde_json::Value>,
 		input: serde_json::Value,
 	) -> WorkflowResult<()>;
 	async fn get_workflow(&self, id: Uuid) -> WorkflowResult<Option<WorkflowRow>>;
@@ -60,6 +61,14 @@ pub trait Database: Send {
 		signal_name: &str,
 		body: serde_json::Value,
 	) -> WorkflowResult<()>;
+	async fn publish_tagged_signal(
+		&self,
+		ray_id: Uuid,
+		tags: &serde_json::Value,
+		signal_id: Uuid,
+		signal_name: &str,
+		body: serde_json::Value,
+	) -> WorkflowResult<()>;
 	async fn pull_next_signal(
 		&self,
 		workflow_id: Uuid,
@@ -74,6 +83,7 @@ pub trait Database: Send {
 		location: &[usize],
 		sub_workflow_id: Uuid,
 		sub_workflow_name: &str,
+		tags: Option<&serde_json::Value>,
 		input: serde_json::Value,
 	) -> WorkflowResult<()>;
 

--- a/lib/chirp-workflow/core/src/error.rs
+++ b/lib/chirp-workflow/core/src/error.rs
@@ -42,6 +42,12 @@ pub enum WorkflowError {
 	#[error("deserialize workflow input: {0}")]
 	DeserializeWorkflowOutput(serde_json::Error),
 
+	#[error("serialize workflow tags: {0}")]
+	SerializeWorkflowTags(serde_json::Error),
+
+	#[error("deserialize workflow tags: {0}")]
+	DeserializeWorkflowTags(serde_json::Error),
+
 	#[error("serialize activity input: {0}")]
 	SerializeActivityInput(serde_json::Error),
 

--- a/lib/chirp-workflow/core/src/prelude.rs
+++ b/lib/chirp-workflow/core/src/prelude.rs
@@ -15,6 +15,7 @@ pub mod util {
 
 pub use crate::{
 	activity::Activity,
+	signal::{Listen, Signal},
 	ctx::*,
 	db,
 	error::{WorkflowError, WorkflowResult},

--- a/lib/chirp-workflow/core/src/signal.rs
+++ b/lib/chirp-workflow/core/src/signal.rs
@@ -53,7 +53,7 @@ macro_rules! join_signal {
 		impl Listen for $join {
 			async fn listen(ctx: &mut chirp_workflow::prelude::WorkflowCtx) -> chirp_workflow::prelude::WorkflowResult<Self> {
 				let row = ctx.listen_any(&[$($signals::NAME),*]).await?;
-				Self::parse(&row.name, row.body)
+				Self::parse(&row.signal_name, row.body)
 			}
 
 			fn parse(name: &str, body: serde_json::Value) -> chirp_workflow::prelude::WorkflowResult<Self> {

--- a/lib/chirp-workflow/core/src/worker.rs
+++ b/lib/chirp-workflow/core/src/worker.rs
@@ -84,7 +84,7 @@ impl Worker {
 						util::sleep_until_ts(wake_deadline_ts).await;
 					}
 
-					ctx.run_workflow().await;
+					ctx.run().await;
 				}
 				.in_current_span(),
 			);

--- a/lib/chirp-workflow/macros/src/lib.rs
+++ b/lib/chirp-workflow/macros/src/lib.rs
@@ -282,11 +282,11 @@ pub fn signal(attr: TokenStream, item: TokenStream) -> TokenStream {
 			const NAME: &'static str = #name;
 		}
 
-		#[::async_trait::async_trait]
+		#[async_trait::async_trait]
 		impl Listen for #struct_ident {
 			async fn listen(ctx: &mut chirp_workflow::prelude::WorkflowCtx) -> chirp_workflow::prelude::WorkflowResult<Self> {
 				let row = ctx.listen_any(&[Self::NAME]).await?;
-				Self::parse(&row.name, &row.body)
+				Self::parse(&row.signal_name, row.body)
 			}
 
 			fn parse(_name: &str, body: serde_json::Value) -> chirp_workflow::prelude::WorkflowResult<Self> {

--- a/svc/pkg/foo/worker/src/workflows/test.rs
+++ b/svc/pkg/foo/worker/src/workflows/test.rs
@@ -1,26 +1,28 @@
 use chirp_workflow::prelude::*;
+use serde_json::json;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TestInput {
 	pub x: i64,
 }
 
-type TestOutput = Result<TestOutputOk, TestOutputErr>;
-
 #[derive(Debug, Serialize, Deserialize)]
-pub struct TestOutputOk {
-	pub y: usize,
-}
-#[derive(Debug, Serialize, Deserialize)]
-pub struct TestOutputErr {
-	pub z: usize,
+pub struct TestOutput {
+	pub y: i64,
 }
 
 #[workflow(Test)]
 pub async fn test(ctx: &mut WorkflowCtx, input: &TestInput) -> GlobalResult<TestOutput> {
-	let a = ctx.activity(FooInput {}).await?;
+	ctx.activity(FooInput {}).await?;
 
-	Ok(Ok(TestOutputOk { y: a.ids.len() }))
+	let sig = ctx.listen::<FooBarSignal>().await?;
+
+	Ok(TestOutput { y: input.x + sig.x })
+}
+
+#[signal("foo-bar")]
+pub struct FooBarSignal {
+	pub x: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Hash)]

--- a/svc/pkg/foo/worker/tests/test.rs
+++ b/svc/pkg/foo/worker/tests/test.rs
@@ -1,9 +1,25 @@
 use chirp_workflow::prelude::*;
+use serde_json::json;
 
 #[workflow_test]
 async fn empty(ctx: TestCtx) {
+	let tags = json!({
+		"amog": "us",
+	});
+
+	let id = ctx
+		.dispatch_tagged_workflow(&tags, foo_worker::workflows::test::TestInput { x: -2 })
+		.await
+		.unwrap();
+
+	tokio::time::sleep(std::time::Duration::from_secs(12)).await;
+
+	ctx.tagged_signal(&tags, foo_worker::workflows::test::FooBarSignal { x: 400 })
+		.await
+		.unwrap();
+
 	let res = ctx
-		.workflow(foo_worker::workflows::test::TestInput { x: 12 })
+		.wait_for_workflow::<foo_worker::workflows::test::Test>(id)
 		.await
 		.unwrap();
 

--- a/svc/pkg/workflow/db/workflow/migrations/20240626202744_add_tags.up.sql
+++ b/svc/pkg/workflow/db/workflow/migrations/20240626202744_add_tags.up.sql
@@ -1,0 +1,26 @@
+-- Add tags
+ALTER TABLE workflows
+ADD COLUMN tags JSONB;
+
+CREATE INDEX gin_workflows_tags
+ON workflows
+USING GIN (tags);
+
+
+-- Stores pending signals with tags
+CREATE TABLE tagged_signals (
+  signal_id UUID PRIMARY KEY,
+  tags JSONB NOT NULL,
+  signal_name TEXT NOT NULL,
+
+  create_ts INT NOT NULL,
+  ray_id UUID NOT NULL,
+
+  body JSONB NOT NULL,
+
+  INDEX (signal_name)
+);
+
+CREATE INDEX gin_tagged_signals_tags
+ON tagged_signals
+USING GIN (tags);


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->
## TLDR

- Tags are a json blob attached to workflows
- Tags are optional
- When publishing a signal with tags, it will be consumed by any workflow with a superset of the signals own tags:
    - a workflow with tags `{ "foo": 1, "bar": ["a"] }` will consume a signal with tags `{ "bar": ["a"] }`
- While any json is allowed, i assume CRDB JSON comparison queries perform better when its plain string comparison

## Changes

<!-- If there are frontend changes, please include screenshots. -->
