### PR TITLE
refactor(hub): hide rivetkit related tabs from ui

### DIFF
--- a/frontend/apps/hub/src/routes/_authenticated/_layout/projects/$projectNameId/environments/$environmentNameId._v2/actors.tsx
+++ b/frontend/apps/hub/src/routes/_authenticated/_layout/projects/$projectNameId/environments/$environmentNameId._v2/actors.tsx
@@ -37,9 +37,9 @@ function Actor() {
 				features={[
 					ActorFeature.Config,
 					ActorFeature.Logs,
-					ActorFeature.State,
-					ActorFeature.Metrics,
-					ActorFeature.Connections,
+					// ActorFeature.State,
+					// ActorFeature.Metrics,
+					// ActorFeature.Connections,
 				]}
 			/>
 		);
@@ -100,8 +100,8 @@ function Content() {
 						features={[
 							ActorFeature.Config,
 							ActorFeature.Logs,
-							ActorFeature.State,
-							ActorFeature.Connections,
+							// ActorFeature.State,
+							// ActorFeature.Connections,
 						]}
 					/>
 				)}

--- a/frontend/packages/components/src/actors/actor-context.tsx
+++ b/frontend/packages/components/src/actors/actor-context.tsx
@@ -388,8 +388,8 @@ const commonActorFeatures = [
 	ActorFeature.Logs,
 	ActorFeature.Config,
 	ActorFeature.Runtime,
-	ActorFeature.Metrics,
-	ActorFeature.InspectReconnectNotification,
+	// ActorFeature.Metrics,
+	// ActorFeature.InspectReconnectNotification,
 ];
 
 export const currentActorFeaturesAtom = atom((get) => {
@@ -409,13 +409,13 @@ export const currentActorFeaturesAtom = atom((get) => {
 			}
 			return [
 				...commonActorFeatures,
-				ActorFeature.Connections,
-				ActorFeature.State,
-				ActorFeature.Console,
-				ActorFeature.InspectReconnectNotification,
+				// ActorFeature.Connections,
+				// ActorFeature.State,
+				// ActorFeature.Console,
+				// ActorFeature.InspectReconnectNotification,
 			];
 		}
-		return commonActorFeatures;
+		return [...commonActorFeatures, ActorFeature.Metrics];
 	}
 
 	return actor.features;

--- a/frontend/packages/components/src/actors/actor-network.tsx
+++ b/frontend/packages/components/src/actors/actor-network.tsx
@@ -84,7 +84,9 @@ export function ActorNetwork({ actor }: ActorNetworkProps) {
 													className="max-w-full min-w-0"
 													value={port.hostname || ""}
 												>
-													{port.hostname}
+													<span className=" min-w-0 truncate flex-1">
+														{port.hostname}
+													</span>
 												</DiscreteCopyButton>
 											</Dd>
 											{port.url ? (


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

Closes FRONT-694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Several actor-related features have been temporarily disabled in various components, resulting in a more streamlined interface for actor details and notifications.
  * Adjusted layout of hostnames in the actor network view to improve text truncation and display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->