### PR TITLE
feat(site): bring back docs navigation to mobile

### DIFF
--- a/site/src/app/(v2)/[section]/[[...page]]/layout.tsx
+++ b/site/src/app/(v2)/[section]/[[...page]]/layout.tsx
@@ -1,11 +1,12 @@
 import { Header } from "@/components/v2/Header";
-import { findPageForHref } from "@/lib/sitemap";
+import { findActiveTab, findPageForHref, Sitemap } from "@/lib/sitemap";
 import { sitemap } from "@/sitemap/mod";
 import { Button } from "@rivet-gg/components";
 import Link from "next/link";
 import type { CSSProperties } from "react";
 import { buildFullPath, buildPathComponents } from "./util";
 import { NavigationStateProvider } from "@/providers/NavigationStateProvider";
+import { Tree } from "@/components/DocsNavigation";
 
 function Subnav({ path }: { path: string[] }) {
 	const fullPath = buildFullPath(path);
@@ -37,9 +38,24 @@ function Subnav({ path }: { path: string[] }) {
 
 export default function Layout({ params: { section, page }, children }) {
 	const path = buildPathComponents(section, page);
+	const fullPath = buildFullPath(path);
+	const foundTab = findActiveTab(fullPath, sitemap as Sitemap);
+
 	return (
 		<NavigationStateProvider>
-			<Header active="docs" subnav={<Subnav path={path} />} variant="full-width" />
+			<Header
+				active="docs"
+				subnav={<Subnav path={path} />}
+				variant="full-width"
+				mobileSidebar={
+					foundTab?.tab.sidebar ? (
+						<Tree
+							className="mt-2 mb-4"
+							pages={foundTab.tab.sidebar}
+						/>
+					) : null
+				}
+			/>
 			<div className="w-full">
 				<div
 					className="md:grid-cols-docs-no-sidebar lg:grid-cols-docs mx-auto flex w-full flex-col justify-center md:grid min-h-content"

--- a/site/src/app/(v2)/[section]/[[...page]]/page.tsx
+++ b/site/src/app/(v2)/[section]/[[...page]]/page.tsx
@@ -32,8 +32,7 @@ function createParamsForFile(section, file): Param {
 	const step2 = step1.replace(".mdx", "");
 	const step3 = step2.split("/");
 	const step4 = step3.filter((x) => x.length > 0);
-	
-	
+
 	return {
 		section,
 		page: step4,
@@ -96,7 +95,7 @@ export default async function CatchAllCorePage({ params: { section, page } }) {
 	const fullPath = buildFullPath(path);
 	const foundTab = findActiveTab(fullPath, sitemap as Sitemap);
 	const parentPage = foundTab?.page.parent;
-	
+
 	// Create markdown path for the dropdown (remove .mdx extension and handle index files)
 	const markdownPath = componentSourcePath
 		.replace(/\.mdx$/, "")
@@ -122,7 +121,10 @@ export default async function CatchAllCorePage({ params: { section, page } }) {
 								/>
 							</div>
 						</div>
-						<Prose as="article" className="max-w-prose lg:max-w-prose mx-auto">
+						<Prose
+							as="article"
+							className="max-w-prose lg:max-w-prose mx-auto"
+						>
 							{parentPage && (
 								<div className="eyebrow h-5 text-primary text-sm font-semibold">
 									{parentPage.title}
@@ -162,7 +164,7 @@ export default async function CatchAllCorePage({ params: { section, page } }) {
 
 export async function generateStaticParams() {
 	const staticParams: Param[] = [];
-	
+
 	for (const section of VALID_SECTIONS) {
 		const dir = path.join(process.cwd(), "src", "content", section);
 

--- a/site/src/components/ActiveLink.tsx
+++ b/site/src/components/ActiveLink.tsx
@@ -7,14 +7,29 @@ import { normalizePath } from "@/lib/normalizePath";
 export interface ActiveLinkProps<T> extends LinkProps<T> {
 	isActive?: boolean;
 	children?: ReactNode;
+	tree?: ReactNode;
+	includeChildren?: boolean;
 }
 
 export function ActiveLink<T>({
 	isActive: isActiveOverride,
+	tree,
+	includeChildren,
 	...props
 }: ActiveLinkProps<T>) {
 	const pathname = usePathname() || "";
-	
-	const isActive = isActiveOverride || normalizePath(pathname) === normalizePath(String(props.href));
-	return <Link<T> {...props} aria-current={isActive ? "page" : undefined} />;
+
+	const isActive =
+		isActiveOverride ||
+		normalizePath(pathname) === normalizePath(String(props.href)) ||
+		(includeChildren &&
+			normalizePath(pathname).startsWith(
+				normalizePath(String(props.href)),
+			));
+	return (
+		<>
+			<Link<T> {...props} aria-current={isActive ? "page" : undefined} />
+			{isActive && tree ? tree : null}
+		</>
+	);
 }

--- a/site/src/components/CollapsibleSidebarItem.tsx
+++ b/site/src/components/CollapsibleSidebarItem.tsx
@@ -27,11 +27,11 @@ export function CollapsibleSidebarItem({
 	const hasActiveChild = findActiveItem(item.pages, pathname) !== null;
 	const isCurrent = false; // Never highlight collapsible sections themselves
 	const [shouldAnimate, setShouldAnimate] = useState(false);
-	
+
 	const itemId = useMemo(() => {
 		return parentPath ? `${parentPath}.${item.title}` : item.title;
 	}, [parentPath, item.title]);
-	
+
 	// Determine initial open state
 	const getInitialState = () => {
 		try {
@@ -48,10 +48,11 @@ export function CollapsibleSidebarItem({
 		// If no saved state, open if has active child
 		return hasActiveChild;
 	};
-	
+
 	const [isItemOpen, setIsItemOpen] = useState(getInitialState);
-	
+
 	// Sync with global state after mount
+	// biome-ignore lint/correctness/useExhaustiveDependencies: it's okay, this runs only once
 	useEffect(() => {
 		const globalIsOpen = isOpen(itemId);
 		if (globalIsOpen !== isItemOpen) {
@@ -59,8 +60,8 @@ export function CollapsibleSidebarItem({
 		}
 		// Enable animations after initial mount
 		setShouldAnimate(true);
-	}, [itemId, isItemOpen, isOpen, setIsOpen]);
-	
+	}, []);
+
 	// Update local state when global state changes
 	useEffect(() => {
 		const globalIsOpen = isOpen(itemId);
@@ -68,16 +69,20 @@ export function CollapsibleSidebarItem({
 			setIsItemOpen(globalIsOpen);
 		}
 	}, [isOpen, itemId, isItemOpen, shouldAnimate]);
-	
+
 	const getPaddingClass = (level: number) => {
 		switch (level) {
-			case 0: return "pl-3 pr-3";
-			case 1: return "pl-6 pr-3";
-			case 2: return "pl-9 pr-3";
-			default: return "pl-12 pr-3";
+			case 0:
+				return "pl-3 pr-3";
+			case 1:
+				return "pl-6 pr-3";
+			case 2:
+				return "pl-9 pr-3";
+			default:
+				return "pl-12 pr-3";
 		}
 	};
-	
+
 	return (
 		<div>
 			<button
@@ -107,7 +112,9 @@ export function CollapsibleSidebarItem({
 						closed: { rotateZ: "-90deg" },
 					}}
 					initial={isItemOpen ? "open" : "closed"}
-					animate={shouldAnimate ? (isItemOpen ? "open" : "closed") : false}
+					animate={
+						shouldAnimate ? (isItemOpen ? "open" : "closed") : false
+					}
 					className="ml-2 inline-block flex-shrink-0 opacity-70"
 				>
 					<Icon icon={faChevronDown} className="w-3 h-3" />
@@ -120,7 +127,9 @@ export function CollapsibleSidebarItem({
 					closed: { height: 0, opacity: 0 },
 				}}
 				initial={isItemOpen ? "open" : "closed"}
-				animate={shouldAnimate ? (isItemOpen ? "open" : "closed") : false}
+				animate={
+					shouldAnimate ? (isItemOpen ? "open" : "closed") : false
+				}
 				transition={{
 					opacity: isItemOpen ? { delay: 0.05 } : {},
 					height: !isItemOpen ? { delay: 0.05 } : {},
@@ -135,7 +144,10 @@ export function CollapsibleSidebarItem({
 
 function findActiveItem(pages: SidebarItem[], href: string) {
 	for (const page of pages) {
-		if ("href" in page && normalizePath(page.href) === normalizePath(href)) {
+		if (
+			"href" in page &&
+			normalizePath(page.href) === normalizePath(href)
+		) {
 			return page;
 		}
 		if ("pages" in page) {

--- a/site/src/components/DocsNavigation.tsx
+++ b/site/src/components/DocsNavigation.tsx
@@ -2,7 +2,7 @@ import { ActiveLink } from "@/components/ActiveLink";
 import { CollapsibleSidebarItem } from "@/components/CollapsibleSidebarItem";
 import { DynamicNavWrapper } from "@/components/DynamicNavWrapper";
 import routes from "@/generated/routes.json";
-import type { SidebarItem, SidebarSection } from "@/lib/sitemap";
+import type { SidebarItem } from "@/lib/sitemap";
 import { cn } from "@rivet-gg/components";
 import { Icon, faArrowUpRight } from "@rivet-gg/icons";
 import clsx from "clsx";
@@ -22,16 +22,28 @@ function TreeItem({ index, item, level = 0, parentPath = "" }: TreeItemProps) {
 		"pages" in item &&
 		item.collapsible
 	) {
-		const itemPath = parentPath ? `${parentPath}.${item.title}` : item.title;
+		const itemPath = parentPath
+			? `${parentPath}.${item.title}`
+			: item.title;
 		return (
-			<CollapsibleSidebarItem item={item} level={level} parentPath={parentPath}>
-				<Tree pages={item.pages} level={level + 1} parentPath={itemPath} />
+			<CollapsibleSidebarItem
+				item={item}
+				level={level}
+				parentPath={parentPath}
+			>
+				<Tree
+					pages={item.pages}
+					level={level + 1}
+					parentPath={itemPath}
+				/>
 			</CollapsibleSidebarItem>
 		);
 	}
 
 	if ("title" in item && "pages" in item) {
-		const itemPath = parentPath ? `${parentPath}.${item.title}` : item.title;
+		const itemPath = parentPath
+			? `${parentPath}.${item.title}`
+			: item.title;
 		return (
 			<div>
 				<p
@@ -45,7 +57,11 @@ function TreeItem({ index, item, level = 0, parentPath = "" }: TreeItemProps) {
 					) : null}
 					<span className="truncate"> {item.title}</span>
 				</p>
-				<Tree pages={item.pages} level={level + 1} parentPath={itemPath} />
+				<Tree
+					pages={item.pages}
+					level={level + 1}
+					parentPath={itemPath}
+				/>
 			</div>
 		);
 	}
@@ -72,7 +88,12 @@ interface TreeProps {
 	parentPath?: string;
 }
 
-export function Tree({ pages, className, level = 0, parentPath = "" }: TreeProps) {
+export function Tree({
+	pages,
+	className,
+	level = 0,
+	parentPath = "",
+}: TreeProps) {
 	return (
 		<ul className={cn(className)}>
 			{pages.map((item, index) => (
@@ -80,7 +101,12 @@ export function Tree({ pages, className, level = 0, parentPath = "" }: TreeProps
 					// biome-ignore lint/suspicious/noArrayIndexKey: FIXME: used only for static content
 					key={index}
 				>
-					<TreeItem index={index} item={item} level={level} parentPath={parentPath} />
+					<TreeItem
+						index={index}
+						item={item}
+						level={level}
+						parentPath={parentPath}
+					/>
 				</li>
 			))}
 		</ul>

--- a/site/src/components/v2/Header.tsx
+++ b/site/src/components/v2/Header.tsx
@@ -1,7 +1,5 @@
 "use client";
 import { ActiveLink } from "@/components/ActiveLink";
-import { Tree } from "@/components/DocsNavigation";
-import { sitemap } from "@/sitemap/mod";
 import logoUrl from "@/images/rivet-logos/icon-text-white.svg";
 import { cn } from "@rivet-gg/components";
 import { Header as RivetHeader } from "@rivet-gg/components/header";
@@ -50,14 +48,14 @@ function TextNavItem({
 interface HeaderProps {
 	active?: "product" | "docs" | "blog" | "cloud" | "pricing" | "solutions";
 	subnav?: ReactNode;
-	mobileBreadcrumbs?: ReactNode;
+	mobileSidebar?: ReactNode;
 	variant?: "floating" | "full-width";
 }
 
 export function Header({
 	active,
 	subnav,
-	mobileBreadcrumbs,
+	mobileSidebar,
 	variant = "full-width",
 }: HeaderProps) {
 	const [isScrolled, setIsScrolled] = useState(false);
@@ -156,7 +154,9 @@ export function Header({
 								</Link>
 							</div>
 						}
-						mobileBreadcrumbs={<DocsMobileNavigation />}
+						mobileBreadcrumbs={
+							<DocsMobileNavigation tree={mobileSidebar} />
+						}
 						breadcrumbs={
 							<div className="flex items-center font-v2 subpixel-antialiased">
 								<TextNavItem
@@ -246,7 +246,7 @@ export function Header({
 					</Link>
 				</div>
 			}
-			mobileBreadcrumbs={<DocsMobileNavigation />}
+			mobileBreadcrumbs={<DocsMobileNavigation tree={mobileSidebar} />}
 			breadcrumbs={
 				<div className="flex items-center font-v2 subpixel-antialiased">
 					<TextNavItem
@@ -273,11 +273,11 @@ export function Header({
 	);
 }
 
-function DocsMobileNavigation() {
+function DocsMobileNavigation({ tree }) {
 	const pathname = usePathname() || "";
 
 	const docsLinks = [
-		{ href: "/docs", label: "Actors" },
+		{ href: "/docs/actors", label: "Actors" },
 		{ href: "/docs/cloud", label: "Cloud" },
 	];
 
@@ -289,12 +289,14 @@ function DocsMobileNavigation() {
 	return (
 		<div className="flex flex-col gap-4 font-v2 subpixel-antialiased">
 			{/* Docs section */}
-			<div className="text-white/40">Documentation</div>
-			<div className="border-l border-white/20">
+			<div className="text-foreground">Documentation</div>
+			<div className="">
 				{docsLinks.map(({ href, label }) => (
-					<div key={href} className="ml-4">
+					<div key={href} className="ml-2">
 						<RivetHeader.NavItem asChild>
-							<ActiveLink href={href}>{label}</ActiveLink>
+							<ActiveLink includeChildren tree={tree} href={href}>
+								{label}
+							</ActiveLink>
 						</RivetHeader.NavItem>
 					</div>
 				))}

--- a/site/src/generated/apiPages.json
+++ b/site/src/generated/apiPages.json
@@ -5,57 +5,57 @@
       "pages": [
         {
           "title": "actors.list",
-          "href": "/docs/api/actors/list",
+          "href": "/docs/cloud/api/actors/list",
           "sortingKey": "/actors get"
         },
         {
           "title": "actors.create",
-          "href": "/docs/api/actors/create",
+          "href": "/docs/cloud/api/actors/create",
           "sortingKey": "/actors post"
         },
         {
           "title": "actors.logs.get",
-          "href": "/docs/api/actors/logs/get",
+          "href": "/docs/cloud/api/actors/logs/get",
           "sortingKey": "/actors/logs get"
         },
         {
           "title": "actors.logs.export",
-          "href": "/docs/api/actors/logs/export",
+          "href": "/docs/cloud/api/actors/logs/export",
           "sortingKey": "/actors/logs/export post"
         },
         {
           "title": "actors.query",
-          "href": "/docs/api/actors/query",
+          "href": "/docs/cloud/api/actors/query",
           "sortingKey": "/actors/query get"
         },
         {
           "title": "actors.upgradeAll",
-          "href": "/docs/api/actors/upgrade-all",
+          "href": "/docs/cloud/api/actors/upgrade-all",
           "sortingKey": "/actors/upgrade post"
         },
         {
           "title": "actors.usage",
-          "href": "/docs/api/actors/usage",
+          "href": "/docs/cloud/api/actors/usage",
           "sortingKey": "/actors/usage get"
         },
         {
           "title": "actors.destroy",
-          "href": "/docs/api/actors/destroy",
+          "href": "/docs/cloud/api/actors/destroy",
           "sortingKey": "/actors/{actor} delete"
         },
         {
           "title": "actors.get",
-          "href": "/docs/api/actors/get",
+          "href": "/docs/cloud/api/actors/get",
           "sortingKey": "/actors/{actor} get"
         },
         {
           "title": "actors.metrics.get",
-          "href": "/docs/api/actors/metrics/get",
+          "href": "/docs/cloud/api/actors/metrics/get",
           "sortingKey": "/actors/{actor}/metrics/history get"
         },
         {
           "title": "actors.upgrade",
-          "href": "/docs/api/actors/upgrade",
+          "href": "/docs/cloud/api/actors/upgrade",
           "sortingKey": "/actors/{actor}/upgrade post"
         }
       ]
@@ -65,27 +65,27 @@
       "pages": [
         {
           "title": "builds.list",
-          "href": "/docs/api/builds/list",
+          "href": "/docs/cloud/api/builds/list",
           "sortingKey": "/builds get"
         },
         {
           "title": "builds.prepare",
-          "href": "/docs/api/builds/prepare",
+          "href": "/docs/cloud/api/builds/prepare",
           "sortingKey": "/builds/prepare post"
         },
         {
           "title": "builds.get",
-          "href": "/docs/api/builds/get",
+          "href": "/docs/cloud/api/builds/get",
           "sortingKey": "/builds/{build} get"
         },
         {
           "title": "builds.complete",
-          "href": "/docs/api/builds/complete",
+          "href": "/docs/cloud/api/builds/complete",
           "sortingKey": "/builds/{build}/complete post"
         },
         {
           "title": "builds.patchTags",
-          "href": "/docs/api/builds/patch-tags",
+          "href": "/docs/cloud/api/builds/patch-tags",
           "sortingKey": "/builds/{build}/tags patch"
         }
       ]
@@ -95,12 +95,12 @@
       "pages": [
         {
           "title": "regions.list",
-          "href": "/docs/api/regions/list",
+          "href": "/docs/cloud/api/regions/list",
           "sortingKey": "/regions get"
         },
         {
           "title": "regions.recommend",
-          "href": "/docs/api/regions/recommend",
+          "href": "/docs/cloud/api/regions/recommend",
           "sortingKey": "/regions/recommend get"
         }
       ]
@@ -110,22 +110,22 @@
       "pages": [
         {
           "title": "routes.list",
-          "href": "/docs/api/routes/list",
+          "href": "/docs/cloud/api/routes/list",
           "sortingKey": "/routes get"
         },
         {
           "title": "routes.history",
-          "href": "/docs/api/routes/history",
+          "href": "/docs/cloud/api/routes/history",
           "sortingKey": "/routes/history get"
         },
         {
           "title": "routes.delete",
-          "href": "/docs/api/routes/delete",
+          "href": "/docs/cloud/api/routes/delete",
           "sortingKey": "/routes/{id} delete"
         },
         {
           "title": "routes.update",
-          "href": "/docs/api/routes/update",
+          "href": "/docs/cloud/api/routes/update",
           "sortingKey": "/routes/{id} put"
         }
       ]


### PR DESCRIPTION
## Changes

This PR adds mobile sidebar navigation to the documentation pages. It enhances the mobile user experience by:

1. Adding a tree-based navigation component to the mobile sidebar that displays the relevant documentation sections
2. Updating the `ActiveLink` component to support tree children and include child path detection
3. Modifying the Header component to accept and display the mobile sidebar content
4. Implementing proper navigation state handling for collapsible sidebar items

The changes allow users on mobile devices to navigate through documentation sections more easily without having to return to main navigation pages.