### PR TITLE
fix(fe): Local Network Access

### DIFF
--- a/frontend/src/app/data-providers/inspector-data-provider.tsx
+++ b/frontend/src/app/data-providers/inspector-data-provider.tsx
@@ -183,5 +183,9 @@ export function createClient({ url, token }: { url: string; token: string }) {
 
 	return createManagerInspectorClient(newUrl.href, {
 		headers: { Authorization: `Bearer ${token}` },
+		init: {
+			// @ts-expect-error missing types
+			targetAddressSpace: "loopback",
+		},
 	});
 }

--- a/frontend/src/app/inspector-root.tsx
+++ b/frontend/src/app/inspector-root.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { match } from "ts-pattern";
+import { askForLocalNetworkAccess } from "@/lib/permissions";
 import { Actors } from "./actors";
 import { BuildPrefiller } from "./build-prefiller";
 import { Connect } from "./connect";
@@ -70,6 +71,17 @@ export function InspectorRoot() {
 				<Connect
 					formRef={formRef}
 					onSubmit={async (values, form) => {
+						const hasLocalNetworkAccess =
+							await askForLocalNetworkAccess();
+
+						if (!hasLocalNetworkAccess) {
+							form.setError("token", {
+								message:
+									"Local network access is required to connect to local RivetKit. Please enable local network access in your browser settings and try again.",
+							});
+							return;
+						}
+
 						try {
 							const client = createClient({
 								url: values.username,

--- a/frontend/src/lib/permissions.ts
+++ b/frontend/src/lib/permissions.ts
@@ -1,0 +1,24 @@
+export const askForLocalNetworkAccess = async () => {
+	try {
+		const status = await navigator.permissions.query({
+			// @ts-expect-error missing types
+			name: "local-network-access",
+		});
+		if (status.state === "granted") {
+			return true;
+		}
+		if (status.state === "denied") {
+			return false;
+		}
+		// If promptable, try to request permission
+		if (status.state === "prompt") {
+			// Note: There is currently no way to programmatically trigger the permission prompt.
+			// It is triggered when the app tries to access local network resources.
+			// So we return true here and handle any failures when trying to connect.
+			return true;
+		}
+	} catch {
+		// Permissions API not supported
+		return true;
+	}
+};

--- a/frontend/src/routes/_context/index.tsx
+++ b/frontend/src/routes/_context/index.tsx
@@ -5,6 +5,7 @@ import { InspectorRoot } from "@/app/inspector-root";
 import { Logo } from "@/app/logo";
 import { Card } from "@/components";
 import { redirectToOrganization } from "@/lib/auth";
+import { askForLocalNetworkAccess } from "@/lib/permissions";
 
 export const Route = createFileRoute("/_context/")({
 	component: () =>
@@ -45,6 +46,12 @@ export const Route = createFileRoute("/_context/")({
 			})
 			.with({ __type: "inspector" }, async (ctx) => {
 				if (!search.t || !search.u) {
+					return { connectedInPreflight: false };
+				}
+
+				const hasLocalNetworkAccess = await askForLocalNetworkAccess();
+
+				if (!hasLocalNetworkAccess) {
 					return { connectedInPreflight: false };
 				}
 


### PR DESCRIPTION
### TL;DR

Added `targetAddressSpace: "loopback"` to the inspector client initialization.

### What changed?

Added a new `init` configuration object to the `createManagerInspectorClient` function with the `targetAddressSpace` property set to "loopback". This property required a TypeScript expect-error comment due to missing types.

### How to test?

1. Verify that the inspector client connects properly
2. Check that inspector functionality works as expected with the loopback address space setting

### Why make this change?

This change ensures that the inspector client uses the loopback address space for connections, which improves security by restricting network access to the local machine. This is particularly important for inspector functionality which may expose sensitive debugging information.