### PR TITLE
Fix InlineWebSocketAdapter message delivery

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/common/inline-websocket-adapter.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/inline-websocket-adapter.ts
@@ -50,6 +50,9 @@ export class InlineWebSocketAdapter implements UniversalWebSocket {
 			readyState: 1,
 		});
 
+		// Set __adapter on WSContext so handleRawWebSocket.onMessage can route messages back
+		(this.#wsContext as any).__adapter = this;
+
 		// Initialize the connection
 		//
 		// Defer initialization to allow event listeners to be attached first
@@ -206,6 +209,12 @@ export class InlineWebSocketAdapter implements UniversalWebSocket {
 			this.#fireError(err);
 			this.close(1011, "Internal error during initialization");
 		}
+	}
+	/**
+	 * Handle message from actor (called via __adapter from handleRawWebSocket.onMessage)
+	 */
+	_handleMessage(event: MessageEvent) {
+	  this.#handleMessage(event.data);
 	}
 
 	/**


### PR DESCRIPTION
When attempting to reproduce https://www.rivet.dev/docs/actors/websocket-handler/ with createFileSystemDriver, messages sent from the actor to the client are never delivered. The connection appears to work (open/close events fire), but message routing fails silently. When using handleRawWebSocket with an InlineWebSocketAdapter, messages sent from the actor to the client are never delivered.

https://github.com/rivet-dev/rivet/blob/c9cfd90d5fb152fd47fc93acfadb1dec7f18e6bf/rivetkit-typescript/packages/rivetkit/src/actor/router-websocket-endpoints.ts#L319-L325 Looks up an adaptor, but this is never set for InlineWebSocketAdapter.