### PR TITLE
chore(pegboard): add workaround fetching image size when not using ats

### DIFF
--- a/docker/dev-full/docker-compose.yml
+++ b/docker/dev-full/docker-compose.yml
@@ -211,6 +211,7 @@ services:
       - RIVET_SERVICE_NAME=rivet-client
       - RIVET_OTEL_ENDPOINT=http://otel-collector:4317
       - RUST_LOG=debug,hyper=info
+      - __HACK__DISABLE_FETCH_IMAGE_SIZE=1
     stop_grace_period: 0s
     depends_on:
       # HACK: rivet-server dependency since we need to do a DNS lookup in entrypoint.sh for the iptables chain

--- a/packages/edge/infra/client/manager/src/image_download_handler.rs
+++ b/packages/edge/infra/client/manager/src/image_download_handler.rs
@@ -573,6 +573,11 @@ impl ImageDownloadHandler {
 		ctx: &Ctx,
 		image_config: &protocol::Image,
 	) -> Result<u64> {
+		// HEAD does not work if not using ATS
+		if std::env::var("__HACK__DISABLE_FETCH_IMAGE_SIZE").map_or(false, |x| x == "1") {
+			return Ok(0);
+		}
+
 		let addresses = self.get_image_addresses(ctx, image_config).await?;
 
 		let mut iter = addresses.into_iter();


### PR DESCRIPTION
<!-- Please make sure there is an issue that this PR is correlated to. -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
