### PR TITLE
feat(dashboard): prefetch daa for context switcher

### DIFF
--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/tokens.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/tokens.tsx
@@ -140,8 +140,6 @@ function SecretToken() {
 		string | undefined
 	>(undefined);
 
-	console.log(regions, selectedDatacenter);
-
 	// Set default datacenter when regions are loaded
 	useEffect(() => {
 		if (regions.length > 0 && !selectedDatacenter) {


### PR DESCRIPTION
### TL;DR

Added prefetching for projects and namespaces in the context switcher to improve navigation performance.

### What changed?

- Added `usePrefetchInfiniteQuery` for projects when viewing an organization
- Refactored `ProjectList` to extract a `ProjectListItem` component
- Added prefetching for namespaces when hovering over a project
- Removed unnecessary `clerk.setActive` call during project navigation
- Removed a debug console.log statement in the tokens page

### How to test?

1. Navigate between organizations and observe smoother transitions when opening the context switcher
2. Hover over projects in the context switcher and verify that navigating to them feels faster
3. Verify that project navigation still works correctly without the `clerk.setActive` call

### Why make this change?

This change improves the user experience by prefetching data that will likely be needed soon. By prefetching projects when viewing an organization and namespaces when hovering over a project, we reduce loading times and create a more responsive interface when users navigate through the application.