### PR TITLE
feat(site): set user's email during newsletter form submission

### DIFF
--- a/site/src/components/Newsletter.tsx
+++ b/site/src/components/Newsletter.tsx
@@ -17,6 +17,10 @@ export function Newsletter() {
 			$survey_id: "01983e70-b743-0000-e4a7-07ce220da177",
 			...data,
 		});
+
+		posthog.setPersonProperties({
+			email: Object.values(data)[0],
+		});
 		setIsSubmitted(true);
 
 		const form = event.currentTarget;


### PR DESCRIPTION
## Changes

Added PostHog person property tracking for email addresses submitted through the newsletter form. When a user submits their email, we now set their email as a person property in PostHog, enabling better user identification and tracking.