### PR TITLE
fix(engine): redirect engine users to the default namespace on startup

### DIFF
--- a/frontend/src/routes/_context/index.tsx
+++ b/frontend/src/routes/_context/index.tsx
@@ -29,7 +29,10 @@ export const Route = createFileRoute("/_context/")({
 
 					const firstNamespace = result.pages[0]?.namespaces[0];
 					if (!firstNamespace) {
-						return;
+						throw redirect({
+							to: "/ns/$namespace",
+							params: { namespace: "default" },
+						});
 					}
 					throw redirect({
 						to: "/ns/$namespace",


### PR DESCRIPTION
Closes RVT-5323



### TL;DR

Redirect users to the default namespace when no namespace is found.

### What changed?

Modified the behavior in the context route when no namespace is found. Instead of simply returning (which would likely result in a blank or error state), the code now redirects the user to the "default" namespace.

### How to test?

1. Log in to the application with a user that has no namespaces configured
2. Navigate to the root or context route
3. Verify you are automatically redirected to the "default" namespace

### Why make this change?

This improves the user experience by providing a fallback destination when no namespaces are available, rather than leaving the user at a dead end. The "default" namespace is a standard fallback in Kubernetes-based systems, making it a logical choice for redirection.