### PR TITLE
feat(hub): actors and builds filters

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,9 +23,13 @@
 			"sdks/api/**",
 			"*.lock",
 			"resources/**",
-			"packages/**",
 			"site/framer/**",
-			"**/out/**"
+			"**/out/**",
+			"packages/infra/**",
+			"packages/common/**",
+			"packages/api/**",
+			"packages/services/**",
+			"packages/toolchain/**"
 		],
 		"ignoreUnknown": true
 	},

--- a/frontend/apps/hub/src/domains/project/components/actors/actors-filters-sheet.tsx
+++ b/frontend/apps/hub/src/domains/project/components/actors/actors-filters-sheet.tsx
@@ -1,0 +1,90 @@
+import * as ActorsFiltersForm from "@/domains/project/forms/actors-filters-form";
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+	Skeleton,
+} from "@rivet-gg/components";
+import { type ReactNode, Suspense } from "react";
+
+interface ActorsFiltersSheetProps {
+	title: string;
+	children?: ReactNode;
+	projectId: string;
+	environmentId: string;
+	onFiltersSubmitted: (values: ActorsFiltersForm.FormValues) => void;
+	tags: Record<string, string>;
+	showDestroyed: boolean;
+}
+
+export function ActorsFiltersSheet({
+	title,
+	children,
+	projectId,
+	environmentId,
+	tags,
+	showDestroyed,
+	onFiltersSubmitted,
+}: ActorsFiltersSheetProps) {
+	return (
+		<Sheet>
+			<SheetTrigger asChild>{children}</SheetTrigger>
+			<SheetContent>
+				<SheetHeader>
+					<SheetTitle>{title}</SheetTitle>
+					<SheetDescription>
+						Filter actors by tags and status.
+					</SheetDescription>
+					<div className="flex gap-4 flex-col">
+						<Suspense
+							fallback={
+								<>
+									<Skeleton className="w-full h-8" />
+									<Skeleton className="w-full h-8" />
+									<Skeleton className="w-full h-8" />
+									<Skeleton className="w-full h-8" />
+								</>
+							}
+						>
+							<ActorsFiltersForm.Form
+								onSubmit={onFiltersSubmitted}
+								defaultValues={{
+									tags: {},
+									showDestroyed: false,
+								}}
+								values={{ tags, showDestroyed }}
+							>
+								<ActorsFiltersForm.Tags
+									projectId={projectId}
+									environmentId={environmentId}
+								/>
+								<ActorsFiltersForm.ShowDestroyed />
+								<div className="flex gap-2 mt-4 items-center justify-end">
+									<ActorsFiltersForm.Submit disablePristine>
+										Apply
+									</ActorsFiltersForm.Submit>
+
+									<ActorsFiltersForm.Reset
+										variant="outline"
+										type="button"
+										onClick={() => {
+											onFiltersSubmitted({
+												tags: {},
+												showDestroyed: false,
+											});
+										}}
+									>
+										Reset
+									</ActorsFiltersForm.Reset>
+								</div>
+							</ActorsFiltersForm.Form>
+						</Suspense>
+					</div>
+				</SheetHeader>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/frontend/apps/hub/src/domains/project/components/actors/actors-list-panel.tsx
+++ b/frontend/apps/hub/src/domains/project/components/actors/actors-list-panel.tsx
@@ -17,16 +17,25 @@ interface ActorsListPanelProps {
 	projectNameId: string;
 	environmentNameId: string;
 	actorId: string | undefined;
+	tags: Record<string, string>;
+	showDestroyed: boolean;
 }
 
 export function ActorsListPanel({
 	actorId,
 	projectNameId,
 	environmentNameId,
+	tags,
+	showDestroyed,
 }: ActorsListPanelProps) {
 	const { data, hasNextPage, isFetchingNextPage, fetchNextPage } =
 		useSuspenseInfiniteQuery(
-			projectActorsQueryOptions({ projectNameId, environmentNameId }),
+			projectActorsQueryOptions({
+				projectNameId,
+				environmentNameId,
+				includeDestroyed: showDestroyed,
+				tags,
+			}),
 		);
 	return (
 		<ScrollArea className="overflow-auto h-full truncate min-w-0">

--- a/frontend/apps/hub/src/domains/project/components/actors/actors-list-preview.tsx
+++ b/frontend/apps/hub/src/domains/project/components/actors/actors-list-preview.tsx
@@ -12,12 +12,16 @@ interface ActorsListPreview {
 	projectNameId: string;
 	environmentNameId: string;
 	actorId?: string;
+	tags: Record<string, string>;
+	showDestroyed: boolean;
 }
 
 export function ActorsListPreview({
 	projectNameId,
 	environmentNameId,
 	actorId,
+	tags,
+	showDestroyed,
 }: ActorsListPreview) {
 	const isMd = useBreakpoint("md");
 
@@ -33,6 +37,8 @@ export function ActorsListPreview({
 						projectNameId={projectNameId}
 						environmentNameId={environmentNameId}
 						actorId={actorId}
+						tags={tags}
+						showDestroyed={showDestroyed}
 					/>
 				</div>
 			</ResizablePanel>

--- a/frontend/apps/hub/src/domains/project/components/tags-select.tsx
+++ b/frontend/apps/hub/src/domains/project/components/tags-select.tsx
@@ -8,6 +8,7 @@ interface TagsSelectProps {
 	environmentId: string;
 	value: Record<string, string>;
 	onValueChange: (value: Record<string, string>) => void;
+	showSelectedOptions?: number;
 }
 
 export function TagsSelect({
@@ -15,6 +16,7 @@ export function TagsSelect({
 	environmentId,
 	value,
 	onValueChange,
+	showSelectedOptions,
 }: TagsSelectProps) {
 	const { data } = useSuspenseQuery(
 		actorBuildTagsQueryOptions({ projectId, environmentId }),
@@ -60,7 +62,12 @@ export function TagsSelect({
 			options={tags}
 			value={val}
 			onValueChange={handleValueChange}
-			className="w-full"
+			showSelectedOptions={showSelectedOptions}
+			filter={(option, search) =>
+				option.tag.key.includes(search) ||
+				option.tag.value.includes(search)
+			}
+			className="w-full min-w-[20rem]"
 		/>
 	);
 }

--- a/frontend/apps/hub/src/domains/project/forms/actors-filters-form.tsx
+++ b/frontend/apps/hub/src/domains/project/forms/actors-filters-form.tsx
@@ -1,0 +1,83 @@
+import {
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+	createSchemaForm,
+} from "@rivet-gg/components";
+import { Switch } from "@rivet-gg/components";
+import { type UseFormReturn, useFormContext } from "react-hook-form";
+import z from "zod";
+import { TagsSelect } from "../components/tags-select";
+
+const allowedTypes = ["image/png", "image/jpeg"];
+
+export const formSchema = z.object({
+	tags: z.record(z.string()),
+	showDestroyed: z.boolean().default(false),
+});
+
+export type FormValues = z.infer<typeof formSchema>;
+export type SubmitHandler = (
+	values: FormValues,
+	form: UseFormReturn<FormValues>,
+) => Promise<void>;
+
+const { Form, Submit, Reset } = createSchemaForm(formSchema);
+export { Form, Submit, Reset };
+
+export const Tags = ({
+	projectId,
+	environmentId,
+}: { projectId: string; environmentId: string }) => {
+	const { control } = useFormContext<FormValues>();
+	return (
+		<FormField
+			control={control}
+			name="tags"
+			render={({ field }) => (
+				<FormItem>
+					<FormLabel>Tags</FormLabel>
+					<FormControl>
+						<TagsSelect
+							value={field.value}
+							projectId={projectId}
+							environmentId={environmentId}
+							onValueChange={field.onChange}
+							showSelectedOptions={1}
+						/>
+					</FormControl>
+					<FormMessage />
+				</FormItem>
+			)}
+		/>
+	);
+};
+
+export function ShowDestroyed() {
+	const { control } = useFormContext<FormValues>();
+	return (
+		<FormField
+			control={control}
+			name="showDestroyed"
+			render={({ field }) => (
+				<FormItem className="space-y-0">
+					<div className="flex justify-between items-center">
+						<FormLabel>Show destroyed?</FormLabel>
+						<FormControl>
+							<Switch
+								className="mt-0"
+								{...field}
+								checked={field.value}
+								onCheckedChange={field.onChange}
+								value="show-destroyed"
+							/>
+						</FormControl>
+					</div>
+					<FormMessage />
+				</FormItem>
+			)}
+		/>
+	);
+}

--- a/frontend/apps/hub/src/domains/project/queries/actors/query-options.ts
+++ b/frontend/apps/hub/src/domains/project/queries/actors/query-options.ts
@@ -12,7 +12,14 @@ import {
 export const projectActorsQueryOptions = ({
 	projectNameId,
 	environmentNameId,
-}: { projectNameId: string; environmentNameId: string }) => {
+	includeDestroyed,
+	tags,
+}: {
+	projectNameId: string;
+	environmentNameId: string;
+	includeDestroyed?: boolean;
+	tags?: Record<string, string>;
+}) => {
 	return infiniteQueryOptions({
 		queryKey: [
 			"project",
@@ -20,20 +27,22 @@ export const projectActorsQueryOptions = ({
 			"environment",
 			environmentNameId,
 			"actors",
-		],
+			{ includeDestroyed, tags },
+		] as const,
 		refetchInterval: 5000,
 		initialPageParam: "",
 		queryFn: ({
 			signal: abortSignal,
 			pageParam,
-			queryKey: [_, project, __, environment],
+			queryKey: [, project, , environment, , { includeDestroyed, tags }],
 		}) =>
 			rivetClient.actor.list(
 				{
 					project,
 					environment,
-					includeDestroyed: true,
+					includeDestroyed,
 					cursor: pageParam ? pageParam : undefined,
+					tagsJson: JSON.stringify(tags),
 				},
 				{ abortSignal },
 			),

--- a/frontend/apps/hub/src/routes/_authenticated/_layout/projects/$projectNameId/environments/$environmentNameId/actors.tsx
+++ b/frontend/apps/hub/src/routes/_authenticated/_layout/projects/$projectNameId/environments/$environmentNameId/actors.tsx
@@ -1,4 +1,5 @@
 import { GetStarted } from "@/components/get-started";
+import { ActorsFiltersSheet } from "@/domains/project/components/actors/actors-filters-sheet";
 import { ActorsListPreview } from "@/domains/project/components/actors/actors-list-preview";
 import * as Layout from "@/domains/project/layouts/servers-layout";
 import { projectActorsQueryOptions } from "@/domains/project/queries";
@@ -9,9 +10,10 @@ import {
 	CardHeader,
 	CardTitle,
 	Flex,
+	Ping,
 	WithTooltip,
 } from "@rivet-gg/components";
-import { Icon, faActors, faRefresh } from "@rivet-gg/icons";
+import { Icon, faActors, faFilter, faRefresh } from "@rivet-gg/icons";
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { zodSearchValidator } from "@tanstack/router-zod-adapter";
@@ -19,15 +21,22 @@ import { z } from "zod";
 
 function ProjectActorsRoute() {
 	const {
-		environment: { nameId: environmentNameId },
-		project: { nameId: projectNameId },
+		environment: { nameId: environmentNameId, namespaceId: environmentId },
+		project: { nameId: projectNameId, gameId: projectId },
 	} = Route.useRouteContext();
+	const { actorId, tags, showDestroyed } = Route.useSearch();
+	const tagsRecord = Object.fromEntries(tags || []);
 	const { data, refetch, isRefetching } = useSuspenseInfiniteQuery(
-		projectActorsQueryOptions({ projectNameId, environmentNameId }),
+		projectActorsQueryOptions({
+			projectNameId,
+			environmentNameId,
+			tags: tagsRecord,
+			includeDestroyed: showDestroyed,
+		}),
 	);
-	const { actorId } = Route.useSearch();
+	const navigate = Route.useNavigate();
 
-	if (data.length === 0) {
+	if (data.length === 0 && !tags && showDestroyed === undefined) {
 		return (
 			<div className="w-full h-full flex flex-col justify-center">
 				<div className="flex flex-col justify-center my-8">
@@ -56,6 +65,52 @@ function ProjectActorsRoute() {
 					Actors
 					<Flex gap="2">
 						<WithTooltip
+							content="Filters"
+							trigger={
+								<ActorsFiltersSheet
+									title="Filters"
+									projectId={projectId}
+									environmentId={environmentId}
+									tags={tagsRecord}
+									showDestroyed={showDestroyed || false}
+									onFiltersSubmitted={(values) => {
+										return navigate({
+											search: {
+												showDestroyed:
+													values.showDestroyed,
+												tags: Object.entries(
+													values.tags,
+												).map(
+													([key, value]) =>
+														[key, value] as [
+															string,
+															string,
+														],
+												),
+											},
+										});
+									}}
+								>
+									<Button
+										size="icon"
+										isLoading={isRefetching}
+										variant="outline"
+									>
+										<div className="relative">
+											{(tags?.length || 0) > 0 &&
+											showDestroyed !== undefined ? (
+												<Ping
+													variant="primary"
+													className="bottom-0 -right-2 top-auto"
+												/>
+											) : null}
+											<Icon icon={faFilter} />
+										</div>
+									</Button>
+								</ActorsFiltersSheet>
+							}
+						/>
+						<WithTooltip
 							content="Refresh"
 							trigger={
 								<Button
@@ -76,6 +131,8 @@ function ProjectActorsRoute() {
 					projectNameId={projectNameId}
 					environmentNameId={environmentNameId}
 					actorId={actorId}
+					tags={tagsRecord}
+					showDestroyed={showDestroyed || false}
 				/>
 			</CardContent>
 		</Card>
@@ -85,6 +142,9 @@ function ProjectActorsRoute() {
 const searchSchema = z.object({
 	actorId: z.string().optional(),
 	tab: z.string().optional(),
+
+	tags: z.array(z.tuple([z.string(), z.string()])).optional(),
+	showDestroyed: z.boolean().optional(),
 });
 
 export const Route = createFileRoute(

--- a/frontend/packages/components/package.json
+++ b/frontend/packages/components/package.json
@@ -3,11 +3,7 @@
 	"private": true,
 	"version": "1.0.0",
 	"type": "module",
-	"files": [
-		"dist",
-		"src",
-		"public"
-	],
+	"files": ["dist", "src", "public"],
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",
 	"sideEffects": false,

--- a/frontend/packages/components/src/code.tsx
+++ b/frontend/packages/components/src/code.tsx
@@ -2,7 +2,6 @@ import { javascript } from "@codemirror/lang-javascript";
 import { json, jsonParseLinter } from "@codemirror/lang-json";
 import { linter } from "@codemirror/lint";
 import { EditorView } from "@codemirror/view";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import { Icon, faCopy, faFile } from "@rivet-gg/icons";
 import { githubDark } from "@uiw/codemirror-theme-github";
 import ReactCodeMirror, {
@@ -15,6 +14,7 @@ import { cn } from "./lib/utils";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { ScrollArea } from "./ui/scroll-area";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import { WithTooltip } from "./ui/tooltip";
 
 interface JsonCodeProps extends ReactCodeMirrorProps {}

--- a/frontend/packages/components/src/lib/create-schema-form.tsx
+++ b/frontend/packages/components/src/lib/create-schema-form.tsx
@@ -18,6 +18,7 @@ interface FormProps<FormValues extends FieldValues>
 	extends Omit<ComponentProps<"form">, "onSubmit"> {
 	onSubmit: SubmitHandler<FormValues>;
 	defaultValues: DefaultValues<FormValues>;
+	values?: FormValues;
 	children: ReactNode;
 }
 
@@ -32,6 +33,7 @@ export const createSchemaForm = <Schema extends z.ZodSchema>(
 	return {
 		Form: ({
 			defaultValues,
+			values,
 			children,
 			onSubmit,
 			...props
@@ -40,6 +42,7 @@ export const createSchemaForm = <Schema extends z.ZodSchema>(
 				reValidateMode: "onSubmit",
 				resolver: zodResolver(schema),
 				defaultValues,
+				values,
 			});
 
 			return (
@@ -74,13 +77,15 @@ export const createSchemaForm = <Schema extends z.ZodSchema>(
 			);
 		},
 		Reset: (props: ButtonProps) => {
-			const { defaultValues, isDirty } = useFormState<z.TypeOf<Schema>>();
+			const { defaultValues } = useFormState<z.TypeOf<Schema>>();
 			const { reset } = useFormContext<z.TypeOf<Schema>>();
 			return (
 				<Button
 					type="button"
-					disabled={!isDirty}
-					onClick={() => reset(defaultValues)}
+					onClick={(e) => {
+						reset(defaultValues);
+						props.onClick?.(e);
+					}}
 					{...props}
 				/>
 			);

--- a/frontend/packages/components/src/ping.tsx
+++ b/frontend/packages/components/src/ping.tsx
@@ -14,11 +14,12 @@ const pingVariants = {
 
 interface PingProps {
 	variant?: Variant;
+	className?: string;
 }
 
-export const Ping = ({ variant = "primary" }: PingProps) => {
+export const Ping = ({ variant = "primary", className }: PingProps) => {
 	return (
-		<span className="flex size-2 absolute top-0 -right-3">
+		<span className={cn("flex size-2 absolute top-0 -right-3", className)}>
 			<span
 				className={cn(
 					"animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",

--- a/frontend/packages/icons/package.json
+++ b/frontend/packages/icons/package.json
@@ -2,12 +2,7 @@
 	"name": "@rivet-gg/icons",
 	"version": "1.0.0",
 	"sideEffects": false,
-	"files": [
-		"scripts",
-		"manifest.json",
-		"src",
-		"dist"
-	],
+	"files": ["scripts", "manifest.json", "src", "dist"],
 	"scripts": {
 		"postinstall": "node scripts/postinstall.js"
 	},


### PR DESCRIPTION
Closes FRONT-474

## Changes

- Added filtering capabilities to the actors list, allowing users to filter by tags and show/hide destroyed actors
- Enhanced the `TagsSelect` component to support better search functionality and display of selected options
- Added a new `ActorsFiltersSheet` component for managing actor filters
- Updated the builds page to support tag filtering
- Improved the Combobox component to handle multiple selections and show selected option counts
- Added visual indicators when filters are active

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/dOgs2Fo4NFCWV1dxDXM1/585cb609-058e-4c8a-ac73-54877b528129.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/dOgs2Fo4NFCWV1dxDXM1/585cb609-058e-4c8a-ac73-54877b528129.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/dOgs2Fo4NFCWV1dxDXM1/585cb609-058e-4c8a-ac73-54877b528129.mov">Untitled.mov</video>

