### PR TITLE
fix(rivetkit): fix missing duplex in nextjs in development

### DIFF
--- a/rivetkit-typescript/packages/next-js/src/mod.ts
+++ b/rivetkit-typescript/packages/next-js/src/mod.ts
@@ -117,7 +117,9 @@ async function handleRequestWithFileWatcher(
 		integrity: request.integrity,
 		// Override with new signal
 		signal: mergedController.signal,
-	});
+		// Required for streaming body
+		duplex: "half",
+	} as RequestInit);
 
 	// Handle request
 	const response = await fetch(newReq);


### PR DESCRIPTION
```
RequestInit: duplex option is required when sending a body.
```

