### PR TITLE
fix(inspector): prevent rivetkit version info to flicker

### DIFF
--- a/frontend/src/components/actors/guard-connectable-inspector.tsx
+++ b/frontend/src/components/actors/guard-connectable-inspector.tsx
@@ -152,11 +152,11 @@ function ActorContextProvider(props: {
 	actorId: ActorId;
 	children: ReactNode;
 }) {
-	const { token, metadata, isError, error } = useActorInspectorData(
+	const { isError, token, metadata, error } = useActorInspectorData(
 		props.actorId,
 	);
 
-	if (isError) {
+	if (!token || !metadata || isError) {
 		return (
 			<InspectorGuardContext.Provider
 				value={


### PR DESCRIPTION
### TL;DR

Fixed a bug in the guard connectable inspector by improving error handling when token or metadata is missing.

### What changed?

- Reordered the destructured variables in the `useActorInspectorData` hook for better readability
- Enhanced the error condition check to verify that both `token` and `metadata` exist before rendering content
- Previously, the component only checked `isError` but now it also checks for the existence of required data

### How to test?

1. Navigate to a page with the actor inspector component
2. Test scenarios where token or metadata might be undefined:
   - Test with invalid actor IDs
   - Test with network failures
   - Test with partial data responses
3. Verify that the error handling works correctly and the component doesn't attempt to render with missing data

### Why make this change?

This change prevents potential runtime errors that could occur when the component tries to use `token` or `metadata` that might be undefined. The previous implementation only checked for explicit errors but didn't account for missing data, which could lead to unexpected behavior or crashes.