### PR TITLE
feat(dashboard): editable serverless configs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -116,6 +116,7 @@
 		"react": "^19.1.1",
 		"react-day-picker": "8.10.1",
 		"react-dom": "^19.1.1",
+		"react-error-boundary": "^6.0.3",
 		"react-hook-form": "^7.62.0",
 		"react-inspector": "^6.0.2",
 		"react-resizable-panels": "^2.1.9",

--- a/frontend/src/app/data-providers/engine-data-provider.tsx
+++ b/frontend/src/app/data-providers/engine-data-provider.tsx
@@ -646,7 +646,10 @@ export const createNamespaceContext = ({
 					const config = response.runnerConfigs[opts.name!];
 
 					if (!config) {
-						throw new Error("Runner config not found");
+						throw new FetchError(
+							"Provider Config not found",
+							"The specified provider configuration could not be found.",
+						);
 					}
 
 					return config;
@@ -673,6 +676,15 @@ export const createNamespaceContext = ({
 		},
 	};
 };
+
+class FetchError extends Error {
+	constructor(
+		message: string,
+		public description: string,
+	) {
+		super(message);
+	}
+}
 
 function transformActor(a: Rivet.Actor): Actor {
 	return {

--- a/frontend/src/app/dialogs/connect-manual-frame.tsx
+++ b/frontend/src/app/dialogs/connect-manual-frame.tsx
@@ -7,6 +7,7 @@ import {
 	ToggleGroup,
 	ToggleGroupItem,
 } from "@/components";
+import { RunnerConfigToggleGroup } from "../runner-config-toggle-group";
 import ConnectManualServerlfullFrameContent from "./connect-manual-serverfull-frame";
 import ConnectManualServerlessFrameContent from "./connect-manual-serverless-frame";
 
@@ -27,33 +28,7 @@ export default function CreateProjectFrameContent({
 				</Frame.Title>
 			</Frame.Header>
 			<Frame.Content>
-				<div className="flex mx-auto items-center justify-center">
-					<ToggleGroup
-						defaultValue="serverfull"
-						type="single"
-						className="border rounded-md gap-0"
-						value={mode}
-						onValueChange={(mode) => {
-							if (!mode) {
-								return;
-							}
-							setMode(mode);
-						}}
-					>
-						<ToggleGroupItem
-							value="serverless"
-							className="rounded-none"
-						>
-							Serverless
-						</ToggleGroupItem>
-						<ToggleGroupItem
-							value="serverfull"
-							className="border-l rounded-none"
-						>
-							Server
-						</ToggleGroupItem>
-					</ToggleGroup>
-				</div>
+				<RunnerConfigToggleGroup mode={mode} onChange={setMode} />
 				{mode === "serverless" ? (
 					<ConnectManualServerlessFrameContent onClose={onClose} />
 				) : null}

--- a/frontend/src/app/dialogs/edit-runner-config.tsx
+++ b/frontend/src/app/dialogs/edit-runner-config.tsx
@@ -1,12 +1,40 @@
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import * as EditRunnerConfigForm from "@/app/forms/edit-runner-config-form";
-import { type DialogContentProps, Frame } from "@/components";
-import { useEngineCompatDataProvider } from "@/components/actors";
+import type { Rivet } from "@rivetkit/engine-api-full";
+import {
+	useMutation,
+	useSuspenseInfiniteQuery,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useFormContext } from "react-hook-form";
+import * as EditRunnerConfigForm from "@/app/forms/edit-shared-runner-config-form";
+import * as EditSingleRunnerConfigForm from "@/app/forms/edit-single-runner-config-form";
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+	Combobox,
+	type DialogContentProps,
+	Frame,
+	ToggleGroup,
+	ToggleGroupItem,
+} from "@/components";
+import { ActorRegion, useEngineCompatDataProvider } from "@/components/actors";
 import { queryClient } from "@/queries/global";
+
+const defaultServerlessConfig: Rivet.RunnerConfigServerless = {
+	url: "",
+	maxRunners: 10,
+	minRunners: 0,
+	requestLifespan: 300,
+	runnersMargin: 2,
+	slotsPerRunner: 1,
+	headers: {},
+};
 
 interface EditRunnerConfigFrameContentProps extends DialogContentProps {
 	name: string;
-	dc: string;
+	dc?: string;
 }
 
 export default function EditRunnerConfigFrameContent({
@@ -20,6 +48,92 @@ export default function EditRunnerConfigFrameContent({
 		...provider.runnerConfigQueryOptions({ name }),
 	});
 
+	const isSharedSettings = useMemo(() => {
+		const configs = Object.values(data.datacenters).map((dc) =>
+			JSON.stringify(dc.serverless || {}),
+		);
+		return configs.every((config) => config === configs[0]);
+	}, [data.datacenters]);
+
+	const [settingsMode, setSettingsMode] = useState(
+		isSharedSettings ? "shared" : "datacenter",
+	);
+
+	return (
+		<Frame.Content className="gap-4 flex flex-col">
+			<Frame.Header>
+				<Frame.Title className="justify-between flex items-center">
+					Edit '{name}' Provider
+				</Frame.Title>
+			</Frame.Header>
+
+			<div>
+				<SharedSettingsToggleGroup
+					value={settingsMode}
+					onChange={setSettingsMode}
+				/>
+			</div>
+
+			<div className="gap-4 flex flex-col">
+				{settingsMode === "shared" ? (
+					<>
+						<div className="text-sm text-muted-foreground mb-2">
+							These settings will apply to all datacenters.
+						</div>
+						<SharedSettingsForm name={name} onClose={onClose} />
+					</>
+				) : null}
+
+				{settingsMode === "datacenter" ? (
+					<DatacenterSettingsForm name={name} onClose={onClose} />
+				) : null}
+			</div>
+		</Frame.Content>
+	);
+}
+
+function SharedSettingsToggleGroup({
+	value,
+	onChange,
+}: {
+	value: string;
+	onChange: (mode: string) => void;
+}) {
+	return (
+		<ToggleGroup
+			defaultValue="shared"
+			type="single"
+			className="border rounded-md gap-0"
+			value={value}
+			onValueChange={(mode) => {
+				if (!mode) {
+					return;
+				}
+				onChange(mode);
+			}}
+		>
+			<ToggleGroupItem value="shared" className="rounded-none w-full">
+				Global Settings
+			</ToggleGroupItem>
+			<ToggleGroupItem
+				value="datacenter"
+				className="border-l rounded-none w-full"
+			>
+				Per Datacenter Settings
+			</ToggleGroupItem>
+		</ToggleGroup>
+	);
+}
+
+function SharedSettingsForm({
+	onClose,
+	name,
+}: {
+	onClose?: () => void;
+	name: string;
+}) {
+	const provider = useEngineCompatDataProvider();
+
 	const { mutateAsync } = useMutation({
 		...provider.upsertRunnerConfigMutationOptions(),
 		onSuccess: () => {
@@ -27,40 +141,42 @@ export default function EditRunnerConfigFrameContent({
 		},
 	});
 
-	const datacenters = data.datacenters;
-	const config = datacenters?.[dc].serverless;
+	const { data } = useSuspenseQuery({
+		...provider.runnerConfigQueryOptions({ name }),
+	});
 
-	if (!config) {
-		return (
-			<Frame.Content>
-				Selected provider config is not available in this datacenter.
-			</Frame.Content>
-		);
-	}
+	const currentConfig = Object.values(data.datacenters).find(
+		(dc): dc is { serverless: Rivet.RunnerConfigServerless } =>
+			!!dc.serverless,
+	) || {
+		serverless: defaultServerlessConfig,
+	};
 
 	return (
 		<EditRunnerConfigForm.Form
-			onSubmit={async (values) => {
+			onSubmit={async ({ regions, ...values }) => {
 				const config = {
-					...(datacenters[dc] || {}),
+					...(currentConfig || {}),
 					serverless: {
 						...values,
 						headers: Object.fromEntries(values.headers || []),
 					},
 				};
 
-				const otherDcs = Object.entries(datacenters)
-					.filter(([k]) => k !== dc)
-					.filter(([k, v]) => v.serverless)
-					.map(([k, v]) => [k, config]);
+				const providerConfig: Record<string, typeof config> = {};
+
+				const selectedRegions = regions || {};
+				for (const [regionId, isSelected] of Object.entries(
+					selectedRegions,
+				)) {
+					if (isSelected) {
+						providerConfig[regionId] = config;
+					}
+				}
 
 				await mutateAsync({
 					name,
-					config: {
-						...(datacenters || {}),
-						[dc]: config,
-						...Object.fromEntries(otherDcs),
-					},
+					config: providerConfig,
 				});
 
 				await queryClient.invalidateQueries(
@@ -72,38 +188,242 @@ export default function EditRunnerConfigFrameContent({
 				onClose?.();
 			}}
 			defaultValues={{
-				url: config.url,
-				maxRunners: config.maxRunners,
-				minRunners: config.minRunners,
-				requestLifespan: config.requestLifespan,
-				runnersMargin: config.runnersMargin,
-				slotsPerRunner: config.slotsPerRunner,
+				url: currentConfig.serverless.url,
+				maxRunners: currentConfig.serverless.maxRunners,
+				minRunners: currentConfig.serverless.minRunners,
+				requestLifespan: currentConfig.serverless.requestLifespan,
+				runnersMargin: currentConfig.serverless.runnersMargin,
+				slotsPerRunner: currentConfig.serverless.slotsPerRunner,
+				headers: Object.entries(
+					currentConfig.serverless.headers || {},
+				).map(([key, value]) => [key, value]),
+				regions: Object.fromEntries(
+					Object.keys(data.datacenters).map((dcId) => [
+						dcId,
+						!!data.datacenters[dcId],
+					]),
+				),
 			}}
 		>
-			<Frame.Header>
-				<Frame.Title className="justify-between flex items-center">
-					Edit {name} Provider
-				</Frame.Title>
-			</Frame.Header>
-			<Frame.Content className="space-y-4">
-				<EditRunnerConfigForm.Url />
+			<EditRunnerConfigForm.Url />
+			<div className="grid grid-cols-2 gap-2">
+				<EditRunnerConfigForm.MinRunners />
+				<EditRunnerConfigForm.MaxRunners />
+			</div>
+			<div className="grid grid-cols-2 gap-2">
+				<EditRunnerConfigForm.RequestLifespan />
+				<EditRunnerConfigForm.SlotsPerRunner />
+			</div>
+
+			<EditRunnerConfigForm.RunnersMargin />
+			<EditRunnerConfigForm.Headers />
+			<EditRunnerConfigForm.Regions />
+			<div className="flex justify-end mt-4">
+				<EditRunnerConfigForm.Submit allowPristine>Save</EditRunnerConfigForm.Submit>
+			</div>
+		</EditRunnerConfigForm.Form>
+	);
+}
+
+function DatacenterSettingsForm({
+	onClose,
+	name,
+}: {
+	onClose?: () => void;
+	name: string;
+}) {
+	const provider = useEngineCompatDataProvider();
+
+	const { data: datacenters } = useSuspenseInfiniteQuery({
+		...provider.regionsQueryOptions(),
+		maxPages: Infinity,
+	});
+
+	const { mutateAsync } = useMutation({
+		...provider.upsertRunnerConfigMutationOptions(),
+		onSuccess: () => {
+			onClose?.();
+		},
+	});
+
+	const { data } = useSuspenseQuery({
+		...provider.runnerConfigQueryOptions({ name }),
+	});
+
+	return (
+		<EditSingleRunnerConfigForm.Form
+			defaultValues={{
+				datacenters: Object.fromEntries(
+					Object.values(datacenters).map((dc) => [
+						dc.id,
+						{
+							...(data.datacenters[dc.id]?.serverless ||
+								defaultServerlessConfig),
+							enable: !!data.datacenters[dc.id]?.serverless,
+							headers: Object.entries(
+								data.datacenters[dc.id]?.serverless?.headers ||
+									{},
+							).map(([key, value]) => [key, value]),
+						},
+					]),
+				),
+			}}
+			onSubmit={async (values) => {
+				const providerConfig: Record<
+					string,
+					{ serverless: Rivet.RunnerConfigServerless }
+				> = {};
+
+				for (const [dcId, dcConfig] of Object.entries(
+					values.datacenters || {},
+				)) {
+					if (dcConfig?.enable) {
+						const { enable, headers, ...rest } = dcConfig;
+						providerConfig[dcId] = {
+							...(data.datacenters[dcId] || {}),
+							serverless: {
+								...rest,
+								headers: Object.fromEntries(headers || []),
+							},
+						};
+					}
+				}
+
+				await mutateAsync({
+					name,
+					config: providerConfig,
+				});
+
+				await queryClient.invalidateQueries(
+					provider.runnerConfigsQueryOptions(),
+				);
+				await queryClient.invalidateQueries(
+					provider.runnerConfigQueryOptions({ name }),
+				);
+				onClose?.();
+			}}
+		>
+			<Accordion type="multiple" className="w-full">
+				{datacenters.map((dc) => (
+					<DatacenterAccordion
+						key={dc.id}
+						regionId={dc.id}
+						name={name}
+					/>
+				))}
+			</Accordion>
+
+			<EditSingleRunnerConfigForm.Datacenters />
+
+			<div className="flex justify-end mt-4">
+				<EditSingleRunnerConfigForm.Submit allowPristine>
+					Save
+				</EditSingleRunnerConfigForm.Submit>
+			</div>
+		</EditSingleRunnerConfigForm.Form>
+	);
+}
+
+function DatacenterAccordion({
+	regionId,
+	name,
+}: {
+	regionId: string;
+	name: string;
+}) {
+	return (
+		<AccordionItem value={regionId} className="-mx-2">
+			<AccordionTrigger className="mx-2">
+				<div className="flex items-center gap-4">
+					<EditSingleRunnerConfigForm.Enable
+						name={`datacenters.${regionId}.enable`}
+					/>
+					<ActorRegion regionId={regionId} showLabel />
+				</div>
+			</AccordionTrigger>
+			<AccordionContent className="flex flex-col gap-4 text-balance px-2">
+				<SelectDatacenterSettingsSource
+					name={name}
+					currentRegionId={regionId}
+				/>
+
+				<EditSingleRunnerConfigForm.Url
+					name={`datacenters.${regionId}.url`}
+				/>
 				<div className="grid grid-cols-2 gap-2">
-					<EditRunnerConfigForm.MinRunners />
-					<EditRunnerConfigForm.MaxRunners />
+					<EditSingleRunnerConfigForm.MinRunners
+						name={`datacenters.${regionId}.minRunners`}
+					/>
+					<EditSingleRunnerConfigForm.MaxRunners
+						name={`datacenters.${regionId}.maxRunners`}
+					/>
 				</div>
 				<div className="grid grid-cols-2 gap-2">
-					<EditRunnerConfigForm.RequestLifespan />
-					<EditRunnerConfigForm.SlotsPerRunner />
+					<EditSingleRunnerConfigForm.RequestLifespan
+						name={`datacenters.${regionId}.requestLifespan`}
+					/>
+					<EditSingleRunnerConfigForm.SlotsPerRunner
+						name={`datacenters.${regionId}.slotsPerRunner`}
+					/>
 				</div>
 
-				<EditRunnerConfigForm.RunnersMargin />
-				<EditRunnerConfigForm.Headers />
-				<div className="flex justify-end mt-4">
-					<EditRunnerConfigForm.Submit>
-						Save
-					</EditRunnerConfigForm.Submit>
-				</div>
-			</Frame.Content>
-		</EditRunnerConfigForm.Form>
+				<EditSingleRunnerConfigForm.RunnersMargin
+					name={`datacenters.${regionId}.runnersMargin`}
+				/>
+				<EditSingleRunnerConfigForm.Headers
+					name={`datacenters.${regionId}.headers`}
+				/>
+			</AccordionContent>
+		</AccordionItem>
+	);
+}
+
+function SelectDatacenterSettingsSource({
+	currentRegionId,
+	name,
+}: {
+	currentRegionId: string;
+	name: string;
+}) {
+	const form = useFormContext();
+	const provider = useEngineCompatDataProvider();
+
+	const { data: datacenters } = useSuspenseInfiniteQuery({
+		...provider.regionsQueryOptions(),
+		maxPages: Infinity,
+	});
+
+	const { data: runnerConfig } = useSuspenseQuery({
+		...provider.runnerConfigQueryOptions({ name }),
+	});
+
+	const availableDatacenters = datacenters.filter(
+		(dc) => dc.id !== currentRegionId && runnerConfig.datacenters[dc.id],
+	);
+
+	if (availableDatacenters.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="flex gap-2 items-center text-muted-foreground">
+			Copy settings from
+			<Combobox
+				onValueChange={(selectedRegionId) => {
+					form.setValue(
+						`datacenters.${currentRegionId}`,
+						form.getValues(`datacenters.${selectedRegionId}`),
+						{ shouldDirty: true, shouldTouch: true },
+					);
+				}}
+				value={undefined}
+				placeholder="Select datacenter"
+				className="w-auto min-w-[200px]"
+				options={availableDatacenters.map((dc) => ({
+					value: dc.id,
+					label: <ActorRegion regionId={dc.id} showLabel />,
+				}))}
+			/>
+		</div>
 	);
 }

--- a/frontend/src/app/forms/edit-single-runner-config-form.tsx
+++ b/frontend/src/app/forms/edit-single-runner-config-form.tsx
@@ -1,0 +1,61 @@
+import { FieldPath, useFormContext, type UseFormReturn } from "react-hook-form";
+import z from "zod";
+import { Checkbox, createSchemaForm, FormField, FormMessage } from "@/components";
+import * as SingleRunnerConfigForm from "./edit-shared-runner-config-form";
+
+export const formSchema = z.object({
+	datacenters: z
+		.record(
+			z.string(),
+			SingleRunnerConfigForm.formSchema.omit({ regions: true }).and(z.object({enable: z.boolean().optional()})).optional(),
+		)
+		.optional()
+		.refine((obj) => {
+			return Object.values(obj || {}).some((dcConfig) => dcConfig?.enable);
+		}, "At least one datacenter must be enabled."),
+});
+
+export type FormValues = z.infer<typeof formSchema>;
+export type SubmitHandler = (
+	values: FormValues,
+	form: UseFormReturn<FormValues>,
+) => Promise<void>;
+
+const { Form, Submit, SetValue } = createSchemaForm(formSchema);
+export { Form, Submit, SetValue };
+
+export const Enable = <TValues extends Record<string, any> = FormValues>({name}: {name: FieldPath<TValues>;}) => {
+	const { control } = useFormContext<FormValues>();
+	return <FormField
+		control={control}
+		name={name as FieldPath<FormValues>}
+		render={({ field }) => (
+			<Checkbox 
+				onClick={(e) => {
+					e.stopPropagation()
+				}}
+				checked={field.value as unknown as boolean ?? false}
+				name={field.name}
+				onCheckedChange={field.onChange}
+			/>
+		)}
+	/>;
+}
+
+export const Datacenters = () => {
+	const { control } = useFormContext<FormValues>();
+	return <FormField
+		control={control}
+		name="datacenters"
+		render={() => <FormMessage />}
+	/>
+}
+
+export const Url = SingleRunnerConfigForm.Url<FormValues>;
+export const MaxRunners = SingleRunnerConfigForm.MaxRunners<FormValues>;
+export const MinRunners = SingleRunnerConfigForm.MinRunners<FormValues>;
+export const RequestLifespan =
+	SingleRunnerConfigForm.RequestLifespan<FormValues>;
+export const RunnersMargin = SingleRunnerConfigForm.RunnersMargin<FormValues>;
+export const SlotsPerRunner = SingleRunnerConfigForm.SlotsPerRunner<FormValues>;
+export const Headers = SingleRunnerConfigForm.Headers<FormValues>;

--- a/frontend/src/app/runner-config-toggle-group.tsx
+++ b/frontend/src/app/runner-config-toggle-group.tsx
@@ -1,0 +1,49 @@
+import { cn, ToggleGroup, ToggleGroupItem } from "@/components";
+
+export function RunnerConfigToggleGroup({
+	mode,
+	id,
+	onChange,
+	className,
+}: {
+	id?: string;
+	mode: string;
+	onChange: (mode: string) => void;
+	className?: string;
+}) {
+	return (
+		<div
+			id={id}
+			className={cn(
+				"flex mx-auto items-center justify-center",
+				className,
+			)}
+		>
+			<ToggleGroup
+				defaultValue="serverfull"
+				type="single"
+				className="border rounded-md gap-0 w-full"
+				value={mode}
+				onValueChange={(mode) => {
+					if (!mode) {
+						return;
+					}
+					onChange(mode);
+				}}
+			>
+				<ToggleGroupItem
+					value="serverless"
+					className="rounded-none w-full"
+				>
+					Serverless
+				</ToggleGroupItem>
+				<ToggleGroupItem
+					value="serverfull"
+					className="border-l rounded-none w-full"
+				>
+					Dedicated
+				</ToggleGroupItem>
+			</ToggleGroup>
+		</div>
+	);
+}

--- a/frontend/src/app/runners-table.tsx
+++ b/frontend/src/app/runners-table.tsx
@@ -1,5 +1,5 @@
 import {
-	faExclamationTriangle,
+	faHourglassEnd,
 	faPlus,
 	faSignalAlt,
 	faSignalAlt2,
@@ -7,6 +7,7 @@ import {
 	faSignalAlt4,
 	Icon,
 } from "@rivet-gg/icons";
+
 import type { Rivet } from "@rivetkit/engine-api-full";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
@@ -24,7 +25,7 @@ import {
 	Text,
 	WithTooltip,
 } from "@/components";
-import { useEngineCompatDataProvider } from "@/components/actors";
+import { ActorRegion, useEngineCompatDataProvider } from "@/components/actors";
 
 interface RunnersTableProps {
 	isLoading?: boolean;
@@ -147,7 +148,9 @@ function Row(runner: Rivet.Runner) {
 					{runner.name}
 				</DiscreteCopyButton>
 			</TableCell>
-			<TableCell>{runner.datacenter}</TableCell>
+			<TableCell>
+				<ActorRegion regionId={runner.datacenter} showLabel />
+			</TableCell>
 
 			<TableCell>
 				{runner.remainingSlots}/{runner.totalSlots}
@@ -189,7 +192,7 @@ function RunnerStatusBadge(runner: Rivet.Runner) {
 				trigger={
 					<div className="text-center relative size-8">
 						<Icon
-							icon={faExclamationTriangle}
+							icon={faHourglassEnd}
 							className="text-red-500 absolute inset-1/2 -translate-x-1/2 -translate-y-1/2"
 						/>
 					</div>

--- a/frontend/src/components/actors/actor-status-label.tsx
+++ b/frontend/src/components/actors/actor-status-label.tsx
@@ -78,21 +78,21 @@ export function ActorError({ error }: { error: Rivet.ActorError }) {
 		.with(P.string, (errMsg) =>
 			match(errMsg)
 				.with("no_capacity", () => (
-					<span>No capacity available to start Actor.</span>
+					<p>No capacity available to start Actor.</p>
 				))
-				.exhaustive(),
+				.otherwise(() => <p>Unknown error: {errMsg}</p>),
 		)
 		.with(P.shape({ runnerPoolError: P.any }), (err) => (
-			<span>
+			<p>
 				Runner Pool Error:{" "}
 				<RunnerPoolError error={err.runnerPoolError} />
-			</span>
+			</p>
 		))
 		.with(P.shape({ runnerNoResponse: P.any }), (err) => (
-			<span>
+			<p>
 				Runner ({err.runnerNoResponse.runnerId}) was allocated but Actor
 				did not respond.
-			</span>
+			</p>
 		))
 		.exhaustive();
 }

--- a/frontend/src/components/actors/dialogs/create-actor-dialog.tsx
+++ b/frontend/src/components/actors/dialogs/create-actor-dialog.tsx
@@ -41,7 +41,7 @@ export default function CreateActorDialog({ onClose }: ContentProps) {
 					input: values.input ? JSON.parse(values.input) : undefined,
 					key: values.key,
 					datacenter: values.datacenter,
-					crashPolicy: values.crashPolicy || CrashPolicy.Restart,
+					crashPolicy: values.crashPolicy || CrashPolicy.Sleep,
 					runnerNameSelector: values.runnerNameSelector || "default",
 				});
 				onClose?.();
@@ -49,7 +49,7 @@ export default function CreateActorDialog({ onClose }: ContentProps) {
 			defaultValues={{
 				name,
 				key: getRandomKey(),
-				crashPolicy: CrashPolicy.Restart,
+				crashPolicy: CrashPolicy.Sleep,
 			}}
 		>
 			<DialogHeader>

--- a/frontend/src/components/actors/guard-connectable-inspector.tsx
+++ b/frontend/src/components/actors/guard-connectable-inspector.tsx
@@ -77,9 +77,8 @@ function UnavailableInfo({
 					className="text-4xl text-destructive"
 				/>
 				<p>Actor is unavailable.</p>
-				<p>
-					<QueriedActorError actorId={actorId} />
-				</p>
+
+				<QueriedActorError actorId={actorId} />
 			</Info>
 		))
 		.with("pending", () => <NoRunners />)

--- a/frontend/src/components/actors/region-select.tsx
+++ b/frontend/src/components/actors/region-select.tsx
@@ -3,17 +3,22 @@ import { Combobox } from "@/components";
 import { ActorRegion } from "./actor-region";
 import { useDataProvider } from "./data-provider";
 
-interface RegionSelectProps {
-	onValueChange: (value: string) => void;
-	value: string | undefined;
+type RegionSelectProps = {
 	showAuto?: boolean;
-}
+} & (
+	| {
+			onValueChange: (value: string) => void;
+			value: string | undefined;
+			multiple?: false;
+	  }
+	| {
+			onValueChange: (value: string[]) => void;
+			value: string[] | undefined;
+			multiple: true;
+	  }
+);
 
-export function RegionSelect({
-	onValueChange,
-	value,
-	showAuto = true,
-}: RegionSelectProps) {
+export function RegionSelect({ showAuto = true, ...props }: RegionSelectProps) {
 	const {
 		data = [],
 		fetchNextPage,
@@ -44,8 +49,7 @@ export function RegionSelect({
 		<Combobox
 			placeholder="Choose a region..."
 			options={regions}
-			value={value}
-			onValueChange={onValueChange}
+			{...props}
 			isLoading={isLoading || isFetchingNextPage}
 			onLoadMore={fetchNextPage}
 			filter={(option, searchMixed) => {

--- a/frontend/src/components/copy-area.tsx
+++ b/frontend/src/components/copy-area.tsx
@@ -123,36 +123,37 @@ export const CopyButton = forwardRef<HTMLElement, CopyButtonProps>(
 	},
 );
 
-export type DiscreteCopyButtonProps = CopyButtonProps &
-	ComponentProps<typeof Button>;
+export type DiscreteCopyButtonProps = CopyButtonProps & {
+	tooltip?: boolean;
+} & ComponentProps<typeof Button>;
 
 export const DiscreteCopyButton = forwardRef<
 	HTMLElement,
 	DiscreteCopyButtonProps
->(({ children, value, ...props }, ref) => {
-	return (
-		<WithTooltip
-			content="Click to copy"
-			trigger={
-				<CopyButton ref={ref} value={value} {...props}>
-					<Button
-						type="button"
-						variant="ghost"
-						size={props.size}
-						className={cn("max-w-full min-w-0", props.className)}
-						endIcon={
-							<Icon
-								className="group-hover:opacity-100 opacity-0 transition-opacity"
-								icon={faCopy}
-							/>
-						}
-					>
-						{children}
-					</Button>
-				</CopyButton>
-			}
-		/>
+>(({ children, value, tooltip = true, ...props }, ref) => {
+	const content = (
+		<CopyButton ref={ref} value={value} {...props}>
+			<Button
+				type="button"
+				variant="ghost"
+				size={props.size}
+				className={cn("max-w-full min-w-0", props.className)}
+				endIcon={
+					<Icon
+						className="group-hover:opacity-100 opacity-0 transition-opacity"
+						icon={faCopy}
+					/>
+				}
+			>
+				{children}
+			</Button>
+		</CopyButton>
 	);
+
+	if (tooltip) {
+		return <WithTooltip content="Click to copy" trigger={content} />;
+	}
+	return content;
 });
 
 interface ClickToCopyProps {

--- a/frontend/src/components/ui/typography.tsx
+++ b/frontend/src/components/ui/typography.tsx
@@ -112,9 +112,9 @@ const Ul = ({ className, asChild, ...props }: TypographyElementProps<"ul">) => {
 	return (
 		<Comp
 			className={cn(
-				className,
 				"my-6 ml-6 list-disc [&>li]:mt-2",
 				getCommonHelperClass(props),
+				className,
 			)}
 			{...omitCommonHelperProps(props)}
 		/>

--- a/frontend/src/routes/_context/_cloud.tsx
+++ b/frontend/src/routes/_context/_cloud.tsx
@@ -5,6 +5,7 @@ import {
 	useNavigate,
 	useSearch,
 } from "@tanstack/react-router";
+import { config } from "process";
 import { match } from "ts-pattern";
 import { useDialog } from "@/app/use-dialog";
 import { waitForClerk } from "@/lib/waitForClerk";
@@ -260,6 +261,8 @@ function CloudModals() {
 								search: (old) => ({
 									...old,
 									modal: undefined,
+									dc: undefined,
+									config: undefined,
 								}),
 							});
 						}
@@ -278,6 +281,7 @@ function CloudModals() {
 								search: (old) => ({
 									...old,
 									modal: undefined,
+									config: undefined,
 								}),
 							});
 						}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,9 +252,18 @@ importers:
 
   examples/actor-actions:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.2.0
+        version: 1.2.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.7.10
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -264,13 +273,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.2.0
-        version: 1.2.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.1
@@ -286,9 +292,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -310,12 +313,21 @@ importers:
       '@ai-sdk/openai':
         specifier: ^0.0.66
         version: 0.0.66(zod@3.25.76)
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
       ai:
         specifier: ^4.0.38
         version: 4.3.19(react@18.3.1)(zod@3.25.76)
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -325,16 +337,13 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
       zod:
         specifier: ^3.25.69
         version: 3.25.76
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.18.1
@@ -350,9 +359,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.2)(yaml@2.8.2)
@@ -371,6 +377,12 @@ importers:
 
   examples/ai-and-user-generated-actors-freestyle:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.1
+        version: 1.19.1(hono@4.9.8)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.1(hono@4.9.8))(hono@4.9.8)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -399,12 +411,6 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.1
-        version: 1.19.1(hono@4.9.8)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.1(hono@4.9.8))(hono@4.9.8)
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.1
@@ -435,6 +441,12 @@ importers:
 
   examples/chat-room:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
@@ -450,19 +462,13 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.18.1
-      '@types/prompts':
-        specifier: ^2
-        version: 2.4.9
       '@types/react':
         specifier: ^19
         version: 19.2.2
@@ -475,15 +481,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      prompts:
-        specifier: ^2.4.2
-        version: 2.4.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
-      tsup:
-        specifier: ^8.5.1
-        version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.2)(yaml@2.8.2)
       tsx:
         specifier: ^3.12.7
         version: 3.14.0
@@ -493,6 +490,9 @@ importers:
       vite:
         specifier: ^5.0.0
         version: 5.4.20(@types/node@22.18.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vite-plugin-srvx:
+        specifier: ^0.1.0
+        version: 0.1.0(srvx@0.10.0)(vite@5.4.20(@types/node@22.18.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
       vitest:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/ui@3.1.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
@@ -608,9 +608,18 @@ importers:
 
   examples/cross-actor-actions:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -620,13 +629,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.1
@@ -642,9 +648,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -663,9 +666,18 @@ importers:
 
   examples/cursors:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -675,19 +687,13 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.18.1
-      '@types/prompts':
-        specifier: ^2
-        version: 2.4.9
       '@types/react':
         specifier: ^19
         version: 19.2.2
@@ -700,12 +706,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      prompts:
-        specifier: ^2.4.2
-        version: 2.4.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.2)(yaml@2.8.2)
@@ -724,9 +724,18 @@ importers:
 
   examples/cursors-raw-websocket:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -736,19 +745,13 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.18.1
-      '@types/prompts':
-        specifier: ^2
-        version: 2.4.9
       '@types/react':
         specifier: ^19
         version: 19.2.2
@@ -761,12 +764,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      prompts:
-        specifier: ^2.4.2
-        version: 2.4.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.2)(yaml@2.8.2)
@@ -785,22 +782,28 @@ importers:
 
   examples/custom-serverless:
     dependencies:
-      rivetkit:
-        specifier: workspace:*
-        version: link:../../rivetkit-typescript/packages/rivetkit
-    devDependencies:
       '@hono/node-server':
         specifier: ^1.19.7
         version: 1.19.7(hono@4.11.3)
       '@hono/node-ws':
         specifier: ^1.3.0
         version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
-      '@types/node':
-        specifier: ^22.13.9
-        version: 22.19.1
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
       srvx:
         specifier: ^0.10.0
         version: 0.10.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.1
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
       tsx:
         specifier: ^3.12.7
         version: 3.14.0
@@ -811,30 +814,14 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
-  examples/deno:
-    dependencies:
-      hono:
-        specifier: 4.9.8
-        version: 4.9.8
-      rivetkit:
-        specifier: workspace:*
-        version: link:../../rivetkit-typescript/packages/rivetkit
-    devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.9.8)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.9.8))(hono@4.9.8)
-      '@types/deno':
-        specifier: ^2.3.0
-        version: 2.5.0
-      '@types/node':
-        specifier: ^24.5.2
-        version: 24.7.1
-
   examples/drizzle:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/db':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/db
@@ -844,19 +831,22 @@ importers:
       drizzle-orm:
         specifier: ^0.44.2
         version: 0.44.6(@cloudflare/workers-types@4.20251014.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.0(@types/react@19.2.2))(kysely@0.28.8)
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.18.1
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.2)(yaml@2.8.2)
       tsx:
         specifier: ^3.12.7
         version: 3.14.0
@@ -866,34 +856,28 @@ importers:
 
   examples/elysia:
     dependencies:
-      '@rivetkit/react':
-        specifier: workspace:*
-        version: link:../../rivetkit-typescript/packages/react
-      '@sinclair/typebox':
-        specifier: ^0.34.15
-        version: 0.34.41
-      elysia:
-        specifier: ^1.3.5
-        version: 1.4.12(@sinclair/typebox@0.34.41)(exact-mirror@0.2.2(@sinclair/typebox@0.34.41))(file-type@21.0.0)(openapi-types@12.1.3)(typescript@5.9.2)
-      react:
-        specifier: ^18.2.0
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
-    devDependencies:
       '@hono/node-server':
         specifier: ^1.19.7
         version: 1.19.7(hono@4.11.3)
       '@hono/node-ws':
         specifier: ^1.3.0
         version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
-      '@types/node':
-        specifier: ^22.13.9
-        version: 22.18.1
+      elysia:
+        specifier: ^1.4.0
+        version: 1.4.12(@sinclair/typebox@0.34.41)(exact-mirror@0.2.2(@sinclair/typebox@0.34.41))(file-type@21.0.0)(openapi-types@12.1.3)(typescript@5.9.2)
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.18.1
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
       typescript:
         specifier: ^5.5.2
         version: 5.9.2
@@ -912,12 +896,21 @@ importers:
       '@durable-streams/writer':
         specifier: https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/writer@0323b8b
         version: https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/writer@0323b8b
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
       ai:
         specifier: ^4.0.38
         version: 4.3.19(react@18.3.1)(zod@4.1.13)
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -927,16 +920,13 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
       zod:
         specifier: ^4.1.0
         version: 4.1.13
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.1
@@ -952,9 +942,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -971,125 +958,42 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
-  examples/express:
-    dependencies:
-      '@rivetkit/react':
-        specifier: workspace:*
-        version: link:../../rivetkit-typescript/packages/react
-      express:
-        specifier: ^5.1.0
-        version: 5.1.0
-      react:
-        specifier: ^18.2.0
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
-    devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.13.9
-        version: 22.18.1
-      rivetkit:
-        specifier: workspace:*
-        version: link:../../rivetkit-typescript/packages/rivetkit
-      tsx:
-        specifier: ^3.12.7
-        version: 3.14.0
-      typescript:
-        specifier: ^5.5.2
-        version: 5.9.2
-
   examples/hono:
     dependencies:
-      hono:
-        specifier: ^4.7.0
-        version: 4.9.8
-    devDependencies:
       '@hono/node-server':
         specifier: ^1.19.1
         version: 1.19.1(hono@4.9.8)
       '@hono/node-ws':
         specifier: ^1.3.0
         version: 1.3.0(@hono/node-server@1.19.1(hono@4.9.8))(hono@4.9.8)
-      '@types/node':
-        specifier: ^22.13.9
-        version: 22.18.1
-      rivetkit:
-        specifier: workspace:*
-        version: link:../../rivetkit-typescript/packages/rivetkit
-      tsx:
-        specifier: ^3.12.7
-        version: 3.14.0
-      typescript:
-        specifier: ^5.5.2
-        version: 5.9.2
-
-  examples/hono-bun:
-    dependencies:
-      '@rivetkit/react':
-        specifier: workspace:*
-        version: link:../../rivetkit-typescript/packages/react
       hono:
         specifier: ^4.7.0
         version: 4.9.8
-      react:
-        specifier: ^18.2.0
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
-    devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.9.8)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.9.8))(hono@4.9.8)
-      '@types/bun':
-        specifier: ^1.1.15
-        version: 1.3.0(@types/react@19.2.2)
-      '@types/react':
-        specifier: ^19
-        version: 19.2.2
-      '@types/react-dom':
-        specifier: ^19
-        version: 19.2.2(@types/react@19.2.2)
-      '@vitejs/plugin-react':
-        specifier: ^4.2.0
-        version: 4.7.0(vite@5.4.20(@types/node@25.0.3)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
-      concurrently:
-        specifier: ^8.2.2
-        version: 8.2.2
       srvx:
         specifier: ^0.10.0
         version: 0.10.0
-      tsup:
-        specifier: ^8.5.1
-        version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@25.0.3))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.2)(yaml@2.8.2)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.18.1
       tsx:
         specifier: ^3.12.7
         version: 3.14.0
       typescript:
         specifier: ^5.5.2
         version: 5.9.2
-      vite:
-        specifier: ^5.0.0
-        version: 5.4.20(@types/node@25.0.3)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   examples/hono-react:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.1
+        version: 1.19.1(hono@4.9.8)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.1(hono@4.9.8))(hono@4.9.8)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
@@ -1105,13 +1009,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.1
-        version: 1.19.1(hono@4.9.8)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.1(hono@4.9.8))(hono@4.9.8)
       '@types/node':
         specifier: ^22.13.9
         version: 22.18.1
@@ -1127,9 +1028,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.2)(yaml@2.8.2)
@@ -1148,9 +1046,18 @@ importers:
 
   examples/kitchen-sink:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.7.4
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1160,13 +1067,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.3
@@ -1182,9 +1086,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.3))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)
@@ -1200,9 +1101,18 @@ importers:
 
   examples/multi-region:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.7.4
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1212,13 +1122,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.1
@@ -1234,9 +1141,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1255,9 +1159,18 @@ importers:
 
   examples/native-websockets:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1267,13 +1180,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.1
@@ -1292,9 +1202,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1350,22 +1257,25 @@ importers:
 
   examples/node:
     dependencies:
-      rivetkit:
-        specifier: workspace:*
-        version: link:../../rivetkit-typescript/packages/rivetkit
-    devDependencies:
       '@hono/node-server':
         specifier: ^1.19.7
         version: 1.19.7(hono@4.11.3)
       '@hono/node-ws':
         specifier: ^1.3.0
         version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
-      '@types/node':
-        specifier: ^22.13.9
-        version: 22.19.1
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
       srvx:
         specifier: ^0.10.0
         version: 0.10.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.1
       tsx:
         specifier: ^3.12.7
         version: 3.14.0
@@ -1375,6 +1285,12 @@ importers:
 
   examples/raw-fetch-handler:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.1
+        version: 1.19.1(hono@4.9.8)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.1(hono@4.9.8))(hono@4.9.8)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
@@ -1390,13 +1306,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.1
-        version: 1.19.1(hono@4.9.8)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.1(hono@4.9.8))(hono@4.9.8)
       '@types/node':
         specifier: ^22.10.6
         version: 22.18.1
@@ -1412,9 +1325,6 @@ importers:
       concurrently:
         specifier: ^9.1.2
         version: 9.2.1
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)
@@ -1433,6 +1343,12 @@ importers:
 
   examples/raw-websocket-handler:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.9.8)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.9.8))(hono@4.9.8)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
@@ -1448,13 +1364,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.9.8)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.9.8))(hono@4.9.8)
       '@types/node':
         specifier: ^22.10.2
         version: 22.18.1
@@ -1470,9 +1383,6 @@ importers:
       concurrently:
         specifier: ^9.1.0
         version: 9.2.1
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)
@@ -1491,6 +1401,12 @@ importers:
 
   examples/raw-websocket-handler-proxy:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.1
+        version: 1.19.1(hono@4.9.8)
+      '@hono/node-ws':
+        specifier: ^1.2.0
+        version: 1.2.0(@hono/node-server@1.19.1(hono@4.9.8))(hono@4.9.8)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
@@ -1506,16 +1422,13 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
       ws:
         specifier: ^8.18.0
         version: 8.18.3
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.1
-        version: 1.19.1(hono@4.9.8)
-      '@hono/node-ws':
-        specifier: ^1.2.0
-        version: 1.2.0(@hono/node-server@1.19.1(hono@4.9.8))(hono@4.9.8)
       '@types/node':
         specifier: ^22.10.2
         version: 22.18.1
@@ -1534,9 +1447,6 @@ importers:
       concurrently:
         specifier: ^9.1.0
         version: 9.2.1
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)
@@ -1555,9 +1465,18 @@ importers:
 
   examples/react:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.7.0
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1567,13 +1486,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.18.1
@@ -1589,9 +1505,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.2)(yaml@2.8.2)
@@ -1610,9 +1523,18 @@ importers:
 
   examples/scheduling:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1622,13 +1544,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.1
@@ -1644,9 +1563,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1665,9 +1581,18 @@ importers:
 
   examples/state:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1677,13 +1602,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.1
@@ -1699,9 +1621,6 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1720,9 +1639,18 @@ importers:
 
   examples/stream:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@rivetkit/react':
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1732,13 +1660,10 @@ importers:
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
-      '@hono/node-ws':
-        specifier: ^1.3.0
-        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.13
@@ -1754,9 +1679,6 @@ importers:
       concurrently:
         specifier: ^8.2.0
         version: 8.2.2
-      srvx:
-        specifier: ^0.10.0
-        version: 0.10.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@20.19.13))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)
@@ -1775,28 +1697,40 @@ importers:
 
   examples/trpc:
     dependencies:
-      '@trpc/client':
-        specifier: ^11.3.1
-        version: 11.6.0(@trpc/server@11.6.0(typescript@5.9.2))(typescript@5.9.2)
-      '@trpc/server':
-        specifier: ^11.4.2
-        version: 11.6.0(typescript@5.9.2)
-      zod:
-        specifier: ^3.25.76
-        version: 3.25.76
-    devDependencies:
       '@hono/node-server':
         specifier: ^1.19.7
         version: 1.19.7(hono@4.11.3)
       '@hono/node-ws':
         specifier: ^1.3.0
         version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
-      '@types/node':
-        specifier: ^22.13.9
-        version: 22.18.1
+      '@hono/trpc-server':
+        specifier: ^0.3.0
+        version: 0.3.4(@trpc/server@11.6.0(typescript@5.9.2))(hono@4.11.3)
+      '@trpc/client':
+        specifier: ^11.3.1
+        version: 11.6.0(@trpc/server@11.6.0(typescript@5.9.2))(typescript@5.9.2)
+      '@trpc/server':
+        specifier: ^11.4.2
+        version: 11.6.0(typescript@5.9.2)
+      hono:
+        specifier: ^4.7.11
+        version: 4.11.3
       rivetkit:
         specifier: workspace:*
         version: link:../../rivetkit-typescript/packages/rivetkit
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.18.1
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.2)(yaml@2.8.2)
       tsx:
         specifier: ^3.12.7
         version: 3.14.0
@@ -2103,6 +2037,9 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
+      react-error-boundary:
+        specifier: ^6.0.3
+        version: 6.0.3(react@19.1.1)
       react-hook-form:
         specifier: ^7.62.0
         version: 7.62.0(react@19.1.1)
@@ -2267,7 +2204,7 @@ importers:
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@uiw/codemirror-extensions-basic-setup':
         specifier: ^4.25.1
-        version: 4.25.1(@codemirror/autocomplete@6.19.0)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.0)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)
+        version: 4.25.1(@codemirror/autocomplete@6.19.0)(@codemirror/commands@6.9.0)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.0)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)
       '@uiw/codemirror-theme-github':
         specifier: ^4.25.1
         version: 4.25.1(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)
@@ -2657,6 +2594,9 @@ importers:
       eventsource:
         specifier: ^4.0.0
         version: 4.0.0
+      local-pkg:
+        specifier: ^0.5.1
+        version: 0.5.1
       tsup:
         specifier: ^8.4.0
         version: 8.5.0(@microsoft/api-extractor@7.53.2(@types/node@22.18.1))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)
@@ -5353,6 +5293,13 @@ packages:
       '@standard-schema/spec': 1.0.0
       hono: '>=3.9.0'
 
+  '@hono/trpc-server@0.3.4':
+    resolution: {integrity: sha512-xFOPjUPnII70FgicDzOJy1ufIoBTu8eF578zGiDOrYOrYN8CJe140s9buzuPkX+SwJRYK8LjEBHywqZtxdm8aA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@trpc/server': ^10.10.0 || >11.0.0-rc
+      hono: '>=4.*'
+
   '@hono/zod-openapi@1.1.5':
     resolution: {integrity: sha512-EAnY6ad4yt/MUKHx716BEGGOXSl5d0/FOLozOYB/pmSEFq07qrzefKFtBEMAgd3hlpJXjH+4lwgTtlAo+BGBgQ==}
     engines: {node: '>=16.0.0'}
@@ -7724,20 +7671,11 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
-  '@types/body-parser@1.19.6':
-    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
-
-  '@types/bun@1.3.0':
-    resolution: {integrity: sha512-+lAGCYjXjip2qY375xX/scJeVRmZ5cY0wyHYyCYxNcdEXrQ4AOe3gACgd4iQ8ksOslJtW4VNxBJ8llUwc3a6AA==}
-
   '@types/canvas-confetti@1.9.0':
     resolution: {integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
-
-  '@types/connect@3.4.38':
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
@@ -7775,9 +7713,6 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/deno@2.5.0':
-    resolution: {integrity: sha512-g8JS38vmc0S87jKsFzre+0ZyMOUDHPVokEJymSCRlL57h6f/FdKPWBXgdFh3Z8Ees9sz11qt9VWELU9Y9ZkiVw==}
-
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
@@ -7796,12 +7731,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/express-serve-static-core@4.19.7':
-    resolution: {integrity: sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==}
-
-  '@types/express@4.17.23':
-    resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
-
   '@types/file-saver@2.0.7':
     resolution: {integrity: sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==}
 
@@ -7810,9 +7739,6 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
-  '@types/http-errors@2.0.5':
-    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/invariant@2.2.37':
     resolution: {integrity: sha512-IwpIMieE55oGWiXkQPSBY1nw1nFs6bsKXTFskNY8sdS17K24vyEBRQZEwlRS7ZmXCWnJcQtbxWzly+cODWGs2A==}
@@ -7849,9 +7775,6 @@ packages:
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
-
-  '@types/mime@1.3.5':
-    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
   '@types/mime@4.0.0':
     resolution: {integrity: sha512-5eEkJZ/BLvTE3vXGKkWlyTSUVZuzj23Wj8PoyOq2lt5I3CYbiLBOPb3XmCW6QcuOibIUE6emHXHt9E/F/rCa6w==}
@@ -7899,14 +7822,8 @@ packages:
   '@types/postcss-modules-scope@3.0.4':
     resolution: {integrity: sha512-//ygSisVq9kVI0sqx3UPLzWIMCmtSVrzdljtuaAEJtGoGnpjBikZ2sXO5MpH9SnWX9HRfXxHifDAXcQjupWnIQ==}
 
-  '@types/prompts@2.4.9':
-    resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
-
   '@types/qs@6.9.8':
     resolution: {integrity: sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==}
-
-  '@types/range-parser@1.2.7':
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
   '@types/react-dom@19.2.2':
     resolution: {integrity: sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==}
@@ -7924,15 +7841,6 @@ packages:
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
-
-  '@types/send@0.17.5':
-    resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
-
-  '@types/send@1.2.0':
-    resolution: {integrity: sha512-zBF6vZJn1IaMpg3xUF25VK3gd3l8zwE0ZLRX7dsQyQi+jp4E8mMDJNGDYnYse+bQhYwWERTxVwHpi3dMOq7RKQ==}
-
-  '@types/serve-static@1.15.9':
-    resolution: {integrity: sha512-dOTIuqpWLyl3BBXU3maNQsS4A3zuuoYRNIvYSxxhebPfXg2mzWQEPne/nlJ37yOse6uGgR386uTpdsx4D0QZWA==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -8380,10 +8288,6 @@ packages:
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
-    engines: {node: '>= 0.6'}
-
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
   acorn-import-phases@1.0.4:
@@ -8836,10 +8740,6 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  body-parser@2.2.0:
-    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
-    engines: {node: '>=18'}
-
   bplist-creator@0.1.0:
     resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
 
@@ -9208,14 +9108,6 @@ packages:
   constant-case@3.0.4:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
 
-  content-disposition@1.0.0:
-    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
-    engines: {node: '>= 0.6'}
-
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
-
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
@@ -9224,10 +9116,6 @@ packages:
 
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
-
-  cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -10196,10 +10084,6 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
-  express@5.1.0:
-    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
-    engines: {node: '>= 18'}
-
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
@@ -10355,10 +10239,6 @@ packages:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
 
-  finalhandler@2.1.0:
-    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
-    engines: {node: '>= 0.8'}
-
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
@@ -10421,10 +10301,6 @@ packages:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
 
-  forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
@@ -10472,10 +10348,6 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-
-  fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -10802,10 +10674,6 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  http-errors@2.0.0:
-    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
-    engines: {node: '>= 0.8'}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -10923,10 +10791,6 @@ packages:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
-  ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
-
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -11032,9 +10896,6 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -11695,19 +11556,11 @@ packages:
   mdx-annotations@0.1.4:
     resolution: {integrity: sha512-SUYBUXP1qbgr0nRFFnUBg4HxxTbYyl5rE38fLTaIm0naPK+EhmKa0wRlUdgTMlMBj5gdCMwP1n7+L47JIHHWUQ==}
 
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
-
   memoize-one@4.0.3:
     resolution: {integrity: sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==}
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
-
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -11953,10 +11806,6 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  mime-types@3.0.1:
-    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
-    engines: {node: '>= 0.6'}
-
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
@@ -12122,10 +11971,6 @@ packages:
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
-    engines: {node: '>= 0.6'}
-
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -12540,9 +12385,6 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
-
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -12880,10 +12722,6 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
-
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
@@ -12951,10 +12789,6 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  raw-body@3.0.1:
-    resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
-    engines: {node: '>= 0.10'}
-
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -12993,6 +12827,11 @@ packages:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
     peerDependencies:
       react: ^19.2.0
+
+  react-error-boundary@6.0.3:
+    resolution: {integrity: sha512-5guqn2UYpCFjE8UDMA8J7Kke+YSGBFrKQRJb3XdcaGZXYINZfQXgBt3ifY6MvjkN7QROc5A8zclyoSCwrcRUKw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -13372,10 +13211,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -13477,10 +13312,6 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
-  send@1.2.0:
-    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
-    engines: {node: '>= 18'}
-
   sentence-case@3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
 
@@ -13504,10 +13335,6 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
-
-  serve-static@2.2.0:
-    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
-    engines: {node: '>= 18'}
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
@@ -13723,10 +13550,6 @@ packages:
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
-
-  statuses@2.0.1:
-    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
-    engines: {node: '>= 0.8'}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -14263,10 +14086,6 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
-
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -14634,6 +14453,12 @@ packages:
 
   vite-plugin-favicons-inject@2.2.0:
     resolution: {integrity: sha512-MaqZE3IjwFffIED38yKcI5BKGkV039N6ilhPeOfW4TILzSKMBNd8Q0ehu0mwbl1emWH2tGcuwV3ZIzDKfb0vIQ==}
+
+  vite-plugin-srvx@0.1.0:
+    resolution: {integrity: sha512-1jUz/BsHD4MY2QwexIk00fjZPzi4ldEQGjzPrFPyWaALZAF1RoWazG5SJZbcJf2YdBwFOsvf6AfX/dkcT5dA1g==}
+    peerDependencies:
+      srvx: '>=0.9.0'
+      vite: ^5.0.0 || ^6.0.0
 
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
@@ -17658,6 +17483,11 @@ snapshots:
       '@standard-schema/spec': 1.0.0
       hono: 4.9.8
 
+  '@hono/trpc-server@0.3.4(@trpc/server@11.6.0(typescript@5.9.2))(hono@4.11.3)':
+    dependencies:
+      '@trpc/server': 11.6.0(typescript@5.9.2)
+      hono: 4.11.3
+
   '@hono/zod-openapi@1.1.5(hono@4.9.8)(zod@4.1.13)':
     dependencies:
       '@asteasolutions/zod-to-openapi': 8.2.0(zod@4.1.13)
@@ -20527,27 +20357,12 @@ snapshots:
     dependencies:
       '@types/node': 22.19.3
 
-  '@types/body-parser@1.19.6':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 22.19.3
-
-  '@types/bun@1.3.0(@types/react@19.2.2)':
-    dependencies:
-      bun-types: 1.3.0(@types/react@19.2.2)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@types/canvas-confetti@1.9.0': {}
 
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
-
-  '@types/connect@3.4.38':
-    dependencies:
-      '@types/node': 22.19.3
 
   '@types/cors@2.8.19':
     dependencies:
@@ -20583,8 +20398,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/deno@2.5.0': {}
-
   '@types/diff-match-patch@1.0.36': {}
 
   '@types/escape-html@1.0.4': {}
@@ -20605,20 +20418,6 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/express-serve-static-core@4.19.7':
-    dependencies:
-      '@types/node': 22.19.3
-      '@types/qs': 6.9.8
-      '@types/range-parser': 1.2.7
-      '@types/send': 1.2.0
-
-  '@types/express@4.17.23':
-    dependencies:
-      '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 4.19.7
-      '@types/qs': 6.9.8
-      '@types/serve-static': 1.15.9
-
   '@types/file-saver@2.0.7': {}
 
   '@types/graceful-fs@4.1.9':
@@ -20628,8 +20427,6 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/http-errors@2.0.5': {}
 
   '@types/invariant@2.2.37': {}
 
@@ -20663,8 +20460,6 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdx@2.0.13': {}
-
-  '@types/mime@1.3.5': {}
 
   '@types/mime@4.0.0':
     dependencies:
@@ -20722,14 +20517,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  '@types/prompts@2.4.9':
-    dependencies:
-      '@types/node': 22.19.1
-      kleur: 3.0.3
-
   '@types/qs@6.9.8': {}
-
-  '@types/range-parser@1.2.7': {}
 
   '@types/react-dom@19.2.2(@types/react@19.2.2)':
     dependencies:
@@ -20746,21 +20534,6 @@ snapshots:
   '@types/retry@0.12.2': {}
 
   '@types/semver@7.7.1': {}
-
-  '@types/send@0.17.5':
-    dependencies:
-      '@types/mime': 1.3.5
-      '@types/node': 22.19.3
-
-  '@types/send@1.2.0':
-    dependencies:
-      '@types/node': 22.19.3
-
-  '@types/serve-static@1.15.9':
-    dependencies:
-      '@types/http-errors': 2.0.5
-      '@types/node': 22.19.3
-      '@types/send': 0.17.5
 
   '@types/stack-utils@2.0.3': {}
 
@@ -20898,6 +20671,16 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.19.0
       '@codemirror/commands': 6.8.1
+      '@codemirror/language': 6.11.3
+      '@codemirror/lint': 6.9.0
+      '@codemirror/search': 6.5.11
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.2
+
+  '@uiw/codemirror-extensions-basic-setup@4.25.1(@codemirror/autocomplete@6.19.0)(@codemirror/commands@6.9.0)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.0)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)':
+    dependencies:
+      '@codemirror/autocomplete': 6.19.0
+      '@codemirror/commands': 6.9.0
       '@codemirror/language': 6.11.3
       '@codemirror/lint': 6.9.0
       '@codemirror/search': 6.5.11
@@ -21070,18 +20853,6 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 5.4.20(@types/node@22.19.3)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitejs/plugin-react@4.7.0(vite@5.4.20(@types/node@25.0.3)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.4)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 5.4.20(@types/node@25.0.3)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21414,11 +21185,6 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.1
-      negotiator: 1.0.0
-
   acorn-import-phases@1.0.4(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -21440,7 +21206,7 @@ snapshots:
   actor-core@0.6.3(ws@8.18.3):
     dependencies:
       cbor-x: 1.6.0
-      hono: 4.9.8
+      hono: 4.11.3
       on-change: 5.0.1
       p-retry: 6.2.1
       zod: 3.25.76
@@ -21942,20 +21708,6 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@2.2.0:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.1
-      http-errors: 2.0.0
-      iconv-lite: 0.6.3
-      on-finished: 2.4.1
-      qs: 6.14.0
-      raw-body: 3.0.1
-      type-is: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   bplist-creator@0.1.0:
     dependencies:
       stream-buffers: 2.2.0
@@ -22030,6 +21782,7 @@ snapshots:
     dependencies:
       '@types/node': 22.19.3
       '@types/react': 19.2.2
+    optional: true
 
   bundle-require@5.1.0(esbuild@0.25.9):
     dependencies:
@@ -22387,19 +22140,11 @@ snapshots:
       tslib: 2.8.1
       upper-case: 2.0.2
 
-  content-disposition@1.0.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  content-type@1.0.5: {}
-
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
   cookie-es@1.2.2: {}
-
-  cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
 
@@ -23145,7 +22890,7 @@ snapshots:
       eslint: 9.39.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@1.21.7))
@@ -23178,7 +22923,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -23193,7 +22938,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -23619,38 +23364,6 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express@5.1.0:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.0
-      content-disposition: 1.0.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.1
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.0
-      fresh: 2.0.0
-      http-errors: 2.0.0
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.1
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.14.0
-      range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.0
-      serve-static: 2.2.0
-      statuses: 2.0.2
-      type-is: 2.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   exsolve@1.0.7: {}
 
   extend@3.0.2: {}
@@ -23799,17 +23512,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.0:
-    dependencies:
-      debug: 4.4.1
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   find-root@1.1.0: {}
 
   find-up@4.1.0:
@@ -23875,8 +23577,6 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
 
-  forwarded@0.2.0: {}
-
   fraction.js@4.3.7: {}
 
   fraction.js@5.3.4: {}
@@ -23907,7 +23607,7 @@ snapshots:
       '@tanstack/react-query': 5.87.1(react@19.2.0)
       expo-router: 4.0.21(expo-constants@18.0.13)(expo-linking@7.0.5)(expo@54.0.18)(react-dom@18.3.1(react@18.3.1))(react-native-safe-area-context@5.6.1(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.2)(react@18.3.1))(react@18.3.1))(react-native-screens@4.17.1(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.2)(react@18.3.1))(react@18.3.1))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.2)(react@18.3.1))(react@19.2.0)
       glob: 11.0.3
-      hono: 4.9.8
+      hono: 4.11.3
       openai: 4.104.0(ws@8.19.0)(zod@3.25.76)
       openapi: 1.0.1
       react: 19.2.0
@@ -23936,7 +23636,7 @@ snapshots:
       expo-router: 4.0.21(expo-constants@18.0.13)(expo-linking@7.0.5)(expo@54.0.18)(react-dom@18.3.1(react@18.3.1))(react-native-safe-area-context@5.6.1(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.2)(react@18.3.1))(react@18.3.1))(react-native-screens@4.17.1(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.2)(react@18.3.1))(react@18.3.1))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.2)(react@18.3.1))(react@19.2.0)
       freestyle-sandboxes: 0.0.66(expo-constants@18.0.13)(expo-linking@7.0.5)(expo@54.0.18)(react-dom@18.3.1(react@18.3.1))(react-native-safe-area-context@5.6.1(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.2)(react@18.3.1))(react@18.3.1))(react-native-screens@4.17.1(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.2)(react@18.3.1))(react@18.3.1))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.2)(react@18.3.1))(ws@8.19.0)
       glob: 11.0.3
-      hono: 4.9.8
+      hono: 4.11.3
       openai: 4.104.0(ws@8.19.0)(zod@3.25.76)
       openapi: 1.0.1
       react: 19.2.0
@@ -23958,8 +23658,6 @@ snapshots:
       - ws
 
   fresh@0.5.2: {}
-
-  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -24386,14 +24084,6 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  http-errors@2.0.0:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      toidentifier: 1.0.1
-
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -24434,6 +24124,7 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+    optional: true
 
   iconv-lite@0.7.0:
     dependencies:
@@ -24500,8 +24191,6 @@ snapshots:
       loose-envify: 1.4.0
 
   ip-address@10.1.0: {}
-
-  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -24602,8 +24291,6 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
-
-  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -25363,13 +25050,9 @@ snapshots:
       estree-util-visit: 1.2.1
       unist-util-visit: 4.1.2
 
-  media-typer@1.1.0: {}
-
   memoize-one@4.0.3: {}
 
   memoize-one@5.2.1: {}
-
-  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -26002,10 +25685,6 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mime-types@3.0.1:
-    dependencies:
-      mime-db: 1.54.0
-
   mime@1.6.0: {}
 
   mime@3.0.0: {}
@@ -26156,8 +25835,6 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
-
-  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -26642,8 +26319,6 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
-  path-to-regexp@8.3.0: {}
-
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
@@ -26944,11 +26619,6 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  proxy-addr@2.0.7:
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
@@ -27042,13 +26712,6 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  raw-body@3.0.1:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.7.0
-      unpipe: 1.0.0
-
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -27094,6 +26757,10 @@ snapshots:
     dependencies:
       react: 19.2.0
       scheduler: 0.27.0
+
+  react-error-boundary@6.0.3(react@19.1.1):
+    dependencies:
+      react: 19.1.1
 
   react-fast-compare@3.2.2: {}
 
@@ -27678,16 +27345,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.53.3
       fsevents: 2.3.3
 
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.1
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.3.0
-    transitivePeerDependencies:
-      - supports-color
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -27796,22 +27453,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.0:
-    dependencies:
-      debug: 4.4.1
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.0
-      mime-types: 3.0.1
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   sentence-case@3.0.4:
     dependencies:
       no-case: 3.0.4
@@ -27836,15 +27477,6 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@2.2.0:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -28151,8 +27783,6 @@ snapshots:
   state-local@1.0.7: {}
 
   statuses@1.5.0: {}
-
-  statuses@2.0.1: {}
 
   statuses@2.0.2: {}
 
@@ -28987,35 +28617,6 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.5.1(@microsoft/api-extractor@7.53.2(@types/node@25.0.3))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.2)(yaml@2.8.2):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.2)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.3
-      esbuild: 0.27.2
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(yaml@2.8.2)
-      resolve-from: 5.0.0
-      rollup: 4.53.3
-      source-map: 0.7.6
-      sucrase: 3.35.1
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.53.2(@types/node@25.0.3)
-      postcss: 8.5.6
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
   tsx@3.14.0:
     dependencies:
       esbuild: 0.18.20
@@ -29082,12 +28683,6 @@ snapshots:
   type-fest@0.7.1: {}
 
   type-fest@4.41.0: {}
-
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.1
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -29674,6 +29269,11 @@ snapshots:
   vite-plugin-favicons-inject@2.2.0:
     dependencies:
       favicons: 7.2.0
+
+  vite-plugin-srvx@0.1.0(srvx@0.10.0)(vite@5.4.20(@types/node@22.18.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)):
+    dependencies:
+      srvx: 0.10.0
+      vite: 5.4.20(@types/node@22.18.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@5.4.20(@types/node@20.19.13)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)):
     dependencies:


### PR DESCRIPTION
### TL;DR

Refactored runner configuration UI to support both shared and per-datacenter settings, improving the management of serverless providers across multiple regions.

### What changed?

- Created a new `RunnerConfigToggleGroup` component for switching between serverless and dedicated modes
- Split the runner config form into shared settings and per-datacenter settings
- Added ability to copy settings between datacenters
- Improved the runner config table to group configurations by provider and endpoint
- Added status indicators showing runner pool errors with detailed error messages
- Enhanced region selection with multi-select capability
- Reorganized the edit dialog to use an accordion for datacenter-specific settings
- Fixed namespace handling in the Vercel connection flow

### How to test?

1. Navigate to the runner configuration page
2. Create a new provider or edit an existing one
3. Test switching between "Shared Settings" and "Per Datacenter Settings" modes
4. Verify that settings can be applied globally or per region
5. Check that error states are properly displayed in the runner config table
6. Confirm that settings can be copied between datacenters in the per-datacenter view

### Why make this change?

This change provides more flexibility in managing runner configurations across multiple regions. Users can now choose between applying the same configuration to all datacenters or customizing settings for specific regions. The improved UI makes it easier to identify and troubleshoot configuration issues with better error reporting and visualization of provider status across regions.