### PR TITLE
fix: incorrect use of `Metrics` in `rivet.health` config

### DIFF
--- a/packages/common/config/src/config/rivet.rs
+++ b/packages/common/config/src/config/rivet.rs
@@ -74,7 +74,7 @@ pub struct Rivet {
 
 	/// Configuration for the health check service.
 	#[serde(default)]
-	pub health: Metrics,
+	pub health: Health,
 
 	/// Configuration for the tunnel service.
 	#[serde(default)]
@@ -136,7 +136,7 @@ impl Default for Rivet {
 			api: Api::default(),
 			api_internal: ApiInternal::default(),
 			metrics: Metrics::default(),
-			health: Metrics::default(),
+			health: Health::default(),
 			telemetry: Telemetry::default(),
 			cdn: None,
 			dns: None,


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
