### PR TITLE
fix(fe): get data based on the app type on connect page

### DIFF
--- a/frontend/src/app/dialogs/create-namespace-frame.tsx
+++ b/frontend/src/app/dialogs/create-namespace-frame.tsx
@@ -22,7 +22,7 @@ const useDataProvider = () => {
 			return match(
 				// biome-ignore lint/correctness/useHookAtTopLevel: match will only run once per app load
 				useRouteContext({
-					from: "/_context/",
+					from: "/_context",
 				}),
 			)
 				.with({ __type: "engine" }, (ctx) => ctx.dataProvider)

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/connect.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/connect.tsx
@@ -436,18 +436,21 @@ function Runners() {
 }
 
 function usePublishableToken() {
-	const cloudProvider = useCloudNamespaceDataProvider();
-	const engineProvider = useEngineNamespaceDataProvider();
-	const cloudData = useSuspenseQuery(
-		cloudProvider.publishableTokenQueryOptions(),
-	);
-	const engineData = useSuspenseQuery(
-		engineProvider.engineAdminTokenQueryOptions(),
-	);
-
 	return match(__APP_TYPE__)
-		.with("cloud", () => cloudData.data)
-		.with("engine", () => engineData.data)
+		.with("cloud", () => {
+			// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
+			return useSuspenseQuery(
+				// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
+				useCloudNamespaceDataProvider().publishableTokenQueryOptions(),
+			).data;
+		})
+		.with("engine", () => {
+			// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
+			return useSuspenseQuery(
+				// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
+				useEngineNamespaceDataProvider().engineAdminTokenQueryOptions(),
+			).data;
+		})
 		.otherwise(() => {
 			throw new Error("Not in a valid context");
 		});


### PR DESCRIPTION
### TL;DR

Fixed a route path and improved hook usage in the namespace connection flow.

### What changed?

- Fixed the route path in `create-namespace-frame.tsx` by removing the trailing slash from `"/_context/"` to `"/_context"`
- Refactored the `usePublishableToken` function in the namespace connect page to avoid unnecessary hook calls when they're not needed for the current app type
- Added appropriate biome-ignore comments to handle lint warnings for hooks used within conditional blocks

### How to test?

1. Verify that namespace creation works correctly
2. Test the connect page in both cloud and engine contexts to ensure tokens are properly retrieved
3. Confirm that no React hook rules are violated during runtime

### Why make this change?

The trailing slash in the route path could cause routing issues. The hook refactoring improves code efficiency by only calling the relevant data provider hooks based on the current app type, rather than always calling both hooks regardless of which one is needed.