### PR TITLE
feat(rivetkit): configure server port via env (for serverless auto-start)

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/registry/run-config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/run-config.ts
@@ -32,7 +32,15 @@ const RunnerConfigSchemaUnmerged = z
 		disableDefaultServer: z.boolean().optional().default(false),
 
 		/** @experimental */
-		defaultServerPort: z.number().default(6420),
+		defaultServerPort: z
+			.number()
+			.default(() => {
+				const defaultPort = getEnvUniversal("RIVET_SERVER_PORT");
+				if (typeof defaultPort === "undefined") {
+					return 6420;
+				}
+				return parseInt(defaultPort);
+			}),
 
 		/** @experimental */
 		runEngine: z


### PR DESCRIPTION
Fixes CLD-37