### PR TITLE
fix(dashboard): use proper timestamp for actor status

### DIFF
--- a/frontend/src/app/data-providers/inspector-data-provider.tsx
+++ b/frontend/src/app/data-providers/inspector-data-provider.tsx
@@ -168,6 +168,9 @@ function transformActor(a: InspectorActor): Actor {
 		destroyedAt: a.destroyedAt
 			? new Date(a.destroyedAt).toISOString()
 			: undefined,
+		connectableAt: a.connectableAt
+			? new Date(a.connectableAt).toISOString()
+			: undefined,
 		startedAt: a.createdAt
 			? new Date(a.createdAt).toISOString()
 			: undefined,

--- a/frontend/src/components/actors/queries/index.ts
+++ b/frontend/src/components/actors/queries/index.ts
@@ -108,6 +108,7 @@ export function getActorStatus(
 		Actor,
 		| "createdAt"
 		| "startedAt"
+		| "connectableAt"
 		| "destroyedAt"
 		| "sleepingAt"
 		| "pendingAllocationAt"
@@ -117,7 +118,7 @@ export function getActorStatus(
 ): ActorStatus {
 	const {
 		createdAt,
-		startedAt,
+		connectableAt,
 		destroyedAt,
 		sleepingAt,
 		pendingAllocationAt,
@@ -133,7 +134,7 @@ export function getActorStatus(
 		return "crash-loop";
 	}
 
-	if (pendingAllocationAt && !startedAt && !destroyedAt) {
+	if (pendingAllocationAt && !connectableAt && !destroyedAt) {
 		return "pending";
 	}
 
@@ -141,19 +142,19 @@ export function getActorStatus(
 		return "sleeping";
 	}
 
-	if (createdAt && !startedAt && !destroyedAt) {
+	if (createdAt && !connectableAt && !destroyedAt) {
 		return "starting";
 	}
 
-	if (createdAt && startedAt && !destroyedAt) {
+	if (createdAt && connectableAt && !destroyedAt) {
 		return "running";
 	}
 
-	if (createdAt && startedAt && destroyedAt) {
+	if (createdAt && connectableAt && destroyedAt) {
 		return "stopped";
 	}
 
-	if (createdAt && !startedAt && destroyedAt) {
+	if (createdAt && !connectableAt && destroyedAt) {
 		return "crashed";
 	}
 


### PR DESCRIPTION
### TL;DR

Updated actor status determination to use `connectableAt` instead of `startedAt` timestamp.

### What changed?

- Added `connectableAt` field to the actor transformation in `inspector-data-provider.tsx`
- Modified the `getActorStatus` function to use `connectableAt` instead of `startedAt` when determining actor status
- Updated the function parameter type to include the new `connectableAt` field

### How to test?

1. Verify actor status is correctly displayed in the UI for actors in different states
2. Check that actors show the correct status transitions (starting → running → stopped/crashed)
3. Confirm that pending and sleeping states are still properly detected

### Why make this change?

The `connectableAt` timestamp provides a more accurate indicator of when an actor becomes available for connections, making it a better signal for determining the actor's running state than the previously used `startedAt` field. This change improves the accuracy of actor status reporting in the UI.