### PR TITLE
fix(dashboard): change serverfull token to admin

### DIFF
--- a/frontend/src/app/dialogs/connect-manual-serverfull-frame.tsx
+++ b/frontend/src/app/dialogs/connect-manual-serverfull-frame.tsx
@@ -222,6 +222,7 @@ function Step2({ provider }: { provider: string }) {
 				))}
 
 			<EnvVariables
+				kind="serverfull"
 				endpoint={useSelectedDatacenter()}
 				runnerName={useWatch({ name: "runnerName" })}
 			/>

--- a/frontend/src/app/dialogs/connect-manual-serverless-frame.tsx
+++ b/frontend/src/app/dialogs/connect-manual-serverless-frame.tsx
@@ -202,6 +202,7 @@ function Step2() {
 		<>
 			<p>Set the following environment variables.</p>
 			<EnvVariables
+				kind="serverless"
 				endpoint={useSelectedDatacenter()}
 				runnerName={useWatch({ name: "runnerName" })}
 			/>

--- a/frontend/src/app/dialogs/connect-railway-frame.tsx
+++ b/frontend/src/app/dialogs/connect-railway-frame.tsx
@@ -186,6 +186,7 @@ function Step2() {
 				settings.
 			</p>
 			<EnvVariables
+				kind="serverfull"
 				endpoint={useSelectedDatacenter()}
 				runnerName={useWatch({ name: "runnerName" })}
 			/>

--- a/frontend/src/app/env-variables.tsx
+++ b/frontend/src/app/env-variables.tsx
@@ -1,16 +1,18 @@
 import { Button, CopyButton, DiscreteInput } from "@/components";
 import { useEngineCompatDataProvider } from "@/components/actors";
 import { Label } from "@/components/ui/label";
-import { usePublishableToken } from "@/queries/accessors";
+import { useAdminToken, usePublishableToken } from "@/queries/accessors";
 
 export function EnvVariables({
 	prefix,
 	runnerName,
 	endpoint,
+	kind,
 }: {
 	prefix?: string;
 	runnerName?: string;
 	endpoint: string;
+	kind: "serverless" | "serverfull";
 }) {
 	return (
 		<div>
@@ -25,7 +27,7 @@ export function EnvVariables({
 					<p>Value</p>
 				</Label>
 				<RivetEndpointEnv prefix={prefix} endpoint={endpoint} />
-				<RivetTokenEnv prefix={prefix} />
+				<RivetTokenEnv prefix={prefix} kind={kind} />
 				<RivetNamespaceEnv prefix={prefix} />
 				<RivetRunnerEnv prefix={prefix} runnerName={runnerName} />
 			</div>
@@ -82,8 +84,16 @@ function RivetRunnerEnv({
 	);
 }
 
-function RivetTokenEnv({ prefix }: { prefix?: string }) {
-	const data = usePublishableToken();
+function RivetTokenEnv({
+	prefix,
+	kind,
+}: {
+	prefix?: string;
+	kind: "serverless" | "serverfull";
+}) {
+	const publishableToken = usePublishableToken();
+	const adminToken = useAdminToken();
+
 	return (
 		<>
 			<DiscreteInput
@@ -94,7 +104,10 @@ function RivetTokenEnv({ prefix }: { prefix?: string }) {
 
 			<DiscreteInput
 				aria-label="environment variable value"
-				value={(data as string) || ""}
+				value={
+					(kind === "serverless" ? publishableToken : adminToken) ||
+					""
+				}
 				show
 			/>
 		</>

--- a/frontend/src/app/forms/connect-vercel-form.tsx
+++ b/frontend/src/app/forms/connect-vercel-form.tsx
@@ -295,6 +295,7 @@ export function EnvVariables() {
 		<EnvVariablesSection
 			prefix="NEXT_PUBLIC"
 			endpoint={useSelectedDatacenter()}
+			kind="serverless"
 			runnerName={useWatch({ name: "runnerName" }) as string}
 		/>
 	);

--- a/frontend/src/queries/accessors.ts
+++ b/frontend/src/queries/accessors.ts
@@ -3,6 +3,7 @@ import { match } from "ts-pattern";
 import { getConfig } from "@/components";
 import {
 	useCloudNamespaceDataProvider,
+	useEngineCompatDataProvider,
 	useEngineNamespaceDataProvider,
 } from "@/components/actors";
 import { cloudEnv } from "@/lib/env";
@@ -26,6 +27,12 @@ export function usePublishableToken() {
 		.otherwise(() => {
 			throw new Error("Not in a valid context");
 		});
+}
+
+export function useAdminToken() {
+	return useSuspenseQuery(
+		useEngineCompatDataProvider().engineAdminTokenQueryOptions(),
+	).data;
 }
 
 export const useEndpoint = () => {


### PR DESCRIPTION
### TL;DR

Added token type differentiation for environment variables based on deployment kind (serverless vs. serverfull).

### What changed?

- Added a new `kind` prop to the `EnvVariables` component to distinguish between "serverless" and "serverfull" deployments
- Modified the `RivetTokenEnv` component to use different tokens based on the deployment kind:
  - For "serverless" deployments, it uses the publishable token
  - For "serverfull" deployments, it uses the admin token
- Added a new `useAdminToken` hook to access the admin token from the engine compatibility data provider
- Updated all instances of `EnvVariables` component usage to include the appropriate `kind` prop

### How to test?

1. Navigate to different connection dialogs (manual serverfull, manual serverless, Railway, Vercel)
2. Verify that serverless deployments show the publishable token
3. Verify that serverfull deployments show the admin token
4. Ensure environment variables are correctly displayed in all connection flows

### Why make this change?

This change ensures that the correct token type is provided in environment variables based on the deployment architecture. Serverless deployments should use the publishable token for security reasons, while serverfull deployments need the admin token for full functionality. This differentiation improves the security posture and ensures proper operation of connected services.