### PR TITLE
feat(inspector): add console (repl) history navigation

### DIFF
--- a/frontend/src/components/actors/console/repl-input.tsx
+++ b/frontend/src/components/actors/console/repl-input.tsx
@@ -34,10 +34,12 @@ interface ReplInputProps {
 	className: string;
 	rpcs: string[];
 	onRun: (code: string) => void;
+	onHistoryUp?: () => void;
+	onHistoryDown?: () => void;
 }
 
 export const ReplInput = forwardRef<ReplInputRef, ReplInputProps>(
-	({ rpcs, onRun, className }, ref) => {
+	({ rpcs, onRun, onHistoryUp, onHistoryDown, className }, ref) => {
 		const rivetKeymap = keymap.of([
 			{
 				key: "Enter",
@@ -51,6 +53,20 @@ export const ReplInput = forwardRef<ReplInputRef, ReplInputProps>(
 						},
 						annotations: [External.of(true)],
 					});
+					return true;
+				},
+			},
+			{
+				key: "ArrowUp",
+				run: () => {
+					onHistoryUp?.();
+					return true;
+				},
+			},
+			{
+				key: "ArrowDown",
+				run: () => {
+					onHistoryDown?.();
 					return true;
 				},
 			},


### PR DESCRIPTION
### TL;DR

Added command history functionality to the actor console input.

### What changed?

- Added state management for command history in `actor-console-input.tsx` using `useState` hooks
- Implemented up/down arrow key navigation through previously executed commands
- Added new props to the `ReplInput` component to handle history navigation
- Added keyboard event handlers for ArrowUp and ArrowDown keys

### How to test?

1. Open the actor console
2. Enter and execute multiple commands
3. Press the up arrow key to cycle through previously executed commands (newest to oldest)
4. Press the down arrow key to navigate forward through the history
5. Verify that pressing down at the end of history clears the input

### Why make this change?

This improves the developer experience when working with the actor console by allowing users to easily recall and reuse previously executed commands, similar to how terminal interfaces work. This saves time and reduces errors when users need to repeat or modify previous commands.