### PR TITLE
fix(pegboard): continue exporting metrics even if fetching actor fails

### DIFF
--- a/packages/edge/api/actor/src/assert.rs
+++ b/packages/edge/api/actor/src/assert.rs
@@ -16,6 +16,7 @@ pub async fn actor_for_env(
 		.op(pegboard::ops::actor::get::Input {
 			actor_ids: vec![actor_id],
 			endpoint_type,
+			allow_errors: false,
 		})
 		.await?;
 	let actor = unwrap_with!(actors_res.actors.into_iter().next(), ACTOR_NOT_FOUND);

--- a/packages/edge/api/actor/src/route/actors.rs
+++ b/packages/edge/api/actor/src/route/actors.rs
@@ -56,6 +56,7 @@ async fn get_inner(
 		.op(pegboard::ops::actor::get::Input {
 			actor_ids: vec![actor_id],
 			endpoint_type: query.endpoint_type.map(ApiInto::api_into),
+			allow_errors: false,
 		})
 		.await?;
 	let actor = unwrap_with!(actors_res.actors.first(), ACTOR_NOT_FOUND);
@@ -255,6 +256,7 @@ pub async fn create(
 		.op(pegboard::ops::actor::get::Input {
 			actor_ids: vec![actor_id],
 			endpoint_type: query.endpoint_type.map(ApiInto::api_into),
+			allow_errors: false,
 		})
 		.await?;
 	let actor = unwrap_with!(actors_res.actors.first(), ACTOR_NOT_FOUND);
@@ -584,6 +586,7 @@ async fn list_actors_inner(
 				.global_endpoint_type
 				.endpoint_type
 				.map(ApiInto::api_into),
+			allow_errors: false,
 		})
 		.await?;
 	actors_res.actors.sort_by_key(|x| -x.create_ts);

--- a/packages/edge/services/pegboard/standalone/usage-metrics-publish/src/lib.rs
+++ b/packages/edge/services/pegboard/standalone/usage-metrics-publish/src/lib.rs
@@ -75,6 +75,7 @@ pub async fn run_from_env(
 		.op(pegboard::ops::actor::get::Input {
 			actor_ids,
 			endpoint_type: None,
+			allow_errors: true,
 		})
 		.await?;
 


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
