### PR TITLE
fix(dashboard): check runner configs when checking runner connection

### DIFF
--- a/frontend/src/app/forms/connect-manual-serverfull-form.tsx
+++ b/frontend/src/app/forms/connect-manual-serverfull-form.tsx
@@ -65,15 +65,27 @@ export const ConnectionCheck = function ConnectionCheck({
 		maxPages: Infinity,
 	});
 
+	const { data: runnerConfigs } = useInfiniteQuery({
+		...useEngineCompatDataProvider().runnerConfigsQueryOptions(),
+		refetchInterval: 1000,
+		maxPages: Infinity,
+	});
+
 	const { watch } = useFormContext();
 
 	const datacenter: string = watch("datacenter");
 	const runnerName: string = watch("runnerName");
 
-	const success = !!queryData?.find(
-		(runner) =>
-			runner.datacenter === datacenter && runner.name === runnerName,
-	);
+	const success =
+		!!queryData?.find(
+			(runner) =>
+				runner.datacenter === datacenter && runner.name === runnerName,
+		) ||
+		!!runnerConfigs?.find(
+			([id, config]) =>
+				Object.keys(config.datacenters || {}).includes(datacenter) &&
+				id === runnerName,
+		);
 
 	const {
 		field: { onChange },


### PR DESCRIPTION
Closes FRONT-885

### TL;DR

Enhanced the connection check to verify runner compatibility with both active runners and runner configurations.

### What changed?

Added a new query to fetch runner configurations using `useInfiniteQuery` with the `runnerConfigsQueryOptions()` method from the engine compatibility data provider. The connection check now considers a success if either:
1. An active runner matches the datacenter and runner name, or
2. A runner configuration exists with the specified runner name that includes the selected datacenter.

### How to test?

1. Navigate to the manual server connection form
2. Enter a datacenter and runner name
3. Verify the connection check succeeds if either:
   - An active runner with matching datacenter and name exists
   - A runner configuration with the specified name includes the selected datacenter

### Why make this change?

This improvement allows the connection check to validate against both currently active runners and configured runners that may not be active at the moment, providing a more comprehensive verification process and reducing false negatives during connection setup.