### PR TITLE
fix: force amd64 platform for FDB tests

### DIFF
--- a/packages/common/chirp-workflow/core/tests/common.rs
+++ b/packages/common/chirp-workflow/core/tests/common.rs
@@ -69,6 +69,7 @@ pub async fn start_fdb() {
 	let status = Command::new("docker")
 		.arg("run")
 		.arg("--rm")
+		.arg("--platform=linux/amd64")
 		.arg("-p")
 		.arg("4500:4500")
 		.arg("--name")


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
