### PR TITLE
feat(dashboard): display ineligible indicator for runners when last ping ts > 15 seconds ago

### DIFF
--- a/frontend/src/app/runners-table.tsx
+++ b/frontend/src/app/runners-table.tsx
@@ -175,6 +175,25 @@ function CreateTs({ createTs }: { createTs: number }) {
 }
 
 function RunnerStatusBadge(runner: Rivet.Runner) {
+	// check if the last ping ts was higher than 15 seconds ago
+	const now = Date.now();
+	if (now - runner.lastPingTs > 15000) {
+		return (
+			<WithTooltip
+				content={`Last ping ${formatDistance(runner.lastPingTs, now, {
+					addSuffix: true,
+				})}`}
+				trigger={
+					<div className="text-center relative size-8">
+						<Icon
+							icon={faSignalAlt}
+							className="text-red-500 absolute inset-1/2 -translate-x-1/2 -translate-y-1/2"
+						/>
+					</div>
+				}
+			/>
+		);
+	}
 	if (runner.lastRtt <= 50) {
 		return (
 			<WithTooltip


### PR DESCRIPTION
Closes FRONT-845

### TL;DR

Added a network status indicator for runners with delayed ping responses.

### What changed?

Enhanced the `RunnerStatusBadge` component to display a red signal icon when a runner's last ping timestamp is more than 15 seconds old. The icon includes a tooltip showing how long ago the last ping occurred.

### How to test?

1. Navigate to the runners table
2. Observe runners with delayed ping responses (>15 seconds)
3. Verify that these runners display a red signal icon
4. Hover over the icon to confirm the tooltip shows the correct time since last ping

### Why make this change?

This change improves visibility of runner connectivity issues by clearly indicating when a runner hasn't responded recently, helping users quickly identify runners that may be experiencing network problems without having to manually check timestamps.