### PR TITLE
fix(cloud): use proper token when using vercel template

### DIFF
--- a/frontend/src/app/dialogs/connect-quick-vercel-frame.tsx
+++ b/frontend/src/app/dialogs/connect-quick-vercel-frame.tsx
@@ -18,6 +18,7 @@ import {
 	Frame,
 } from "@/components";
 import { type Region, useEngineCompatDataProvider } from "@/components/actors";
+import { usePublishableToken } from "@/queries/accessors";
 import { queryClient } from "@/queries/global";
 import { StepperForm } from "../forms/stepper-form";
 import { useSelectedDatacenter } from "./connect-manual-serverfull-frame";
@@ -140,9 +141,7 @@ function FormStepper({
 
 const useVercelTemplateLink = () => {
 	const dataProvider = useEngineCompatDataProvider();
-	const { data: token } = useQuery(
-		dataProvider.engineAdminTokenQueryOptions(),
-	);
+	const token = usePublishableToken();
 	const endpoint = useSelectedDatacenter();
 
 	return useMemo(() => {


### PR DESCRIPTION
Closes FRONT-899
### TL;DR

Replaced admin token query with publishable token in Vercel template link generation.

### What changed?

This PR replaces the admin token query in the `useVercelTemplateLink` hook with the `usePublishableToken` hook. The change involves:

1. Importing the `usePublishableToken` hook from `@/queries/accessors`
2. Replacing the previous `useQuery(dataProvider.engineAdminTokenQueryOptions())` call with the new `usePublishableToken()` hook

### How to test?

1. Navigate to the Vercel quick connect dialog
2. Verify that the template link is generated correctly
3. Confirm that the connection flow works as expected with the publishable token

### Why make this change?

Using a publishable token instead of an admin token is more appropriate for this use case, as it follows the principle of least privilege. The publishable token provides sufficient access for the template link generation without exposing admin-level permissions.