### PR TITLE
feat: use new onboarding flow when linking a device

### DIFF
--- a/frontend/apps/hub/package.json
+++ b/frontend/apps/hub/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
-		"build": "tsc && vite build --mode=production --base=/",
+		"build": "vite build --mode=production --base=/",
 		"preview": "vite preview"
 	},
 	"dependencies": {

--- a/frontend/apps/hub/src/components/onboarding/onboarding.tsx
+++ b/frontend/apps/hub/src/components/onboarding/onboarding.tsx
@@ -1,0 +1,57 @@
+import type { Rivet } from "@rivet-gg/api";
+import { H1, Lead, Page } from "@rivet-gg/components";
+import { LayoutGroup, motion } from "framer-motion";
+import { Intro } from "../intro";
+import { OnboardingBackground } from "../onboarding-background";
+
+interface OnboardingProps {
+	initialProjectName?: string;
+	initialStep?: number;
+	onFinish?: (project: Rivet.game.GameSummary) => Promise<void> | void;
+}
+
+export function Onboarding({
+	initialProjectName,
+	initialStep,
+	onFinish,
+}: OnboardingProps) {
+	return (
+		<>
+			<OnboardingBackground />
+			<Page className="relative h-full flex flex-col items-center justify-center">
+				<div className="">
+					<H1 asChild className="text-center mb-2">
+						<motion.h1
+							initial={{ opacity: 0 }}
+							animate={{ opacity: 1 }}
+						>
+							Get Started
+						</motion.h1>
+					</H1>
+					<Lead asChild className="mx-auto text-center max-w-md mb-8">
+						<motion.p
+							initial={{ opacity: 0 }}
+							animate={{ opacity: 1, transition: { delay: 0.1 } }}
+						>
+							Your system to build robust, fast, and scalable
+							applications on the edge.
+						</motion.p>
+					</Lead>
+
+					<motion.div
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1, transition: { delay: 0.5 } }}
+					>
+						<LayoutGroup>
+							<Intro
+								onFinish={onFinish}
+								initialProjectName={initialProjectName}
+								initialStep={initialStep}
+							/>
+						</LayoutGroup>
+					</motion.div>
+				</div>
+			</Page>
+		</>
+	);
+}

--- a/frontend/apps/hub/src/domains/project/components/billing/billing-plans.tsx
+++ b/frontend/apps/hub/src/domains/project/components/billing/billing-plans.tsx
@@ -27,7 +27,7 @@ import { BillingPlanStatus } from "./billing-plan-status";
 interface BillingPlansProps {
 	projectId: string;
 	showHeader?: boolean;
-	onChoosePlan?: () => void;
+	onChoosePlan?: () => Promise<void> | void;
 	config?: Partial<
 		Record<RivetEe.ee.billing.Plan, Partial<BillingPlanCardProps>>
 	>;

--- a/frontend/apps/hub/src/routes/_authenticated/_layout/index.tsx
+++ b/frontend/apps/hub/src/routes/_authenticated/_layout/index.tsx
@@ -1,51 +1,26 @@
-import { Intro } from "@/components/intro";
-import { OnboardingBackground } from "@/components/onboarding-background";
+import { Onboarding } from "@/components/onboarding/onboarding";
 import { guardOssNewbie } from "@/lib/guards";
-import { H1, Lead, Page } from "@rivet-gg/components";
 import { createFileRoute } from "@tanstack/react-router";
 import { zodSearchValidator } from "@tanstack/router-zod-adapter";
-import { LayoutGroup, motion } from "framer-motion";
 import { z } from "zod";
 
 function IndexRoute() {
+	const navigate = Route.useNavigate();
 	const { initialStep, project_name: projectName } = Route.useSearch();
 	return (
-		<>
-			<OnboardingBackground />
-			<Page className="relative h-full flex flex-col items-center justify-center">
-				<div className="">
-					<H1 asChild className="text-center mb-2">
-						<motion.h1
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1 }}
-						>
-							Get Started
-						</motion.h1>
-					</H1>
-					<Lead asChild className="mx-auto text-center max-w-md mb-8">
-						<motion.p
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1, transition: { delay: 0.1 } }}
-						>
-							Your system to build robust, fast, and scalable
-							applications on the edge.
-						</motion.p>
-					</Lead>
-
-					<motion.div
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1, transition: { delay: 0.5 } }}
-					>
-						<LayoutGroup>
-							<Intro
-								initialProjectName={projectName}
-								initialStep={initialStep}
-							/>
-						</LayoutGroup>
-					</motion.div>
-				</div>
-			</Page>
-		</>
+		<Onboarding
+			initialStep={initialStep}
+			initialProjectName={projectName}
+			onFinish={(project) => {
+				return navigate({
+					to: "/projects/$projectNameId/environments/$environmentNameId",
+					params: {
+						projectNameId: project.nameId,
+						environmentNameId: "prod",
+					},
+				});
+			}}
+		/>
 	);
 }
 


### PR DESCRIPTION
Closes FRONT-572

## Changes

- Created a reusable `Onboarding` component to standardize the onboarding flow
- Added `onFinish` callback to handle post-onboarding navigation
- Enhanced device linking flow to support new user onboarding
- Improved project selection by auto-selecting when only one project exists
- Added support for conditional onboarding display based on user status

The changes streamline the onboarding experience and make it more flexible for different entry points in the application.