### PR TITLE
DOCS: Update Dead Links from Repo Name Change

### DIFF
--- a/website/src/content/docs/actors/request-handler.mdx
+++ b/website/src/content/docs/actors/request-handler.mdx
@@ -75,7 +75,7 @@ export const counterActor = actor({
 </Tab>
 </Tabs>
 
-See also the [raw fetch handler example](https://github.com/rivet-dev/rivetkit/tree/main/examples/raw-fetch-handler).
+See also the [raw fetch handler example](https://github.com/rivet-dev/rivet/tree/main/examples/raw-fetch-handler).
 
 ## Sending Requests To Actors
 
@@ -178,4 +178,3 @@ The `onRequest` handler is WinterTC compliant and will work with existing librar
 
 - [`RequestContext`](/typedoc/interfaces/rivetkit.mod.RequestContext.html) - Context for HTTP request handlers
 - [`ActorDefinition`](/typedoc/interfaces/rivetkit.mod.ActorDefinition.html) - Interface for defining request handlers
-

--- a/website/src/content/docs/actors/websocket-handler.mdx
+++ b/website/src/content/docs/actors/websocket-handler.mdx
@@ -36,7 +36,7 @@ export const chatActor = actor({
 });
 ```
 
-See also the [raw WebSocket handler example](https://github.com/rivet-dev/rivetkit/tree/main/examples/raw-websocket-handler).
+See also the [raw WebSocket handler example](https://github.com/rivet-dev/rivet/tree/main/examples/raw-websocket-handler).
 
 ## Connecting To Actors
 
@@ -153,7 +153,7 @@ app.get("/ws/:id", upgradeWebSocket(async (c) => {
 export default app;
 ```
 
-See also the [raw WebSocket handler with proxy example](https://github.com/rivet-dev/rivetkit/tree/main/examples/raw-websocket-handler-proxy).
+See also the [raw WebSocket handler with proxy example](https://github.com/rivet-dev/rivet/tree/main/examples/raw-websocket-handler-proxy).
 
 ## Connection & Lifecycle Hooks
 

--- a/website/src/content/docs/clients/next-js.mdx
+++ b/website/src/content/docs/clients/next-js.mdx
@@ -6,7 +6,7 @@ import { InstallPackage } from "@/components/docs/InstallPackage";
 The Rivet Next.js client allows you to connect to and interact with actors in Next.js applications.
 
 <CardGroup>
-<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/next-js">
+<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivet/tree/main/examples/next-js">
 	Check out the complete example
 </Card>
 <Card title="View the backend integration" icon="github" href="https://rivet.dev/docs/integrations/next-js/">

--- a/website/src/content/docs/clients/rust.mdx
+++ b/website/src/content/docs/clients/rust.mdx
@@ -79,4 +79,4 @@ The Rivet Rust client provides a way to connect to and interact with actors from
 
 ## API Reference
 
-For detailed API documentation, please refer to the [RivetKit Rust client implementation](https://github.com/rivet-dev/rivetkit/blob/main/clients/rust).
+For detailed API documentation, please refer to the [RivetKit Rust client implementation](https://github.com/rivet-dev/rivet/tree/main/rivetkit-rust/packages/client).

--- a/website/src/content/docs/connect/cloudflare-workers.mdx
+++ b/website/src/content/docs/connect/cloudflare-workers.mdx
@@ -5,13 +5,13 @@ import { faGithub } from "@rivet-gg/icons";
 Deploy your Cloudflare Workers + RivetKit app to [Cloudflare Workers](https://workers.cloudflare.com/).
 
 <CardGroup>
-<Card title="Cloudflare Workers" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/cloudflare-workers" target="_blank" icon={faGithub}>
+<Card title="Cloudflare Workers" href="https://github.com/rivet-dev/rivet/tree/main/examples/cloudflare-workers" target="_blank" icon={faGithub}>
 Minimal Cloudflare Workers + RivetKit example.
 </Card>
-<Card title="Cloudflare Workers + Hono" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/cloudflare-workers-hono" target="_blank" icon={faGithub}>
+<Card title="Cloudflare Workers + Hono" href="https://github.com/rivet-dev/rivet/tree/main/examples/cloudflare-workers-hono" target="_blank" icon={faGithub}>
 Cloudflare Workers with Hono router.
 </Card>
-<Card title="Cloudflare Workers + Inline Client" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/cloudflare-workers-inline-client" target="_blank" icon={faGithub}>
+<Card title="Cloudflare Workers + Inline Client" href="https://github.com/rivet-dev/rivet/tree/main/examples/cloudflare-workers-inline-client" target="_blank" icon={faGithub}>
 Advanced setup using createInlineClient.
 </Card>
 </CardGroup>
@@ -24,7 +24,7 @@ Advanced setup using createInlineClient.
 - [Cloudflare account](https://dash.cloudflare.com/) with Durable Objects enabled
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) v3
 - A Cloudflare Worker app integrated with RivetKit
-  - See the [Cloudflare Workers quickstart](/docs/actors/quickstart/cloudflare-workers/) or [Cloudflare Workers example](https://github.com/rivet-dev/rivetkit/tree/main/examples/cloudflare-workers) to get started
+  - See the [Cloudflare Workers quickstart](/docs/actors/quickstart/cloudflare-workers/) or [Cloudflare Workers example](https://github.com/rivet-dev/rivet/tree/main/examples/cloudflare-workers) to get started
 
 </Step>
 <Step title="Verify RivetKit integration with Cloudflare Workers">
@@ -34,7 +34,7 @@ Your project should have the following files:
 - `src/registry.ts` (or similar actor registry file)
 - `wrangler.json` with proper Durable Objects and KV namespace configuration
 
-If your project is not integrated with RivetKit yet, follow the [Cloudflare Workers quickstart guide](/docs/actors/quickstart/cloudflare-workers/) or see the [Cloudflare Workers example](https://github.com/rivet-dev/rivetkit/tree/main/examples/cloudflare-workers).
+If your project is not integrated with RivetKit yet, follow the [Cloudflare Workers quickstart guide](/docs/actors/quickstart/cloudflare-workers/) or see the [Cloudflare Workers example](https://github.com/rivet-dev/rivet/tree/main/examples/cloudflare-workers).
 </Step>
 <Step title="Deploy to Cloudflare Workers">
 

--- a/website/src/content/docs/connect/freestyle.mdx
+++ b/website/src/content/docs/connect/freestyle.mdx
@@ -5,7 +5,7 @@ Deploy RivetKit app to [Freestyle.sh](https://freestyle.sh/), a cloud platform f
 Freestyle provides built-in security for running untrusted AI-generated code, making it ideal for AI agent applications. Using Rivet, it is easy to deploy your vibe-coded or user-provided RivetKit backends straight to Freestyle.
 
 <CardGroup>
-<Card title="Freestyle + Rivet" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/freestyle" target="_blank">
+<Card title="Freestyle + Rivet" href="https://github.com/rivet-dev/rivet/tree/main/examples/freestyle" target="_blank">
 Complete example of deploying RivetKit app to Freestyle.sh.
 </Card>
 </CardGroup>

--- a/website/src/content/docs/connect/railway.mdx
+++ b/website/src/content/docs/connect/railway.mdx
@@ -13,7 +13,7 @@ If you're starting from scratch, go to the Connect tab on the Rivet dashboard an
 
 - [Railway account](https://railway.app)
 - Your RivetKit app
-  - If you don't have one, see the [Quickstart](/docs/actors/quickstart) page or our [Examples](https://github.com/rivet-dev/rivetkit/tree/main/examples)
+  - If you don't have one, see the [Quickstart](/docs/actors/quickstart) page or our [Examples](https://github.com/rivet-dev/rivet/tree/main/examples)
 - Access to the [Rivet Cloud](https://dashboard.rivet.dev/) or a [self-hosted Rivet Engine](/docs/general/self-hosting)
 
 </Step>

--- a/website/src/content/docs/connect/vercel.mdx
+++ b/website/src/content/docs/connect/vercel.mdx
@@ -6,7 +6,7 @@ import { faGithub } from "@rivet-gg/icons";
 Deploy your Next.js + RivetKit app to [Vercel](https://vercel.com/).
 
 <CardGroup>
-<Card title="View Example on GitHub" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/next-js" target="_blank" icon={faGithub}>
+<Card title="View Example on GitHub" href="https://github.com/rivet-dev/rivet/tree/main/examples/next-js" target="_blank" icon={faGithub}>
 Complete example Next.js + RivetKit app.
 </Card>
 </CardGroup>
@@ -19,7 +19,7 @@ Complete example Next.js + RivetKit app.
 - [Vercel account](https://vercel.com/)
 - Access to the [Rivet Cloud](https://dashboard.rivet.dev/) or a self-hosted [Rivet Engine](/docs/general/self-hosting)
 - A Next.js app integrated with RivetKit
-  - See the [Next.js quickstart](/docs/actors/quickstart/next-js/) or [Next.js example](https://github.com/rivet-dev/rivetkit/tree/main/examples/next-js) to get started
+  - See the [Next.js quickstart](/docs/actors/quickstart/next-js/) or [Next.js example](https://github.com/rivet-dev/rivet/tree/main/examples/next-js) to get started
   - Your project should have the following files:
     - `src/app/api/rivet/[...all]/route.ts`
     - `src/rivet/registry.ts`
@@ -48,4 +48,3 @@ Your Vercel Functions deployment is now connected to Rivet.
 </Step>
 
 </Steps>
-


### PR DESCRIPTION
My clankers were getting confused by the Next.js example not existing when I linked to some docs. Turns out there were several dead links, here's a fix :)