### PR TITLE
fix(cloud): incorrect property names for railway

### DIFF
--- a/frontend/src/app/dialogs/connect-railway-frame.tsx
+++ b/frontend/src/app/dialogs/connect-railway-frame.tsx
@@ -259,7 +259,7 @@ function RivetRunnerEnv() {
 		<>
 			<DiscreteInput
 				aria-label="environment variable key"
-				value="NEXT_PUBLIC_RIVET_RUNNER"
+				value="RIVET_RUNNER"
 				show
 			/>
 			<DiscreteInput
@@ -279,7 +279,7 @@ function RivetTokenEnv() {
 		<>
 			<DiscreteInput
 				aria-label="environment variable key"
-				value="NEXT_PUBLIC_RIVET_TOKEN"
+				value="RIVET_TOKEN"
 				show
 			/>
 			{isLoading ? (
@@ -301,7 +301,7 @@ function RivetEndpointEnv() {
 		<>
 			<DiscreteInput
 				aria-label="environment variable key"
-				value="NEXT_PUBLIC_RIVET_ENDPOINT"
+				value="RIVET_ENDPOINT"
 				show
 			/>
 			<DiscreteInput
@@ -319,7 +319,7 @@ function RivetNamespaceEnv() {
 		<>
 			<DiscreteInput
 				aria-label="environment variable key"
-				value="NEXT_PUBLIC_RIVET_NAMESPACE"
+				value="RIVET_NAMESPACE"
 				show
 			/>
 			<DiscreteInput


### PR DESCRIPTION
### TL;DR

Updated Rivet environment variable names by removing the `NEXT_PUBLIC_` prefix.

### What changed?

Modified the environment variable keys displayed in the Railway connection dialog:
- Changed `NEXT_PUBLIC_RIVET_RUNNER` to `RIVET_RUNNER`
- Changed `NEXT_PUBLIC_RIVET_TOKEN` to `RIVET_TOKEN`
- Changed `NEXT_PUBLIC_RIVET_ENDPOINT` to `RIVET_ENDPOINT`
- Changed `NEXT_PUBLIC_RIVET_NAMESPACE` to `RIVET_NAMESPACE`

### How to test?

1. Open the Railway connection dialog
2. Verify that the environment variable keys are displayed without the `NEXT_PUBLIC_` prefix
3. Ensure that the connection functionality still works correctly with the updated variable names

### Why make this change?

The `NEXT_PUBLIC_` prefix is typically used for client-side environment variables in Next.js applications. Since these Rivet variables are likely meant to be server-side only, removing this prefix ensures they won't be exposed to the client, improving security and following best practices for environment variable naming.