### PR TITLE
fix(cloud): use correct property to retrive datacenter endpoint

### DIFF
--- a/frontend/src/app/data-providers/cloud-data-provider.tsx
+++ b/frontend/src/app/data-providers/cloud-data-provider.tsx
@@ -466,7 +466,7 @@ export const createNamespaceContext = ({
 						{ org: parent.organization },
 					);
 					const t = await f;
-					return t.token;
+					return t.token as string;
 				},
 			});
 		},

--- a/frontend/src/app/data-providers/default-data-provider.tsx
+++ b/frontend/src/app/data-providers/default-data-provider.tsx
@@ -328,6 +328,8 @@ const defaultContext = {
 			initialPageParam: null as string | null,
 			queryFn: async () => {
 				throw new Error("Not implemented");
+				// biome-ignore lint/correctness/noUnreachable: <explanation>
+				return {} as PaginatedRegionsResponse;
 			},
 			getNextPageParam: () => null,
 			select: (data) => data.pages.flatMap((page) => page.regions),

--- a/frontend/src/app/dialogs/connect-vercel-frame.tsx
+++ b/frontend/src/app/dialogs/connect-vercel-frame.tsx
@@ -21,8 +21,8 @@ import {
 } from "@/components";
 import { type Region, useEngineCompatDataProvider } from "@/components/actors";
 import { cloudEnv } from "@/lib/env";
+import { usePublishableToken } from "@/queries/accessors";
 import { queryClient } from "@/queries/global";
-import { usePublishableToken } from "../env-variables";
 import { type JoinStepSchemas, StepperForm } from "../forms/stepper-form";
 
 const { stepper } = ConnectVercelForm;

--- a/frontend/src/app/dialogs/tokens-frame.tsx
+++ b/frontend/src/app/dialogs/tokens-frame.tsx
@@ -80,7 +80,7 @@ function SecretToken() {
 	const endpoint = match(__APP_TYPE__)
 		.with("cloud", () => {
 			const region = regions.find((r) => r.id === selectedDatacenter);
-			return region?.endpoint || cloudEnv().VITE_APP_API_URL;
+			return region?.url || cloudEnv().VITE_APP_API_URL;
 		})
 		.with("engine", () => getConfig().apiUrl)
 		.otherwise(() => {

--- a/frontend/src/app/env-variables.tsx
+++ b/frontend/src/app/env-variables.tsx
@@ -1,12 +1,7 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { useRouteContext } from "@tanstack/react-router";
-import { match } from "ts-pattern";
 import { Button, CopyButton, DiscreteInput } from "@/components";
-import {
-	useEngineCompatDataProvider,
-	useEngineNamespaceDataProvider,
-} from "@/components/actors";
+import { useEngineCompatDataProvider } from "@/components/actors";
 import { Label } from "@/components/ui/label";
+import { usePublishableToken } from "@/queries/accessors";
 
 export function EnvVariables({
 	prefix,
@@ -145,28 +140,4 @@ function RivetNamespaceEnv({ prefix }: { prefix?: string }) {
 			/>
 		</>
 	);
-}
-
-export function usePublishableToken() {
-	return match(__APP_TYPE__)
-		.with("cloud", () => {
-			// biome-ignore lint/correctness/useHookAtTopLevel: guarded by the build flag
-			const routeContext = useRouteContext({
-				from: "/_context/_cloud/orgs/$organization/projects/$project/ns/$namespace/connect",
-				select: (ctx) => ctx.dataProvider,
-			});
-			// biome-ignore lint/correctness/useHookAtTopLevel: guarded by the build flag
-			return useSuspenseQuery(routeContext.publishableTokenQueryOptions())
-				.data;
-		})
-		.with("engine", () => {
-			// biome-ignore lint/correctness/useHookAtTopLevel: guarded by the build flag
-			return useSuspenseQuery(
-				// biome-ignore lint/correctness/useHookAtTopLevel: guarded by the build flag
-				useEngineNamespaceDataProvider().engineAdminTokenQueryOptions(),
-			).data;
-		})
-		.otherwise(() => {
-			throw new Error("Not in a valid context");
-		});
 }

--- a/frontend/src/queries/accessors.ts
+++ b/frontend/src/queries/accessors.ts
@@ -1,0 +1,42 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { match } from "ts-pattern";
+import { getConfig } from "@/components";
+import {
+	useCloudNamespaceDataProvider,
+	useEngineNamespaceDataProvider,
+} from "@/components/actors";
+import { cloudEnv } from "@/lib/env";
+
+export function usePublishableToken() {
+	return match(__APP_TYPE__)
+		.with("cloud", () => {
+			// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
+			return useSuspenseQuery(
+				// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
+				useCloudNamespaceDataProvider().publishableTokenQueryOptions(),
+			).data;
+		})
+		.with("engine", () => {
+			// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
+			return useSuspenseQuery(
+				// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
+				useEngineNamespaceDataProvider().engineAdminTokenQueryOptions(),
+			).data;
+		})
+		.otherwise(() => {
+			throw new Error("Not in a valid context");
+		});
+}
+
+export const useEndpoint = () => {
+	return match(__APP_TYPE__)
+		.with("cloud", () => {
+			return cloudEnv().VITE_APP_API_URL;
+		})
+		.with("engine", () => {
+			return getConfig().apiUrl;
+		})
+		.otherwise(() => {
+			throw new Error("Not in a valid context");
+		});
+};

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/connect.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/connect.tsx
@@ -15,11 +15,9 @@ import {
 import {
 	useInfiniteQuery,
 	useSuspenseInfiniteQuery,
-	useSuspenseQuery,
 } from "@tanstack/react-query";
 import {
 	createFileRoute,
-	Link,
 	notFound,
 	Link as RouterLink,
 	useParams,
@@ -36,18 +34,13 @@ import {
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
-	getConfig,
 	H1,
 	H2,
 	H3,
 	Skeleton,
 } from "@/components";
-import {
-	useCloudNamespaceDataProvider,
-	useEngineCompatDataProvider,
-	useEngineNamespaceDataProvider,
-} from "@/components/actors";
-import { cloudEnv } from "@/lib/env";
+import { useEngineCompatDataProvider } from "@/components/actors";
+import { useEndpoint, usePublishableToken } from "@/queries/accessors";
 
 export const Route = createFileRoute(
 	"/_context/_cloud/orgs/$organization/projects/$project/ns/$namespace/connect",
@@ -415,40 +408,6 @@ function Runners() {
 		</div>
 	);
 }
-
-function usePublishableToken() {
-	return match(__APP_TYPE__)
-		.with("cloud", () => {
-			// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
-			return useSuspenseQuery(
-				// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
-				useCloudNamespaceDataProvider().publishableTokenQueryOptions(),
-			).data;
-		})
-		.with("engine", () => {
-			// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
-			return useSuspenseQuery(
-				// biome-ignore lint/correctness/useHookAtTopLevel: it's okay, its guarded by build constant
-				useEngineNamespaceDataProvider().engineAdminTokenQueryOptions(),
-			).data;
-		})
-		.otherwise(() => {
-			throw new Error("Not in a valid context");
-		});
-}
-
-const useEndpoint = () => {
-	return match(__APP_TYPE__)
-		.with("cloud", () => {
-			return cloudEnv().VITE_APP_API_URL;
-		})
-		.with("engine", () => {
-			return getConfig().apiUrl;
-		})
-		.otherwise(() => {
-			throw new Error("Not in a valid context");
-		});
-};
 
 function ConnectYourFrontend() {
 	const token = usePublishableToken();

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/tokens.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/tokens.tsx
@@ -42,6 +42,7 @@ import {
 import { useEngineCompatDataProvider } from "@/components/actors";
 import { RegionSelect } from "@/components/actors/region-select";
 import { cloudEnv } from "@/lib/env";
+import { usePublishableToken } from "@/queries/accessors";
 import { queryClient } from "@/queries/global";
 
 export const Route = createFileRoute(
@@ -81,9 +82,7 @@ function RouteComponent() {
 
 function PublishableToken() {
 	const dataProvider = useEngineCompatDataProvider();
-	const { data: token, isLoading } = useQuery(
-		dataProvider.publishableTokenQueryOptions(),
-	);
+	const token = usePublishableToken();
 
 	const namespace = dataProvider.engineNamespace;
 
@@ -104,18 +103,15 @@ function PublishableToken() {
 				used either on your frontend or backend.
 			</p>
 			<div className="space-y-8">
-				{isLoading ? (
-					<Skeleton className="w-full h-10" />
-				) : (
-					<DiscreteInput value={token || ""} show />
-				)}
-				{token && (
+				<DiscreteInput value={token || ""} show />
+
+				{token ? (
 					<PublishableTokenCodeGroup
 						token={token}
 						endpoint={endpoint}
 						namespace={namespace}
 					/>
-				)}
+				) : null}
 			</div>
 		</div>
 	);
@@ -133,6 +129,8 @@ function SecretToken() {
 		string | undefined
 	>(undefined);
 
+	console.log(regions, selectedDatacenter);
+
 	// Set default datacenter when regions are loaded
 	useEffect(() => {
 		if (regions.length > 0 && !selectedDatacenter) {
@@ -145,7 +143,7 @@ function SecretToken() {
 	const endpoint = match(__APP_TYPE__)
 		.with("cloud", () => {
 			const region = regions.find((r) => r.id === selectedDatacenter);
-			return region?.endpoint || cloudEnv().VITE_APP_API_URL;
+			return region?.url || cloudEnv().VITE_APP_API_URL;
 		})
 		.with("engine", () => getConfig().apiUrl)
 		.otherwise(() => {


### PR DESCRIPTION
Closes FRONT-901

### TL;DR

Refactored token and endpoint handling, moved accessor functions to a dedicated file, and fixed type issues.

### What changed?

- Created a new `accessors.ts` file to centralize token and endpoint accessor functions
- Moved `usePublishableToken()` and `useEndpoint()` functions from component files to the new accessors file
- Fixed a type issue in `cloud-data-provider.tsx` by explicitly casting token as string
- Updated region property reference from `endpoint` to `url` in tokens-frame.tsx and tokens.tsx
- Added an unreachable return statement with proper typing in default-data-provider.tsx
- Removed duplicate accessor functions from connect.tsx
- Improved token display in the PublishableToken component

### How to test?

1. Verify that token generation and display works correctly in both cloud and engine contexts
2. Check that region selection properly updates the endpoint URL
3. Ensure that the environment variables display correctly in the connect page
4. Confirm that the publishable token is properly displayed in the tokens page

### Why make this change?

This refactoring improves code organization by centralizing accessor functions that were duplicated across multiple files. It also fixes type issues and ensures consistent handling of tokens and endpoints across the application. The changes make the codebase more maintainable and reduce duplication.