### PR TITLE
fix(drivers/fs): return proper data for all endpoints

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/manager.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/manager.ts
@@ -4,7 +4,6 @@ import { ActorStopping } from "@/actor/errors";
 import { type ActorRouter, createActorRouter } from "@/actor/router";
 import { routeWebSocket } from "@/actor/router-websocket-endpoints";
 import { createClientWithDriver } from "@/client/client";
-import { ClientConfigSchema } from "@/client/config";
 import { createInlineWebSocket } from "@/common/inline-websocket-adapter";
 import { noopNext } from "@/common/utils";
 import type {
@@ -21,12 +20,11 @@ import { ManagerInspector } from "@/inspector/manager";
 import { type Actor, ActorFeature, type ActorId } from "@/inspector/mod";
 import type { ManagerDisplayInformation } from "@/manager/driver";
 import type { Encoding, UniversalWebSocket } from "@/mod";
+import type { DriverConfig, RegistryConfig } from "@/registry/config";
 import type * as schema from "@/schemas/file-system-driver/mod";
+import type { GetUpgradeWebSocket } from "@/utils";
 import type { FileSystemGlobalState } from "./global-state";
-import { logger } from "./log";
 import { generateActorId } from "./utils";
-import { RegistryConfig, DriverConfig } from "@/registry/config";
-import { GetUpgradeWebSocket } from "@/utils";
 
 export class FileSystemManagerDriver implements ManagerDriver {
 	#config: RegistryConfig;


### PR DESCRIPTION
### TL;DR

Added a helper function to standardize actor output creation with timestamps.

### What changed?

- Created a new `buildActorOutput` helper function that constructs an `ActorOutput` object with all timestamp fields
- Replaced multiple instances of manual `ActorOutput` object creation with calls to this helper function
- Ensured consistent handling of timestamps across all actor-related operations

### How to test?

- Verify that actor creation, lookup, and listing operations return consistent output format
- Check that all timestamp fields (createTs, startTs, connectableTs, sleepTs, destroyTs) are properly populated
- Test actor operations to ensure the refactored code maintains the same functionality

### Why make this change?

This refactoring improves code maintainability by centralizing the logic for building actor output objects. It eliminates duplication and ensures that all actor-related operations return consistent data structures with properly formatted timestamps. This change also makes it easier to modify the actor output format in the future, as changes would only need to be made in one place.