### PR TITLE
fix(dashboard): disable pagination on actor builds

### DIFF
--- a/frontend/src/app/data-providers/engine-data-provider.tsx
+++ b/frontend/src/app/data-providers/engine-data-provider.tsx
@@ -270,13 +270,10 @@ export const createNamespaceContext = ({
 					return data;
 				},
 				getNextPageParam: (lastPage) => {
-					// TEMPORARILY DISABLED PAGINATION
-					// FIXME(@NathanFlurry)
-					return undefined;
-					// if (lastPage.actors.length < RECORDS_PER_PAGE) {
-					// 	return undefined;
-					// }
-					// return lastPage.pagination.cursor;
+					if (lastPage.actors.length < RECORDS_PER_PAGE) {
+						return undefined;
+					}
+					return lastPage.pagination.cursor;
 				},
 				retry: shouldRetryAllExpect403,
 				throwOnError: noThrow,
@@ -302,7 +299,12 @@ export const createNamespaceContext = ({
 
 					return data;
 				},
-				getNextPageParam: (lastPage) => lastPage.pagination?.cursor,
+				getNextPageParam: (lastPage) => {
+					// TEMPORARILY DISABLED PAGINATION
+					// FIXME(@NathanFlurry)
+					return undefined;
+					// return lastPage.pagination?.cursor;
+				},
 				retry: shouldRetryAllExpect403,
 				throwOnError: noThrow,
 				meta: {


### PR DESCRIPTION
### TL;DR

Swapped pagination functionality between actors and another endpoint.

### What changed?

- Re-enabled pagination for actors by uncommenting the code that checks if the number of actors is less than `RECORDS_PER_PAGE` and returns the pagination cursor
- Temporarily disabled pagination for another endpoint by commenting out the cursor return and adding a FIXME comment with the same attribution (@NathanFlurry)

### How to test?

1. Navigate to a page that displays actors
2. Verify that pagination works correctly when there are more actors than fit on a single page
3. Check that the other endpoint (which had pagination disabled) doesn't attempt to load additional pages

### Why make this change?

It appears that pagination was temporarily disabled for actors but should now be re-enabled, while pagination for another endpoint needs to be temporarily disabled. This change ensures the correct pagination behavior for each endpoint.