### PR TITLE
fix(inspector): use proper kv key, follow metadata client endpoint

### DIFF
--- a/frontend/src/app/data-providers/engine-data-provider.tsx
+++ b/frontend/src/app/data-providers/engine-data-provider.tsx
@@ -383,7 +383,7 @@ export const createNamespaceContext = ({
 				queryFn: async ({ signal: abortSignal }) => {
 					const response = await client.actorsKvGet(
 						actorId,
-						KV_KEYS
+						KV_KEYS.INSPECTOR_TOKEN
 							// @ts-expect-error
 							.toBase64(),
 						{ namespace },

--- a/frontend/src/app/data-providers/inspector-data-provider.tsx
+++ b/frontend/src/app/data-providers/inspector-data-provider.tsx
@@ -1,4 +1,5 @@
 import { queryOptions } from "@tanstack/react-query";
+import z from "zod";
 import {
 	createDefaultGlobalContext,
 	type DefaultDataProvider,
@@ -47,10 +48,10 @@ export const createGlobalContext = (opts: { url?: string; token?: string }) => {
 			return queryOptions({
 				...global.statusQueryOptions(),
 				queryFn: async () => {
-					const response = await fetch(opts.url || "");
-					if (!response.ok) {
-						throw new Error("Failed to fetch status");
+					if (!opts.url) {
+						throw new Error("No inspector URL provided");
 					}
+					await getInspectorClientEndpoint(opts.url);
 					return true;
 				},
 				enabled: Boolean(opts.url),
@@ -58,3 +59,44 @@ export const createGlobalContext = (opts: { url?: string; token?: string }) => {
 		},
 	} satisfies DefaultDataProvider;
 };
+
+export async function getInspectorClientEndpoint(url: string) {
+	const rivetkitEndpoint = url.replace(/\/+$/, "");
+
+	const finalUrl =
+		(await tryMetadata(`${rivetkitEndpoint}`)) ||
+		(await tryMetadata(`${rivetkitEndpoint}/api/rivet`));
+
+	if (!finalUrl) {
+		throw new Error("Failed to reach client endpoint");
+	}
+
+	const finalResponse = await fetch(finalUrl, { method: "OPTIONS" });
+	if (!finalResponse.ok) {
+		throw new Error("Failed to reach client endpoint");
+	}
+
+	return finalUrl;
+}
+
+const metadataSchema = z.object({
+	runtime: z.string().optional(),
+	version: z.string().optional(),
+	clientEndpoint: z.string().optional(),
+});
+
+async function tryMetadata(url: string) {
+	try {
+		const response = await fetch(`${url}/metadata`);
+		if (!response.ok) {
+			throw new Error("Failed to fetch metadata");
+		}
+
+		const data = await response.json();
+		const parsed = metadataSchema.parse(data);
+
+		return parsed.clientEndpoint || url;
+	} catch {
+		return null;
+	}
+}

--- a/frontend/src/app/inspector-root.tsx
+++ b/frontend/src/app/inspector-root.tsx
@@ -4,6 +4,7 @@ import { askForLocalNetworkAccess } from "@/lib/permissions";
 import { Actors } from "./actors";
 import { BuildPrefiller } from "./build-prefiller";
 import { Connect } from "./connect";
+import { getInspectorClientEndpoint } from "./data-providers/inspector-data-provider";
 import { useInspectorContext } from "./inspector-context";
 import { Logo } from "./logo";
 import { RouteLayout } from "./route-layout";
@@ -51,14 +52,11 @@ export function InspectorRoot() {
 						}
 
 						try {
-							const response = await fetch(values.url, {
-								method: "OPTIONS",
-							});
-							if (!response.ok) {
-								throw new Error("CORS preflight failed");
-							}
+							const realUrl = await getInspectorClientEndpoint(
+								values.url,
+							);
 
-							await connect({ url: values.url });
+							await connect({ url: realUrl });
 						} catch {
 							form.setError("url", {
 								message: "localhost.cors.error",


### PR DESCRIPTION
### TL;DR

Improved inspector connection handling with better endpoint discovery and error handling.

### What changed?

- Added a new `getInspectorClientEndpoint` function that attempts to discover the correct client endpoint URL by checking metadata
- Fixed the KV key reference in `engine-data-provider.tsx` to use `KV_KEYS.INSPECTOR_TOKEN` instead of the entire `KV_KEYS` object
- Enhanced the connection process in `inspector-root.tsx` to use the new endpoint discovery function
- Added proper metadata schema validation using Zod
- Improved error handling for inspector connections

### How to test?

1. Attempt to connect to an inspector URL in the UI
2. Verify that the connection works with both direct URLs and URLs that require endpoint discovery
3. Test with invalid URLs to ensure proper error handling
4. Verify that the inspector token is correctly retrieved from KV storage

### Why make this change?

This change improves the reliability of connecting to inspector endpoints by implementing a discovery mechanism that can find the correct client endpoint URL. It handles various URL formats and validates the connection properly, making the inspector connection process more robust and user-friendly.