### PR TITLE
fix(hub): bring back monospace font

### DIFF
--- a/frontend/packages/components/src/tailwind-base.ts
+++ b/frontend/packages/components/src/tailwind-base.ts
@@ -44,13 +44,12 @@ const config = {
 		},
 		extend: {
 			fontFamily: {
-				// TODO: We haven't configured importing this font
-				//"mono-console": [
-				//	"Consolas",
-				//	"Lucida Console",
-				//	"Courier New",
-				//	"monospace",
-				//],
+				"mono-console": [
+					"Consolas",
+					"Lucida Console",
+					"Courier New",
+					"monospace",
+				],
 			},
 			data: {
 				active: 'status~="active"',


### PR DESCRIPTION
## Changes

Uncommented the `mono-console` font family in the Tailwind configuration, enabling the use of Consolas, Lucida Console, Courier New, and monospace fonts in the application.