### PR TITLE
fix(engine): handle no datacenters case

### DIFF
--- a/frontend/src/components/actors/form/actor-create-form.tsx
+++ b/frontend/src/components/actors/form/actor-create-form.tsx
@@ -1,7 +1,4 @@
-import {
-	useInfiniteQuery,
-	useSuspenseInfiniteQuery,
-} from "@tanstack/react-query";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { type UseFormReturn, useFormContext } from "react-hook-form";
 import z from "zod";
@@ -22,7 +19,6 @@ import { CrashPolicySelect } from "../crash-policy-select";
 import { useEngineCompatDataProvider } from "../data-provider";
 import { CrashPolicy as CrashPolicyEnum } from "../queries";
 import { RegionSelect } from "../region-select";
-import { ConnectedRunnerSelect } from "../runner-select";
 
 const jsonValid = z.custom<string>(
 	(value) => {
@@ -274,8 +270,9 @@ export const PrefillDatacenter = () => {
 		...useEngineCompatDataProvider().runnerConfigsQueryOptions(),
 		select: (data) => {
 			return Object.keys(
-				Object.values(data.pages[0].runnerConfigs)[0].datacenters,
-			)[0];
+				Object.values(data.pages[0].runnerConfigs || {})?.[0]
+					?.datacenters || {},
+			)?.[0];
 		},
 	});
 


### PR DESCRIPTION
Closes FRONT-902



### TL;DR

Fixed potential null reference error in the PrefillDatacenter component.

### What changed?

Added null checks in the PrefillDatacenter component's select function to handle cases where runnerConfigs might be undefined or datacenters might not exist. This prevents potential runtime errors by:

- Adding a fallback empty object when accessing datacenters
- Adding optional chaining when accessing the first key of the datacenters object

### How to test?

1. Navigate to the actor creation form
2. Verify that the datacenter prefill functionality works correctly
3. Test with both populated and empty runner configurations to ensure no errors occur

### Why make this change?

This change improves the robustness of the code by handling edge cases where data might be missing or undefined. Without these null checks, the application could crash when attempting to access properties of undefined objects, particularly when runner configurations don't contain datacenter information.