### PR TITLE
fix(frontend): make changelog not blocking

### DIFF
--- a/frontend/src/app/changelog.tsx
+++ b/frontend/src/app/changelog.tsx
@@ -1,5 +1,5 @@
 import { faSparkle, Icon } from "@rivet-gg/icons";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useLocalStorage } from "usehooks-ts";
 import {
 	Avatar,
@@ -113,12 +113,26 @@ interface ChangelogProps {
 }
 
 export function Changelog({ className, children, ...props }: ChangelogProps) {
-	const { data } = useSuspenseQuery(changelogQueryOptions());
+	const { data, isLoading } = useQuery(changelogQueryOptions());
 
 	const [lastChangelog, setLast] = useLocalStorage<string | null>(
 		"rivet-lastchangelog",
 		null,
 	);
+
+	if (isLoading || !data) {
+		return (
+			<Slot
+				{...props}
+				className={cn(
+					"relative [&_[data-changelog-ping]]:hidden",
+					className,
+				)}
+			>
+				{children}
+			</Slot>
+		);
+	}
 
 	const hasNewChangelog = !lastChangelog
 		? data.length > 0


### PR DESCRIPTION
### TL;DR

Updated the Changelog component to handle loading states gracefully.

### What changed?

- Imported `useQuery` from `@tanstack/react-query` alongside the existing `useSuspenseQuery`
- Replaced `useSuspenseQuery` with `useQuery` in the Changelog component to get access to loading state
- Added a conditional rendering block that returns a simplified version of the component when data is loading or unavailable
- The simplified version hides the changelog ping indicator during loading

### How to test?

1. Open the application and verify the changelog component doesn't show errors during loading
2. Confirm that the changelog ping indicator is hidden during the loading state
3. Verify that the full changelog functionality works correctly after data is loaded

### Why make this change?

This change improves the user experience by handling the loading state of the changelog data properly. Previously, the component might have shown errors or unexpected behavior while data was being fetched. Now it gracefully renders a placeholder version until the data is available.