### PR TITLE
feat(dashboard): surface actor errors in ui

### DIFF
--- a/frontend/src/app/data-providers/default-data-provider.tsx
+++ b/frontend/src/app/data-providers/default-data-provider.tsx
@@ -189,9 +189,17 @@ const defaultContext = {
 	actorStatusAdditionalInfoQueryOptions(actorId: ActorId) {
 		return queryOptions({
 			...this.actorQueryOptions(actorId),
-			select: ({ rescheduleAt }) => ({
+			select: ({ rescheduleAt, error }) => ({
 				rescheduleAt,
+				error,
 			}),
+		});
+	},
+
+	actorErrorQueryOptions(actorId: ActorId) {
+		return queryOptions({
+			...this.actorQueryOptions(actorId),
+			select: (data) => data.error,
 		});
 	},
 

--- a/frontend/src/app/data-providers/engine-data-provider.tsx
+++ b/frontend/src/app/data-providers/engine-data-provider.tsx
@@ -697,6 +697,7 @@ function transformActor(a: Rivet.Actor): Actor {
 		rescheduleAt: a.rescheduleTs
 			? new Date(a.rescheduleTs).toISOString()
 			: undefined,
+		error: a.error,
 		features: [
 			ActorFeature.Config,
 			ActorFeature.Connections,

--- a/frontend/src/app/runner-config-table.tsx
+++ b/frontend/src/app/runner-config-table.tsx
@@ -28,7 +28,7 @@ import {
 	Text,
 	WithTooltip,
 } from "@/components";
-import { ActorRegion } from "@/components/actors";
+import { ActorRegion, RunnerPoolError } from "@/components/actors";
 import { REGION_LABEL } from "@/components/matchmaker/lobby-region";
 import { hasMetadataProvider } from "./data-providers/engine-data-provider";
 
@@ -256,48 +256,7 @@ function Row({
 	);
 }
 
-function RunnerPoolError({
-	error,
-}: {
-	error: Rivet.RunnerPoolError | undefined;
-}) {
-	return match(error)
-		.with(P.nullish, () => null)
-		.with(P.string, (errStr) =>
-			match(errStr)
-				.with(
-					"internal_error",
-					() => "Internal error occurred in runner pool",
-				)
-				.with(
-					"serverless_invalid_base64",
-					() => "Invalid base64 encoding in serverless response",
-				)
-				.with(
-					"serverless_stream_ended_early",
-					() => "Connection terminated unexpectedly",
-				)
-				.otherwise(() => "Unknown runner pool error"),
-		)
-		.with(P.shape({ serverlessHttpError: P.any }), (errObj) => {
-			const { statusCode, body } = errObj.serverlessHttpError;
-			const code = statusCode ?? "unknown";
-			return body ? `HTTP ${code} error: ${body}` : `HTTP ${code} error`;
-		})
-		.with(P.shape({ serverlessConnectionError: P.any }), (errObj) => {
-			const message = errObj.serverlessConnectionError?.message;
-			return message
-				? `Connection failed: ${message}`
-				: "Unable to connect to serverless endpoint";
-		})
-		.with(P.shape({ serverlessInvalidPayload: P.any }), (errObj) => {
-			const message = errObj.serverlessInvalidPayload?.message;
-			return message
-				? `Invalid request payload: ${message}`
-				: "Request payload validation failed";
-		})
-		.otherwise(() => "Unexpected runner pool error");
-}
+
 
 function StatusCell({
 	errors,

--- a/frontend/src/components/actors/queries/index.ts
+++ b/frontend/src/components/actors/queries/index.ts
@@ -1,3 +1,4 @@
+import type { Rivet } from "@rivetkit/engine-api-full";
 import type { Actor as InspectorActor } from "rivetkit/inspector";
 
 export type { ActorLogEntry } from "rivetkit/inspector";
@@ -64,6 +65,7 @@ export type Actor = Omit<InspectorActor, "id" | "key"> & {
 	pendingAllocationAt?: string | null;
 	datacenter?: string | null;
 	rescheduleAt?: string | null;
+	error?: Rivet.ActorError | null;
 } & { id: ActorId };
 
 export enum CrashPolicy {
@@ -110,6 +112,7 @@ export function getActorStatus(
 		| "sleepingAt"
 		| "pendingAllocationAt"
 		| "rescheduleAt"
+		| "error"
 	>,
 ): ActorStatus {
 	const {
@@ -119,7 +122,12 @@ export function getActorStatus(
 		sleepingAt,
 		pendingAllocationAt,
 		rescheduleAt,
+		error,
 	} = actor;
+
+	if (error) {
+		return "crashed";
+	}
 
 	if (rescheduleAt) {
 		return "crash-loop";


### PR DESCRIPTION
### TL;DR

Added error handling and display for Actors in the frontend UI.

### What changed?

- Added `error` field to Actor data structure and query options
- Created new `actorErrorQueryOptions` for retrieving Actor errors
- Moved `RunnerPoolError` component from runner-config-table to actor-status-label for reuse
- Added `ActorError` component to display different types of Actor errors
- Updated `GuardConnectableInspector` to show appropriate error messages based on Actor status
- Changed "Stopped" status label to "Destroyed" for better clarity
- Enhanced Actor status determination to consider error state as "crashed"

### How to test?

1. Create an Actor that encounters an error (e.g., by configuring an invalid serverless endpoint)
2. Observe the error message displayed in the Actor UI
3. Verify different error types are properly formatted and displayed
4. Check that the Actor status correctly shows as "Crashed" when an error is present

### Why make this change?

This change improves the developer experience by providing clearer feedback when Actors fail to start or encounter errors. Previously, error information was limited, making it difficult to diagnose issues. Now, specific error messages are displayed based on the error type, helping users understand and resolve problems more efficiently.