### PR TITLE
Get rid of require() call in sdks/typescript/ ... /Fetcher.ts

### DIFF
--- a/sdks/full/typescript/src/core/fetcher/Fetcher.ts
+++ b/sdks/full/typescript/src/core/fetcher/Fetcher.ts
@@ -73,15 +73,13 @@ async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIResponse
         body = JSON.stringify(args.body);
     }
 
-    const fetchFn = typeof fetch == "function" ? fetch : require("node-fetch");
-
     const makeRequest = async (): Promise<Response> => {
         const controller = new AbortController();
         let abortId = undefined;
         if (args.timeoutMs != null) {
             abortId = setTimeout(() => controller.abort(), args.timeoutMs);
         }
-        const response = await fetchFn(url, {
+        const response = await fetch(url, {
             method: args.method,
             headers,
             body,

--- a/sdks/runtime/typescript/src/core/fetcher/Fetcher.ts
+++ b/sdks/runtime/typescript/src/core/fetcher/Fetcher.ts
@@ -73,15 +73,15 @@ async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIResponse
         body = JSON.stringify(args.body);
     }
 
-    const fetchFn = typeof fetch == "function" ? fetch : require("node-fetch");
-
     const makeRequest = async (): Promise<Response> => {
         const controller = new AbortController();
         let abortId = undefined;
         if (args.timeoutMs != null) {
             abortId = setTimeout(() => controller.abort(), args.timeoutMs);
         }
-        const response = await fetchFn(url, {
+
+		// We assume here that the environment is providing fetch functionality
+        const response = await fetch(url, {
             method: args.method,
             headers,
             body,


### PR DESCRIPTION
Regarding #982 

## Changes

Get rid of support for environments that don't provide `fetch`; this means the SDK will not install / import `node-fetch` or other fetch polyfills ourselves. 

Given the fact Node (along with most other) JS runtimes provide fetch api by default, this should have little to no impact (?). Users with abnormal js environments should probably have to install fetch by themselves and not through the rivet lib
