### PR TITLE
fix(engine): surface vercel connect form errors on any change

### DIFF
--- a/frontend/src/app/dialogs/connect-quick-vercel-frame.tsx
+++ b/frontend/src/app/dialogs/connect-quick-vercel-frame.tsx
@@ -89,6 +89,7 @@ function FormStepper({
 			{...stepper}
 			showAllSteps
 			initialStep="deploy"
+			mode="all"
 			content={{
 				"initial-info": () => <StepInitialInfo />,
 				deploy: () => <StepDeploy />,


### PR DESCRIPTION
Closes FRONT-900

### TL;DR

Added `mode="all"` to the FormStepper component in the Vercel quick connect dialog.

### What changed?

Added the `mode="all"` prop to the FormStepper component in the connect-quick-vercel-frame.tsx file. This prop will ensure that all steps in the stepper are displayed according to the specified mode.

### How to test?

1. Navigate to the Vercel quick connect dialog
2. Verify that the FormStepper displays all steps correctly
3. Confirm that the stepper behavior matches the expected "all" mode functionality

### Why make this change?

The `mode="all"` property ensures consistent display and behavior of the stepper component. This change likely fixes an issue with step visibility or improves the user experience by making all steps accessible in the Vercel connection flow.