### PR TITLE
fix(engine): prevent 404 to hang

### DIFF
--- a/frontend/src/app/data-providers/cloud-data-provider.tsx
+++ b/frontend/src/app/data-providers/cloud-data-provider.tsx
@@ -16,6 +16,7 @@ import {
 	createNamespaceContext as createEngineNamespaceContext,
 	type Namespace,
 } from "./engine-data-provider";
+import { no404Retry } from "./utilities";
 
 function createClient({ clerk }: { clerk: Clerk }) {
 	return new RivetClient({
@@ -156,6 +157,7 @@ export const createOrganizationContext = ({
 				return data.project;
 			},
 			enabled: !!opts.project,
+			...no404Retry(),
 		});
 
 	const namespaceQueryOptions = (opts: {
@@ -176,6 +178,7 @@ export const createOrganizationContext = ({
 				);
 				return data.namespace;
 			},
+			...no404Retry(),
 		});
 	};
 

--- a/frontend/src/app/data-providers/utilities.ts
+++ b/frontend/src/app/data-providers/utilities.ts
@@ -1,0 +1,27 @@
+export const no404Retry = <TError extends { statusCode?: number }>(
+	options: {
+		retry?:
+			| boolean
+			| number
+			| ((failureCount: number, error: TError) => boolean);
+	} = {},
+) => {
+	return {
+		...options,
+		retry: (failureCount: number, error: TError) => {
+			if ("statusCode" in error && error.statusCode === 404) {
+				return false;
+			}
+			if (typeof options.retry === "function") {
+				return options.retry(failureCount, error);
+			}
+			if (typeof options.retry === "boolean") {
+				return options.retry;
+			}
+			if (typeof options.retry === "number") {
+				return failureCount < options.retry;
+			}
+			return failureCount < 3; // default retry behavior
+		},
+	};
+};


### PR DESCRIPTION
Closes FRONT-888

### TL;DR

Added a utility function to prevent retrying API requests that return 404 errors.

### What changed?

- Created a new utility file `utilities.ts` with a `no404Retry` function that customizes the retry behavior for API requests
- Applied this utility to project and namespace queries in the cloud data provider to prevent unnecessary retries when resources don't exist

### How to test?

1. Try accessing a non-existent project or namespace in the cloud environment
2. Verify that the application doesn't repeatedly retry the request when a 404 is returned
3. Confirm that other error types (500, etc.) still follow the default retry behavior

### Why make this change?

When a resource doesn't exist (404 error), there's no benefit in retrying the request as the outcome won't change. This change improves application performance by avoiding unnecessary network requests and reduces console errors by preventing repeated failed attempts to fetch non-existent resources.