### PR TITLE
feat: add skip_upgrade flag for actor deployments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10727,7 +10727,6 @@ dependencies = [
  "reqwest 0.12.12",
  "rivet-logs",
  "rivet-util",
- "scc",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -13478,15 +13477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13574,12 +13564,6 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "sealed"

--- a/packages/toolchain/cli/src/commands/actor/create.rs
+++ b/packages/toolchain/cli/src/commands/actor/create.rs
@@ -203,6 +203,7 @@ impl Opts {
 				skip_route_creation: None,
 				keep_existing_routes: None,
 				non_interactive: false,
+				skip_upgrade: false,
 			})
 			.await?;
 

--- a/packages/toolchain/cli/src/commands/build/publish.rs
+++ b/packages/toolchain/cli/src/commands/build/publish.rs
@@ -56,6 +56,10 @@ pub struct Opts {
 	#[clap(long)]
 	unstable_compression: Option<config::build::Compression>,
 
+	/// Skip upgrading actors
+	#[clap(long)]
+	skip_upgrade: bool,
+
 	// Docker options
 	/// Specify a pre-built Docker image instead of building from a Dockerfile
 	#[clap(long)]
@@ -170,6 +174,7 @@ impl Opts {
 				version_name,
 				build_name: self.name.clone(),
 				runtime,
+				skip_upgrade: self.skip_upgrade,
 			},
 		)
 		.await?;

--- a/packages/toolchain/cli/src/commands/deploy.rs
+++ b/packages/toolchain/cli/src/commands/deploy.rs
@@ -30,6 +30,10 @@ pub struct Opts {
 	/// Run in non-interactive mode (no prompts)
 	#[clap(long)]
 	non_interactive: bool,
+
+	/// Skip upgrading actors
+	#[clap(long)]
+	skip_upgrade: bool,
 }
 
 impl Opts {
@@ -61,6 +65,7 @@ impl Opts {
 			skip_route_creation: self.skip_route_creation,
 			keep_existing_routes: self.keep_existing_routes,
 			non_interactive: self.non_interactive,
+			skip_upgrade: self.skip_upgrade,
 		})
 		.await?;
 

--- a/packages/toolchain/cli/src/util/deploy.rs
+++ b/packages/toolchain/cli/src/util/deploy.rs
@@ -91,6 +91,7 @@ pub struct DeployOpts<'a> {
 	pub skip_route_creation: Option<bool>,
 	pub keep_existing_routes: Option<bool>,
 	pub non_interactive: bool,
+	pub skip_upgrade: bool,
 }
 
 pub async fn deploy(opts: DeployOpts<'_>) -> Result<Vec<Uuid>> {
@@ -257,6 +258,7 @@ pub async fn deploy(opts: DeployOpts<'_>) -> Result<Vec<Uuid>> {
 			filter_tags: opts.filter_tags.clone(),
 			build_tags: opts.build_tags.clone(),
 			version_name: opts.version.clone(),
+			skip_upgrade: opts.skip_upgrade,
 		},
 	)
 	.await?;

--- a/packages/toolchain/toolchain/src/tasks/deploy/mod.rs
+++ b/packages/toolchain/toolchain/src/tasks/deploy/mod.rs
@@ -18,6 +18,7 @@ pub struct Input {
 	pub filter_tags: Option<HashMap<String, String>>,
 	pub build_tags: Option<HashMap<String, String>>,
 	pub version_name: Option<String>,
+	pub skip_upgrade: bool,
 }
 
 #[derive(Serialize)]
@@ -131,6 +132,7 @@ async fn perform_builds(
 				version_name: version_name.to_string(),
 				build_name: build_name.to_string(),
 				runtime: build.runtime.clone(),
+				skip_upgrade: input.skip_upgrade,
 			},
 		)
 		.await?;


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new --skip-upgrade command-line option to build and deploy commands, allowing users to optionally skip the actor upgrade step during these processes.
  * When using the new flag, a message will indicate that the actor upgrade step has been skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->