### PR TITLE
fix(dashboard): onboarding tiny bits

### DIFF
--- a/frontend/src/app/data-providers/engine-data-provider.tsx
+++ b/frontend/src/app/data-providers/engine-data-provider.tsx
@@ -270,10 +270,13 @@ export const createNamespaceContext = ({
 					return data;
 				},
 				getNextPageParam: (lastPage) => {
-					if (lastPage.actors.length < RECORDS_PER_PAGE) {
-						return undefined;
-					}
-					return lastPage.pagination.cursor;
+					// TEMPORARILY DISABLED PAGINATION
+					// FIXME(@NathanFlurry)
+					return undefined;
+					// if (lastPage.actors.length < RECORDS_PER_PAGE) {
+					// 	return undefined;
+					// }
+					// return lastPage.pagination.cursor;
 				},
 				retry: shouldRetryAllExpect403,
 				throwOnError: noThrow,

--- a/frontend/src/app/dialogs/connect-manual-frame.tsx
+++ b/frontend/src/app/dialogs/connect-manual-frame.tsx
@@ -1,12 +1,6 @@
 import { faServer, Icon } from "@rivet-gg/icons";
 import { useState } from "react";
-import {
-	type DialogContentProps,
-	Frame,
-	Tabs,
-	ToggleGroup,
-	ToggleGroupItem,
-} from "@/components";
+import { type DialogContentProps, Frame } from "@/components";
 import { RunnerConfigToggleGroup } from "../runner-config-toggle-group";
 import ConnectManualServerlfullFrameContent from "./connect-manual-serverfull-frame";
 import ConnectManualServerlessFrameContent from "./connect-manual-serverless-frame";
@@ -16,7 +10,7 @@ interface CreateProjectFrameContentProps extends DialogContentProps {}
 export default function CreateProjectFrameContent({
 	onClose,
 }: CreateProjectFrameContentProps) {
-	const [mode, setMode] = useState("serverfull");
+	const [mode, setMode] = useState("serverless");
 
 	return (
 		<>

--- a/frontend/src/app/dialogs/connect-manual-serverfull-frame.tsx
+++ b/frontend/src/app/dialogs/connect-manual-serverfull-frame.tsx
@@ -67,10 +67,11 @@ export default function ConnectManualServerlfullFrameContent({
 
 	const prefferedRegionForRailway =
 		data.find((region) => region.name.toLowerCase().includes("us-west"))
-			?.id ||
+			?.name ||
 		data.find((region) => region.name.toLowerCase().includes("us-east"))
-			?.id ||
-		data.find((region) => region.name.toLowerCase().includes("ore"))?.id ||
+			?.name ||
+		data.find((region) => region.name.toLowerCase().includes("ore"))
+			?.name ||
 		"auto";
 
 	return (

--- a/frontend/src/app/dialogs/connect-quick-railway-frame.tsx
+++ b/frontend/src/app/dialogs/connect-quick-railway-frame.tsx
@@ -61,10 +61,11 @@ export default function ConnectQuickRailwayFrameContent({
 
 	const prefferedRegionForRailway =
 		data.find((region) => region.name.toLowerCase().includes("us-west"))
-			?.id ||
+			?.name ||
 		data.find((region) => region.name.toLowerCase().includes("us-east"))
-			?.id ||
-		data.find((region) => region.name.toLowerCase().includes("ore"))?.id ||
+			?.name ||
+		data.find((region) => region.name.toLowerCase().includes("ore"))
+			?.name ||
 		"auto";
 
 	return (

--- a/frontend/src/app/dialogs/connect-quick-vercel-frame.tsx
+++ b/frontend/src/app/dialogs/connect-quick-vercel-frame.tsx
@@ -148,12 +148,14 @@ const useVercelTemplateLink = () => {
 	return useMemo(() => {
 		const repositoryUrl = "https://github.com/rivet-dev/template-vercel";
 		const env = [
+			"RIVET_ENDPOINT",
 			"NEXT_PUBLIC_RIVET_ENDPOINT",
 			"NEXT_PUBLIC_RIVET_TOKEN",
 			"NEXT_PUBLIC_RIVET_NAMESPACE",
 		].join(",");
 		const projectName = "rivetkit-vercel";
 		const envDefaults = {
+			RIVET_ENDPOINT: endpoint,
 			NEXT_PUBLIC_RIVET_ENDPOINT: endpoint,
 			NEXT_PUBLIC_RIVET_TOKEN: token,
 			NEXT_PUBLIC_RIVET_NAMESPACE: dataProvider.engineNamespace,

--- a/frontend/src/app/dialogs/connect-railway-frame.tsx
+++ b/frontend/src/app/dialogs/connect-railway-frame.tsx
@@ -72,10 +72,11 @@ export default function ConnectRailwayFrameContent({
 
 	const prefferedRegionForRailway =
 		data.find((region) => region.name.toLowerCase().includes("us-west"))
-			?.id ||
+			?.name ||
 		data.find((region) => region.name.toLowerCase().includes("us-east"))
-			?.id ||
-		data.find((region) => region.name.toLowerCase().includes("ore"))?.id ||
+			?.name ||
+		data.find((region) => region.name.toLowerCase().includes("ore"))
+			?.name ||
 		"auto";
 
 	return (

--- a/frontend/src/app/dialogs/connect-vercel-frame.tsx
+++ b/frontend/src/app/dialogs/connect-vercel-frame.tsx
@@ -19,7 +19,7 @@ import {
 	Frame,
 	getConfig,
 } from "@/components";
-import { type Region, useEngineCompatDataProvider } from "@/components/actors";
+import { useEngineCompatDataProvider } from "@/components/actors";
 import { cloudEnv } from "@/lib/env";
 import { usePublishableToken } from "@/queries/accessors";
 import { queryClient } from "@/queries/global";
@@ -118,6 +118,15 @@ function FormStepper({
 						endpoint={endpoint}
 						namespace={namespace}
 					/>
+				),
+				variables: () => (
+					<>
+						<p>
+							Set these variables in Settings &gt; Environment
+							Variables in the Vercel dashboard.
+						</p>
+						<ConnectVercelForm.EnvVariables />
+					</>
 				),
 				deploy: () => <StepDeploy />,
 			}}

--- a/frontend/src/app/env-variables.tsx
+++ b/frontend/src/app/env-variables.tsx
@@ -8,11 +8,13 @@ export function EnvVariables({
 	runnerName,
 	endpoint,
 	kind,
+	prefixlessEndpint = false,
 }: {
 	prefix?: string;
 	runnerName?: string;
 	endpoint: string;
 	kind: "serverless" | "serverfull";
+	prefixlessEndpint?: boolean;
 }) {
 	return (
 		<div>
@@ -26,6 +28,10 @@ export function EnvVariables({
 				<Label asChild className="text-muted-foreground text-xs mb-1">
 					<p>Value</p>
 				</Label>
+
+				{prefixlessEndpint ? (
+					<RivetEndpointEnv endpoint={endpoint} />
+				) : null}
 				<RivetEndpointEnv prefix={prefix} endpoint={endpoint} />
 				<RivetTokenEnv prefix={prefix} kind={kind} />
 				<RivetNamespaceEnv prefix={prefix} />

--- a/frontend/src/app/forms/connect-vercel-form.tsx
+++ b/frontend/src/app/forms/connect-vercel-form.tsx
@@ -65,6 +65,14 @@ export const stepper = defineStepper(
 		schema: z.object({}),
 	},
 	{
+		id: "variables",
+		title: "Configure Environment Variables",
+		assist: false,
+		next: "Next",
+		optional: true,
+		schema: z.object({}),
+	},
+	{
 		id: "deploy",
 		title: "Deploy to Vercel",
 		assist: true,
@@ -296,6 +304,7 @@ export function EnvVariables() {
 			prefix="NEXT_PUBLIC"
 			endpoint={useSelectedDatacenter()}
 			kind="serverless"
+			prefixlessEndpint
 			runnerName={useWatch({ name: "runnerName" }) as string}
 		/>
 	);

--- a/frontend/src/app/runner-config-toggle-group.tsx
+++ b/frontend/src/app/runner-config-toggle-group.tsx
@@ -15,12 +15,12 @@ export function RunnerConfigToggleGroup({
 		<div
 			id={id}
 			className={cn(
-				"flex mx-auto items-center justify-center",
+				"flex mx-auto items-center justify-center mb-4",
 				className,
 			)}
 		>
 			<ToggleGroup
-				defaultValue="serverfull"
+				defaultValue="serverless"
 				type="single"
 				className="border rounded-md gap-0 w-full"
 				value={mode}
@@ -41,7 +41,7 @@ export function RunnerConfigToggleGroup({
 					value="serverfull"
 					className="border-l rounded-none w-full"
 				>
-					Dedicated
+					Runners
 				</ToggleGroupItem>
 			</ToggleGroup>
 		</div>


### PR DESCRIPTION
# Temporarily Disable Pagination and Update Connection Dialogs

### TL;DR

Temporarily disabled pagination in the engine data provider and updated connection dialogs with improved region selection and environment variable handling.

### What changed?

- Temporarily disabled pagination in the engine data provider
- Changed default mode from "serverfull" to "serverless" in connection dialogs
- Fixed region selection to use region name instead of ID in Railway and manual connection frames
- Added `RIVET_ENDPOINT` environment variable to Vercel template
- Added a new "variables" step to the Vercel connection flow
- Updated UI labels in the runner config toggle group (changed "Dedicated" to "Runners")
- Added support for prefixless endpoint environment variables

### How to test?

1. Verify that pagination is disabled in the engine data provider
2. Check that connection dialogs default to "serverless" mode
3. Confirm region selection works correctly in Railway and manual connection frames
4. Test the Vercel connection flow with the new "variables" step
5. Verify environment variables are correctly displayed with both prefixed and prefixless options

### Why make this change?

These changes improve the connection experience by defaulting to serverless mode, which is more appropriate for most users. The pagination disabling is a temporary fix for an issue that needs to be addressed later. The environment variable improvements ensure better compatibility with various deployment platforms, particularly Vercel, by providing both prefixed and prefixless options.