### PR TITLE
fix(dashboard): use rivetkit/client

### DIFF
--- a/frontend/src/app/data-providers/engine-data-provider.tsx
+++ b/frontend/src/app/data-providers/engine-data-provider.tsx
@@ -6,7 +6,7 @@ import {
 	type QueryKey,
 	queryOptions,
 } from "@tanstack/react-query";
-import { KV_KEYS } from "rivetkit";
+import { KV_KEYS } from "rivetkit/client";
 import z from "zod";
 import { getConfig, ls } from "@/components";
 import type { ActorId } from "@/components/actors";

--- a/rivetkit-typescript/packages/rivetkit/src/client/mod.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/mod.ts
@@ -1,5 +1,5 @@
-import type { Registry } from "@/registry";
 import { injectDevtools } from "@/devtools-loader";
+import type { Registry } from "@/registry";
 import { RemoteManagerDriver } from "@/remote-manager-driver/mod";
 import {
 	type Client,
@@ -22,13 +22,14 @@ export {
 	ManagerError,
 } from "@/client/errors";
 export type { CreateRequest } from "@/manager/protocol/query";
+export { KEYS as KV_KEYS } from "../actor/instance/kv";
 export type { ActorActionFunction } from "./actor-common";
 export type {
 	ActorConn,
+	ActorConnStatus,
 	ConnectionStateCallback,
 	EventUnsubscribe,
 	StatusChangeCallback,
-	ActorConnStatus,
 } from "./actor-conn";
 export { ActorConnRaw } from "./actor-conn";
 export type { ActorHandle } from "./actor-handle";


### PR DESCRIPTION
### TL;DR

Fixed import path for KV_KEYS and exported it from the client module.

### What changed?

- Updated the import path for `KV_KEYS` in `engine-data-provider.tsx` from `rivetkit` to `rivetkit/client`
- Exported `KV_KEYS` from the client module in `rivetkit-typescript/packages/rivetkit/src/client/mod.ts`
- Reordered some imports in the client module for better organization

### How to test?

1. Verify that the application builds successfully
2. Check that any functionality using `KV_KEYS` continues to work properly
3. Confirm that imports from `rivetkit/client` resolve correctly

### Why make this change?

This change improves the module structure by properly exporting `KV_KEYS` from the client module, making it accessible through the correct import path. This ensures better encapsulation and organization of the codebase, preventing potential import errors.