### PR TITLE
fix(clusters): fix trafficserver run dir permissions on reboot

### DIFF
--- a/svc/pkg/cluster/worker/src/workers/server_install/install_scripts/files/traffic_server_configure.sh
+++ b/svc/pkg/cluster/worker/src/workers/server_install/install_scripts/files/traffic_server_configure.sh
@@ -9,9 +9,13 @@ mkdir -p /etc/trafficserver /var/cache/trafficserver /run/trafficserver /var/log
 # Write config
 __CONFIG__
 
-# NOTE: the /run directory is often mounted as a tmpfs and thus will not retain its permissions after a reboot.
 # Change owner
 chown -R trafficserver:trafficserver /etc/trafficserver /var/cache/trafficserver /run/trafficserver /var/log/trafficserver
+
+# The /run directory is often mounted as a tmpfs and does not retain permissions after reboot. This fixes that
+cat << EOF > /etc/tmpfiles.d/trafficserver.conf
+d /run/trafficserver 0755 trafficserver trafficserver
+EOF
 
 cat << EOF > /etc/systemd/system/trafficserver.service
 [Unit]


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->
Fixes RVT-3718
## Changes

<!-- If there are frontend changes, please include screenshots. -->
