### PR TITLE
feat(hub): add separate protocol for actor inspect

### DIFF
--- a/frontend/apps/hub/src/domains/project/components/actors/actors-actor-details.tsx
+++ b/frontend/apps/hub/src/domains/project/components/actors/actors-actor-details.tsx
@@ -41,7 +41,11 @@ export function ActorsActorDetails({
 	const { data } = useSuspenseQuery(actorQueryOptions(props));
 	return (
 		<ActorDetailsSettingsProvider>
-			<ActorWorkerContextProvider enabled={!data.destroyedAt} {...props}>
+			<ActorWorkerContextProvider
+				enabled={!data.destroyedAt}
+				endpoint={data.endpoint}
+				{...props}
+			>
 				<div className="flex flex-col h-full flex-1 pt-2">
 					<Tabs
 						value={tab || "logs"}

--- a/frontend/apps/hub/src/domains/project/components/actors/worker/actor-worker-container.ts
+++ b/frontend/apps/hub/src/domains/project/components/actors/worker/actor-worker-container.ts
@@ -1,7 +1,4 @@
-import {
-	actorManagerUrlQueryOptions,
-	actorQueryOptions,
-} from "@/domains/project/queries";
+import { actorQueryOptions } from "@/domains/project/queries";
 import { queryClient } from "@/queries/global";
 import ActorWorker from "./actor-repl.worker?worker";
 import {
@@ -66,11 +63,13 @@ export class ActorWorkerContainer {
 		projectNameId,
 		environmentNameId,
 		actorId,
+		endpoint,
 		signal,
 	}: {
 		projectNameId: string;
 		environmentNameId: string;
 		actorId: string;
+		endpoint: string;
 		signal: AbortSignal;
 	}) {
 		this.terminate();
@@ -79,16 +78,6 @@ export class ActorWorkerContainer {
 		this.#state.status = { type: "pending" };
 		this.#update();
 		try {
-			// To check if the actor is supported, first we need to get the actor manager URL
-			// if there's no manager URL, we can't support the actor
-			const managerUrl = await queryClient.fetchQuery(
-				actorManagerUrlQueryOptions({
-					projectNameId,
-					environmentNameId,
-				}),
-			);
-			signal.throwIfAborted();
-
 			// If we have the manager URL, next we need to check actor's runtime
 			const { actor } = await queryClient.fetchQuery(
 				actorQueryOptions({
@@ -118,7 +107,7 @@ export class ActorWorkerContainer {
 			const worker = new ActorWorker({ name: `actor-${actorId}` });
 			signal.throwIfAborted();
 			// now worker needs to check if the actor is supported
-			this.#setupWorker(worker, { actorId, managerUrl });
+			this.#setupWorker(worker, { actorId, endpoint });
 			signal.throwIfAborted();
 			return worker;
 		} catch (e) {

--- a/frontend/apps/hub/src/domains/project/components/actors/worker/actor-worker-context.tsx
+++ b/frontend/apps/hub/src/domains/project/components/actors/worker/actor-worker-context.tsx
@@ -24,6 +24,7 @@ interface ActorWorkerContextProviderProps {
 	actorId: string;
 	projectNameId: string;
 	environmentNameId: string;
+	endpoint?: string;
 	enabled?: boolean;
 	children: ReactNode;
 }
@@ -32,6 +33,7 @@ export const ActorWorkerContextProvider = ({
 	children,
 	actorId,
 	enabled,
+	endpoint,
 	projectNameId,
 	environmentNameId,
 }: ActorWorkerContextProviderProps) => {
@@ -43,11 +45,12 @@ export const ActorWorkerContextProvider = ({
 	useEffect(() => {
 		const ctrl = new AbortController();
 
-		if (enabled) {
+		if (enabled && endpoint) {
 			container.init({
 				projectNameId,
 				environmentNameId,
 				actorId,
+				endpoint,
 				signal: ctrl.signal,
 			});
 		}
@@ -56,7 +59,7 @@ export const ActorWorkerContextProvider = ({
 			ctrl.abort();
 			container.terminate();
 		};
-	}, [actorId, projectNameId, environmentNameId, enabled]);
+	}, [actorId, projectNameId, environmentNameId, endpoint, enabled]);
 
 	return (
 		<ActorWorkerContext.Provider value={container}>

--- a/frontend/apps/hub/src/domains/project/components/actors/worker/actor-worker-schema.ts
+++ b/frontend/apps/hub/src/domains/project/components/actors/worker/actor-worker-schema.ts
@@ -14,7 +14,7 @@ const CodeMessageSchema = z.object({
 });
 const InitMessageSchema = z.object({
 	type: z.literal("init"),
-	managerUrl: z.string(),
+	endpoint: z.string(),
 	actorId: z.string(),
 });
 

--- a/frontend/apps/hub/src/domains/project/queries/actors/query-options.ts
+++ b/frontend/apps/hub/src/domains/project/queries/actors/query-options.ts
@@ -151,6 +151,7 @@ export const actorQueryOptions = ({
 					(arg) => arg !== "",
 				),
 			},
+			endpoint: createActorEndpoint(data.actor.network),
 		}),
 	});
 };
@@ -442,7 +443,9 @@ export const actorRegionQueryOptions = ({
 	});
 };
 
-const createActorEndpoint = (network: Rivet.actor.Network) => {
+const createActorEndpoint = (
+	network: Rivet.actor.Network,
+): string | undefined => {
 	const http = Object.values(network.ports).find(
 		(port) => port.protocol === "http" || port.protocol === "https",
 	);

--- a/frontend/packages/components/src/ui/button.tsx
+++ b/frontend/packages/components/src/ui/button.tsx
@@ -75,6 +75,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 	) => {
 		const C = asChild ? Slot : "button";
 
+		const isIcon = size?.includes("icon");
+
 		return (
 			<C
 				className={cn(
@@ -93,9 +95,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 				) : startIcon ? (
 					React.cloneElement(startIcon, startIcon.props)
 				) : null}
-				{!size?.includes("icon") && isLoading ? null : (
-					<Slottable>{children}</Slottable>
-				)}
+				{isIcon && isLoading ? null : <Slottable>{children}</Slottable>}
 				{endIcon ? React.cloneElement(endIcon, endIcon.props) : null}
 			</C>
 		);

--- a/sdks/actor/runtime/src/connection.ts
+++ b/sdks/actor/runtime/src/connection.ts
@@ -4,6 +4,7 @@ import * as cbor from "cbor-x";
 import type { WSContext } from "hono/ws";
 import type { AnyActor, ExtractActorConnState } from "./actor";
 import * as errors from "./errors";
+import { INSPECT_SYMBOL } from "./inspect";
 import { logger } from "./log";
 import { assertUnreachable } from "./utils";
 
@@ -196,7 +197,7 @@ export class Connection<A extends AnyActor> {
 	 * Inspects the connection for debugging purposes.
 	 * @internal
 	 */
-	public _inspect() {
+	[INSPECT_SYMBOL]() {
 		return {
 			id: this.id.toString(),
 			subscriptions: [...this.subscriptions.values()],

--- a/sdks/actor/runtime/src/errors.ts
+++ b/sdks/actor/runtime/src/errors.ts
@@ -150,6 +150,12 @@ export class StateTooLarge extends ActorError {
 	}
 }
 
+export class Unsupported extends ActorError {
+	constructor(feature: string) {
+		super("unsupported", `Unsupported feature: ${feature}`);
+	}
+}
+
 /**
  * Options for the UserError class.
  */

--- a/sdks/actor/runtime/src/event.ts
+++ b/sdks/actor/runtime/src/event.ts
@@ -1,0 +1,177 @@
+import type * as wsToClient from "@rivet-gg/actor-protocol/ws/to_client";
+import * as wsToServer from "@rivet-gg/actor-protocol/ws/to_server";
+import type { WSMessageReceive } from "hono/ws";
+import type { AnyActor } from "./actor";
+import type { Connection, IncomingWebSocketMessage } from "./connection";
+import * as errors from "./errors";
+import { Rpc } from "./rpc";
+import { assertUnreachable } from "./utils";
+
+interface MessageEventConfig {
+	protocol: { maxIncomingMessageSize: number };
+}
+
+export async function validateMessageEvent<A extends AnyActor>(
+	evt: MessageEvent<WSMessageReceive>,
+	connection: Connection<A>,
+	config: MessageEventConfig,
+) {
+	const value = evt.data.valueOf() as IncomingWebSocketMessage;
+
+	// Validate value length
+	let length: number;
+	if (typeof value === "string") {
+		length = value.length;
+	} else if (value instanceof Blob) {
+		length = value.size;
+	} else if (
+		value instanceof ArrayBuffer ||
+		value instanceof SharedArrayBuffer
+	) {
+		length = value.byteLength;
+	} else {
+		assertUnreachable(value);
+	}
+	if (length > config.protocol.maxIncomingMessageSize) {
+		throw new errors.MessageTooLong();
+	}
+
+	// Parse & validate message
+	const {
+		data: message,
+		success,
+		error,
+	} = wsToServer.ToServerSchema.safeParse(await connection._parse(value));
+
+	if (!success) {
+		throw new errors.MalformedMessage(error);
+	}
+
+	return message;
+}
+
+export async function handleMessageEvent<A extends AnyActor>(
+	event: MessageEvent<WSMessageReceive>,
+	conn: Connection<A>,
+	config: MessageEventConfig,
+	handlers: {
+		onExecuteRpc?: (
+			ctx: Rpc<A>,
+			name: string,
+			args: unknown[],
+		) => Promise<unknown>;
+		onSubscribe?: (eventName: string, conn: Connection<A>) => Promise<void>;
+		onUnsubscribe?: (
+			eventName: string,
+			conn: Connection<A>,
+		) => Promise<void>;
+		onError: (error: {
+			code: string;
+			message: string;
+			metadata: unknown;
+			rpcRequestId?: number;
+			internal: boolean;
+		}) => void;
+	},
+) {
+	let rpcRequestId: number | undefined;
+	const message = await validateMessageEvent(event, conn, config);
+
+	try {
+		if ("rr" in message.body) {
+			// RPC request
+
+			if (handlers.onExecuteRpc === undefined) {
+				throw new errors.Unsupported("RPC");
+			}
+
+			const { i: id, n: name, a: args = [] } = message.body.rr;
+
+			rpcRequestId = id;
+
+			const ctx = new Rpc<A>(conn);
+			const output = await handlers.onExecuteRpc(ctx, name, args);
+
+			conn._sendWebSocketMessage(
+				conn._serialize({
+					body: {
+						ro: {
+							i: id,
+							o: output,
+						},
+					},
+				} satisfies wsToClient.ToClient),
+			);
+		} else if ("sr" in message.body) {
+			// Subscription request
+
+			if (
+				handlers.onSubscribe === undefined ||
+				handlers.onUnsubscribe === undefined
+			) {
+				throw new errors.Unsupported("Subscriptions");
+			}
+
+			const { e: eventName, s: subscribe } = message.body.sr;
+
+			if (subscribe) {
+				await handlers.onSubscribe(eventName, conn);
+			} else {
+				await handlers.onUnsubscribe(eventName, conn);
+			}
+		} else {
+			assertUnreachable(message.body);
+		}
+	} catch (error) {
+		// Build response error information. Only return errors if flagged as public in order to prevent leaking internal behavior.
+		let code: string;
+		let message: string;
+		let metadata: unknown = undefined;
+		let internal = false;
+		if (error instanceof errors.ActorError && error.public) {
+			code = error.code;
+			message = String(error);
+			metadata = error.metadata;
+		} else {
+			code = errors.INTERNAL_ERROR_CODE;
+			message = errors.INTERNAL_ERROR_DESCRIPTION;
+			internal = true;
+		}
+
+		// Build response
+		if (rpcRequestId !== undefined) {
+			conn._sendWebSocketMessage(
+				conn._serialize({
+					body: {
+						re: {
+							i: rpcRequestId,
+							c: code,
+							m: message,
+							md: metadata,
+						},
+					},
+				} satisfies wsToClient.ToClient),
+			);
+		} else {
+			conn._sendWebSocketMessage(
+				conn._serialize({
+					body: {
+						er: {
+							c: code,
+							m: message,
+							md: metadata,
+						},
+					},
+				} satisfies wsToClient.ToClient),
+			);
+		}
+
+		handlers.onError({
+			code,
+			message,
+			metadata,
+			rpcRequestId,
+			internal,
+		});
+	}
+}

--- a/sdks/actor/runtime/src/inspect.ts
+++ b/sdks/actor/runtime/src/inspect.ts
@@ -1,0 +1,197 @@
+import { safeStringify } from "@rivet-gg/actor-common/utils";
+import type * as wsToClient from "@rivet-gg/actor-protocol/ws/to_client";
+import type { Context } from "hono";
+import type { WSEvents } from "hono/ws";
+import type { AnyActor, ExtractActorState } from "./actor";
+import { type ActorConfig, mergeActorConfig } from "./config";
+import { Connection } from "./connection";
+import * as errors from "./errors";
+import { handleMessageEvent } from "./event";
+import { inspectLogger } from "./log";
+import type { Rpc } from "./rpc";
+import { throttle } from "./utils";
+
+/**
+ * Internal symbol used to mark a property as an inspection method.
+ * @internal
+ */
+export const INSPECT_SYMBOL = Symbol("inspect");
+
+export type ConnectionId = number;
+
+type SkipFirst<T extends unknown[]> = T extends [infer _, ...infer Rest]
+	? Rest
+	: never;
+
+function connectionMap<A extends AnyActor>() {
+	let id: ConnectionId = 0;
+	const map = new Map<ConnectionId, Connection<A>>();
+	return {
+		create: (
+			...params: SkipFirst<ConstructorParameters<typeof Connection<A>>>
+		) => {
+			const conId = id++;
+			const connection = new Connection<A>(conId, ...params);
+			map.set(conId, connection);
+			return connection;
+		},
+		delete: (conId: ConnectionId) => {
+			map.delete(conId);
+		},
+		get: (conId: ConnectionId) => {
+			return map.get(conId);
+		},
+		[Symbol.iterator]: () => map.values(),
+		get size() {
+			return map.size;
+		},
+	};
+}
+
+interface InspectionAccessProxy<A extends AnyActor> {
+	connections: () => Iterable<Connection<A>>;
+	state: () => { enabled: boolean; state: unknown };
+	rpcs: () => string[];
+	setState: (state: ExtractActorState<A>) => Promise<void> | void;
+	onRpcCall: (ctx: Rpc<A>, rpc: string, args: unknown[]) => void;
+}
+
+/**
+ * Thin compatibility layer for handling inspection access to an actor.
+ * @internal
+ */
+export class ActorInspection<A extends AnyActor> {
+	readonly #connections = connectionMap<A>();
+	readonly #proxy: InspectionAccessProxy<A>;
+
+	readonly #config: ActorConfig;
+
+	readonly #logger = inspectLogger();
+
+	constructor(config: ActorConfig, proxy: InspectionAccessProxy<A>) {
+		this.#config = mergeActorConfig(config);
+		this.#proxy = proxy;
+	}
+
+	readonly notifyStateChanged = throttle(async () => {
+		const inspectionResult = this.inspect();
+		this.#broadcast("_state-changed", inspectionResult.state);
+	}, 500);
+
+	readonly notifyConnectionsChanged = throttle(async () => {
+		const inspectionResult = this.inspect();
+		this.#broadcast("_connections-changed", inspectionResult.connections);
+	}, 500);
+
+	handleWebsocketConnection(c: Context): WSEvents<WebSocket> {
+		// TODO: Compare hub version with protocol version
+		const protocolVersion = c.req.query("version");
+		if (protocolVersion !== "1") {
+			this.#logger.warn("invalid protocol version", {
+				protocolVersion,
+			});
+			throw new errors.InvalidProtocolVersion(protocolVersion);
+		}
+
+		let connection: Connection<A> | undefined;
+		return {
+			onOpen: (evt, ws) => {
+				connection = this.#connections.create(
+					ws,
+					"cbor",
+					undefined,
+					false,
+				);
+			},
+			onMessage: async (evt, ws) => {
+				if (!connection) {
+					this.#logger.warn("`connection` does not exist");
+					return;
+				}
+
+				await handleMessageEvent(evt, connection, this.#config, {
+					onExecuteRpc: async (ctx, name, args) => {
+						return await this.#executeRpc(ctx, name, args);
+					},
+					onSubscribe: async () => {
+						// we do not support granular subscriptions
+					},
+					onUnsubscribe: async () => {
+						// we do not support granular subscriptions
+					},
+					onError: (error) => {
+						this.#logger.warn("connection error", {
+							rpc: error.rpcRequestId,
+							error,
+						});
+					},
+				});
+			},
+			onClose: () => {
+				if (!connection) {
+					this.#logger.warn("`connection` does not exist");
+					return;
+				}
+
+				this.#connections.delete(connection.id);
+			},
+			onError: (error) => {
+				this.#logger.warn("inspect websocket error", { error });
+			},
+		};
+	}
+
+	#broadcast(event: string, ...args: unknown[]) {
+		if (this.#connections.size === 0) {
+			return;
+		}
+
+		for (const connection of this.#connections) {
+			connection.send(event, ...args);
+		}
+	}
+
+	/**
+	 * Safely transforms the actor state into a string for debugging purposes.
+	 */
+	#inspectState(): string {
+		try {
+			return safeStringify(this.#proxy.state().state, 128 * 1024 * 1024);
+		} catch (error) {
+			return JSON.stringify({ _error: new errors.StateTooLarge() });
+		}
+	}
+
+	/**
+	 * Public RPC method that inspects the actor's state and connections.
+	 * @internal
+	 * @returns The actor's state and connections.
+	 */
+	inspect(): wsToClient.InspectRpcResponse {
+		return {
+			// Filter out internal 'inspect' RPC
+			rpcs: this.#proxy.rpcs(),
+			state: {
+				enabled: this.#proxy.state().enabled,
+				native: this.#proxy.state().enabled ? this.#inspectState() : "",
+			},
+			connections: [...this.#proxy.connections()].map((connection) =>
+				connection[INSPECT_SYMBOL](),
+			),
+		};
+	}
+
+	async #executeRpc(ctx: Rpc<A>, name: string, args: unknown[]) {
+		if (name === "inspect") {
+			return this.inspect();
+		}
+
+		if (name === "setState") {
+			const state = args[0] as Record<string, unknown>;
+			await this.#proxy.setState(state as ExtractActorState<A>);
+			return;
+		}
+
+		return this.#proxy.onRpcCall(ctx, name, args);
+	}
+}

--- a/sdks/actor/runtime/src/log.ts
+++ b/sdks/actor/runtime/src/log.ts
@@ -6,10 +6,21 @@ export const RUNTIME_LOGGER_NAME = "actor-runtime";
 /** Logger used for logs from the actor instance itself. */
 export const ACTOR_LOGGER_NAME = "actor";
 
+/** Logger used for logs from the actor inspector. */
+export const INSPECT_LOGGER_NAME = "actor-inspect";
+
 export function logger() {
 	return getLogger(RUNTIME_LOGGER_NAME);
 }
 
 export function instanceLogger() {
 	return getLogger(ACTOR_LOGGER_NAME);
+}
+
+/**
+ * Get the logger for the actor inspector.
+ * @internal
+ */
+export function inspectLogger() {
+	return getLogger(INSPECT_LOGGER_NAME);
 }


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

Closes ACTR-32

## Discussion points
- [ ] Current implementation vs. an additional layer of abstraction  `Actor > { ActorUser, ActorInspect )`

<!-- If there are frontend changes, please include screenshots. -->
