### PR TITLE
feat(dashboard): add button to toggle sidebar on tokens and overview pages

### DIFF
--- a/frontend/src/app/sidebar-toggle.tsx
+++ b/frontend/src/app/sidebar-toggle.tsx
@@ -1,0 +1,27 @@
+import { faSidebar, Icon } from "@rivet-gg/icons";
+import { Button, WithTooltip } from "@/components";
+import { useRootLayout } from "@/components/actors/root-layout-context";
+
+export function SidebarToggle({ className }: { className?: string }) {
+	const { isSidebarCollapsed, sidebarRef } = useRootLayout();
+
+	if (isSidebarCollapsed) {
+		return (
+			<WithTooltip
+				delayDuration={0}
+				trigger={
+					<Button
+						onClick={() => sidebarRef.current?.expand()}
+						variant="outline"
+						size="icon-sm"
+						className={className}
+					>
+						<Icon icon={faSidebar} />
+					</Button>
+				}
+				content="Show sidebar"
+			/>
+		);
+	}
+	return null;
+}

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/connect.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/connect.tsx
@@ -27,12 +27,14 @@ import { HelpDropdown } from "@/app/help-dropdown";
 import { PublishableTokenCodeGroup } from "@/app/publishable-token-code-group";
 import { RunnerConfigsTable } from "@/app/runner-config-table";
 import { RunnersTable } from "@/app/runners-table";
+import { SidebarToggle } from "@/app/sidebar-toggle";
 import {
 	Accordion,
 	AccordionContent,
 	AccordionItem,
 	AccordionTrigger,
 	Button,
+	cn,
 	DocsSheet,
 	DropdownMenu,
 	DropdownMenuContent,
@@ -46,6 +48,7 @@ import {
 	WithTooltip,
 } from "@/components";
 import { ActorRegion, useEngineCompatDataProvider } from "@/components/actors";
+import { useRootLayout } from "@/components/actors/root-layout-context";
 import { useEndpoint, usePublishableToken } from "@/queries/accessors";
 
 export const Route = createFileRoute(
@@ -90,11 +93,20 @@ export function RouteComponent() {
 	const hasRunnerConfigs =
 		runnerConfigsCount !== undefined && runnerConfigsCount > 0;
 
+	const { isSidebarCollapsed } = useRootLayout();
+
 	if (isLoading) {
 		return (
-			<div className="bg-card h-full border my-2 mr-2 rounded-lg overflow-auto">
+			<div
+				className={cn(
+					"h-full overflow-auto",
+					!isSidebarCollapsed &&
+						"border my-2 bg-card rounded-lg mr-2",
+				)}
+			>
 				<div className=" max-w-5xl mx-auto">
 					<div className="mt-2 flex justify-between items-center px-6 py-4 ">
+						<SidebarToggle className="absolute left-4" />
 						<H1>Overview</H1>
 						<HelpDropdown>
 							<Button
@@ -321,10 +333,16 @@ export function RouteComponent() {
 	}
 
 	return (
-		<div className="bg-card h-full border my-2 mr-2 rounded-lg overflow-auto @container">
+		<div
+			className={cn(
+				" h-full overflow-auto @container transition-colors",
+				!isSidebarCollapsed && "border my-2 bg-card rounded-lg mr-2",
+			)}
+		>
 			<div className=" ">
 				<div className="mb-4 pt-2 max-w-5xl mx-auto">
 					<div className="flex justify-between items-center px-6 py-4 ">
+						<SidebarToggle className="absolute left-4" />
 						<H1>Overview</H1>
 						<HelpDropdown>
 							<Button

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/tokens.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/tokens.tsx
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { match } from "ts-pattern";
 import { HelpDropdown } from "@/app/help-dropdown";
 import { PublishableTokenCodeGroup } from "@/app/publishable-token-code-group";
+import { SidebarToggle } from "@/app/sidebar-toggle";
 import { useDialog } from "@/app/use-dialog";
 import {
 	Badge,
@@ -25,6 +26,7 @@ import {
 	CodeFrame,
 	CodeGroup,
 	CodePreview,
+	cn,
 	DiscreteInput,
 	DocsSheet,
 	getConfig,
@@ -41,6 +43,7 @@ import {
 } from "@/components";
 import { useEngineCompatDataProvider } from "@/components/actors";
 import { RegionSelect } from "@/components/actors/region-select";
+import { useRootLayout } from "@/components/actors/root-layout-context";
 import { cloudEnv } from "@/lib/env";
 import { usePublishableToken } from "@/queries/accessors";
 import { queryClient } from "@/queries/global";
@@ -52,10 +55,18 @@ export const Route = createFileRoute(
 });
 
 function RouteComponent() {
+	const { isSidebarCollapsed } = useRootLayout();
+
 	return (
-		<div className="bg-card h-full border my-2 mr-2 rounded-lg overflow-auto @container">
+		<div
+			className={cn(
+				" h-full overflow-auto @container",
+				!isSidebarCollapsed && "bg-card border my-2 mr-2 rounded-lg",
+			)}
+		>
 			<div className="max-w-5xl mx-auto">
 				<div className="mt-2 flex justify-between items-center px-10 py-4">
+					<SidebarToggle className="absolute left-4" />
 					<H1>Tokens</H1>
 					<HelpDropdown>
 						<Button


### PR DESCRIPTION
Closes FRONT-814

# Add Sidebar Toggle Component

### TL;DR

Added a new `SidebarToggle` component that allows users to expand the sidebar when it's collapsed.

### What changed?

- Created a new `SidebarToggle` component in `frontend/src/app/sidebar-toggle.tsx`
- Integrated the toggle button into namespace pages (connect and tokens routes)
- Added conditional styling to adjust the layout based on sidebar state
- Positioned the toggle button in the left side of the page header

### How to test?

1. Collapse the sidebar in the application
2. Navigate to a namespace page (connect or tokens)
3. Verify the sidebar toggle button appears on the left side
4. Click the toggle button and confirm the sidebar expands
5. Verify the layout adjusts appropriately when the sidebar is collapsed/expanded

### Why make this change?

This improves the user experience by providing an easy way to expand the sidebar when it's collapsed, without having to navigate to a different part of the UI. The toggle button only appears when needed (when sidebar is collapsed) and provides a tooltip for clarity.