### PR TITLE
feat(cli): support passing env name to `rivet env select <name>`

### DIFF
--- a/packages/toolchain/cli/src/commands/environment/select.rs
+++ b/packages/toolchain/cli/src/commands/environment/select.rs
@@ -3,12 +3,15 @@ use clap::Parser;
 
 /// Select the default environment to use
 #[derive(Parser)]
-pub struct Opts {}
+pub struct Opts {
+	/// Environment name to select (will prompt if not specified)
+	environment: Option<String>,
+}
 
 impl Opts {
 	pub async fn execute(&self) -> Result<()> {
 		let ctx = crate::util::login::load_or_login().await?;
-		crate::util::env::select(&ctx, true).await?;
+		crate::util::env::select(&ctx, true, self.environment.as_deref()).await?;
 		Ok(())
 	}
 }


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
