### PR TITLE
fix(inspector): allow executing rpcs in inspector

### DIFF
--- a/frontend/src/components/actors/worker/actor-worker-context.tsx
+++ b/frontend/src/components/actors/worker/actor-worker-context.tsx
@@ -43,6 +43,17 @@ const useInspectorToken = (runnerName: string) => {
 		});
 };
 
+const useConnectionDetails = () => {
+	return match(__APP_TYPE__)
+		.with("inspector", () => {
+			return {namespace: "", engineToken: ""};
+		})
+		.otherwise(() => {
+			const provider = useEngineCompatDataProvider();
+			return {namespace: provider.engineNamespace, engineToken: provider.engineToken};
+		});
+}
+
 interface ActorWorkerContextProviderProps {
 	actorId: ActorId;
 	children: ReactNode;
@@ -51,9 +62,9 @@ export const ActorWorkerContextProvider = ({
 	children,
 	actorId,
 }: ActorWorkerContextProviderProps) => {
-	const dataProvider = useEngineCompatDataProvider();
-	const engineToken = dataProvider.engineToken;
-	const namespace = dataProvider.engineNamespace;
+	const dataProvider = useDataProvider();
+	const {engineToken, namespace} = useConnectionDetails();
+	
 	const {
 		data: {
 			features,


### PR DESCRIPTION
### TL;DR

Refactored actor worker context to support inspector mode and standardized HTTP header usage.

### What changed?

- Added a new `useConnectionDetails()` hook in `actor-worker-context.tsx` that returns different connection details based on the application type
- Updated `ActorWorkerContextProvider` to use the new hook instead of directly accessing the data provider
- Replaced hardcoded header strings in `rivetkit` with imported constants from `driver-helpers/mod`
- Added `HEADER_ACTOR_QUERY` to the list of allowed CORS headers

### How to test?

1. Run the application in both normal and inspector modes
2. Verify that actor workers connect properly in both modes
3. Confirm that cross-origin requests with the Rivet headers are properly handled

### Why make this change?

This change improves the codebase by:
1. Adding proper support for inspector mode in the actor worker context
2. Reducing duplication by using constants for header names
3. Ensuring consistent header handling across the application
4. Preventing potential bugs from mismatched header names