### PR TITLE
fix(dashboard): use ineligible icon for runners

### DIFF
--- a/frontend/src/app/runners-table.tsx
+++ b/frontend/src/app/runners-table.tsx
@@ -1,4 +1,5 @@
 import {
+	faExclamationTriangle,
 	faPlus,
 	faSignalAlt,
 	faSignalAlt2,
@@ -180,13 +181,15 @@ function RunnerStatusBadge(runner: Rivet.Runner) {
 	if (now - runner.lastPingTs > 15000) {
 		return (
 			<WithTooltip
-				content={`Last ping ${formatDistance(runner.lastPingTs, now, {
-					addSuffix: true,
-				})}`}
+				content={`Offline (last seen ${formatDistance(
+					runner.lastPingTs,
+					now,
+					{ addSuffix: true },
+				)})`}
 				trigger={
 					<div className="text-center relative size-8">
 						<Icon
-							icon={faSignalAlt}
+							icon={faExclamationTriangle}
 							className="text-red-500 absolute inset-1/2 -translate-x-1/2 -translate-y-1/2"
 						/>
 					</div>


### PR DESCRIPTION
### TL;DR

Updated the offline runner status indicator to use a warning triangle icon with improved tooltip text.

### What changed?

- Imported `faExclamationTriangle` icon from Font Awesome
- Changed the offline runner status icon from `faSignalAlt` to `faExclamationTriangle`
- Updated the tooltip text from "Last ping X time ago" to "Offline (last seen X time ago)" for better clarity

### How to test?

1. Navigate to the runners table view
2. Wait for a runner to go offline (or simulate an offline runner)
3. Verify that the offline runner now displays a warning triangle icon instead of the signal icon
4. Hover over the icon to confirm the tooltip now shows "Offline (last seen X time ago)"

### Why make this change?

The warning triangle icon more clearly communicates an error state compared to the previous signal icon. The updated tooltip text also explicitly states that the runner is offline, making the status more immediately understandable to users.