### PR TITLE
fix: init clerk only on cloud

### DIFF
--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,4 +1,7 @@
 import { Clerk } from "@clerk/clerk-js";
 import { cloudEnv } from "./env";
 
-export const clerk = new Clerk(cloudEnv().VITE_APP_CLERK_PUBLISHABLE_KEY);
+export const clerk =
+	__APP_TYPE__ === "cloud"
+		? new Clerk(cloudEnv().VITE_APP_CLERK_PUBLISHABLE_KEY)
+		: (null as unknown as Clerk);


### PR DESCRIPTION
### TL;DR

Conditionally initialize Clerk authentication based on app type

### What changed?

Modified the `auth.ts` file to only initialize the Clerk authentication client when the application is running in cloud mode. When not in cloud mode, the clerk variable is set to null (cast as Clerk type).

### How to test?

1. Verify that authentication works correctly in cloud environments
2. Confirm that the application doesn't attempt to initialize Clerk in non-cloud environments
3. Check that no authentication errors occur in either environment

### Why make this change?

This change prevents unnecessary Clerk initialization in non-cloud environments where authentication might be handled differently or not needed. This improves efficiency and prevents potential errors from attempting to use Clerk with invalid or missing credentials in development or other non-cloud contexts.