### PR TITLE
fix: buildQueryOptions error

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -42,6 +42,7 @@ import {
 	Skeleton,
 } from "@/components";
 import {
+	useDataProvider,
 	useDataProviderCheck,
 	useInspectorDataProvider,
 } from "@/components/actors";
@@ -392,6 +393,7 @@ const Subnav = () => {
 			: { to: "/", fuzzy: true },
 	);
 	const hasDataProvider = useDataProviderCheck();
+	const hasQuery = !!useDataProvider().buildsQueryOptions;
 
 	if (nsMatch === false) {
 		return null;
@@ -409,7 +411,7 @@ const Subnav = () => {
 					Connect
 				</HeaderLink>
 			) : null}
-			{hasDataProvider ? (
+			{hasDataProvider && hasQuery ? (
 				<div className="w-full">
 					<span className="block text-muted-foreground text-xs px-2 py-1 transition-colors mb-0.5">
 						Instances
@@ -542,6 +544,7 @@ function CloudSidebarContent() {
 	});
 
 	const hasDataProvider = useDataProviderCheck();
+	const hasQuery = !!useDataProvider().buildsQueryOptions;
 
 	if (matchNamespace) {
 		return (
@@ -554,7 +557,7 @@ function CloudSidebarContent() {
 				>
 					Connect
 				</HeaderLink>
-				{hasDataProvider ? (
+				{hasDataProvider && hasQuery ? (
 					<div className="w-full pt-1.5">
 						<span className="block text-muted-foreground text-xs px-1 py-1 transition-colors mb-0.5">
 							Instances


### PR DESCRIPTION

Closes FRONT-838
### TL;DR

Hide the "Instances" section in the sidebar when the data provider doesn't support query options.

### What changed?

Added a check to verify if the data provider has the `buildsQueryOptions` capability before rendering the "Instances" section in both the Subnav and CloudSidebarContent components. This prevents displaying the Instances section when it's not applicable.

### How to test?

1. Connect to a data provider that doesn't support query options
2. Verify that the "Instances" section is not displayed in the sidebar
3. Connect to a data provider that does support query options
4. Verify that the "Instances" section appears correctly

### Why make this change?

Some data providers don't support query options, making the "Instances" section irrelevant for those providers. This change improves the UI by only showing relevant navigation options based on the capabilities of the connected data provider.