### PR TITLE
fix(inspector): use proper status indicator

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -371,28 +371,30 @@ function ConnectionStatus() {
 		);
 	}
 
-	// if (isError) {
-	return (
-		<div className="text-red-500 border p-2 rounded-md flex items-center text-sm justify-between bg-stripes-destructive ">
-			<div className="flex items-center">
-				<div>
-					<p>Disconnected</p>
-					<p className="text-muted-foreground text-xs">{endpoint}</p>
+	if (isError) {
+		return (
+			<div className="text-red-500 border p-2 rounded-md flex items-center text-sm justify-between bg-stripes-destructive ">
+				<div className="flex items-center">
+					<div>
+						<p>Disconnected</p>
+						<p className="text-muted-foreground text-xs">
+							{endpoint}
+						</p>
+					</div>
 				</div>
-			</div>
 
-			<Button
-				variant="outline"
-				size="xs"
-				className="ml-2 text-foreground"
-				onClick={() => setCredentials(null)}
-			>
-				<Icon icon={faLink} />
-				Reconnect
-			</Button>
-		</div>
-	);
-	// }
+				<Button
+					variant="outline"
+					size="xs"
+					className="ml-2 text-foreground"
+					onClick={() => setCredentials(null)}
+					startIcon={<Icon icon={faLink} />}
+				>
+					Reconnect
+				</Button>
+			</div>
+		);
+	}
 
 	if (isSuccess) {
 		return (


### PR DESCRIPTION
### TL;DR

Fixed the disconnected state in the ConnectionStatus component to only display when there's an actual error.

### What changed?

- Uncommented the `if (isError)` condition that was previously commented out
- Moved the disconnected state UI inside the conditional block
- Added the link icon as a `startIcon` prop to the Button component instead of as a child element

### How to test?

1. Intentionally cause a connection error in the application
2. Verify that the disconnected state UI only appears when there's an actual error
3. Check that the "Reconnect" button displays correctly with the link icon

### Why make this change?

The disconnected state was previously always showing regardless of connection status because the conditional check was commented out. This change ensures the error UI only displays when there's an actual connection error, improving the user experience by providing accurate connection status information.