### PR TITLE
fix: proper turbo

### DIFF
--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -7,7 +7,13 @@
 			"env": ["VITE_APP_*"],
 			"outputs": ["dist/**"]
 		},
+		"build:inspector": {
+			"dependsOn": ["^build"],
+			"env": ["VITE_APP_*"],
+			"outputs": ["dist/**"]
+		},
 		"dev": {
+			"dependsOn": ["^build"],
 			"env": ["VITE_APP_*"],
 			"persistent": true
 		}


### PR DESCRIPTION
### TL;DR

Added build configuration for inspector and updated dev dependencies in Turbo config.

### What changed?

- Added a new `build:inspector` task with the same configuration as the existing build task
- Added a dependency on `^build` to the `dev` task, ensuring build tasks complete before dev starts

### How to test?

1. Run `turbo run build:inspector` to verify the new task works correctly
2. Run `turbo run dev` to confirm it properly waits for build tasks to complete first

### Why make this change?

This change improves the development workflow by ensuring that build dependencies are properly resolved before development starts. The new inspector build task allows for specialized builds with inspector capabilities while maintaining the same environment variables and output structure as the standard build.