### PR TITLE
fix(inspector): prevent flickering upgrade notice

### DIFF
--- a/frontend/src/components/actors/actor-inspector-context.tsx
+++ b/frontend/src/components/actors/actor-inspector-context.tsx
@@ -195,6 +195,9 @@ export const createDefaultActorInspectorContext = ({
 	actorMetadataQueryOptions(actorId: ActorId) {
 		return queryOptions({
 			queryKey: ["actor", actorId, "metadata"],
+			retry: 0,
+			retryDelay: 5_000,
+			refetchInterval: 5_000,
 			queryFn: async () => {
 				return api.getMetadata();
 			},
@@ -285,6 +288,9 @@ export const actorMetadataQueryOptions = ({
 }) =>
 	queryOptions({
 		queryKey: ["actor", actorId, "metadata"],
+		retry: 0,
+		retryDelay: 5_000,
+		refetchInterval: 1_000,
 		queryFn: async () => {
 			return getActorMetadata({ actorId, credentials });
 		},
@@ -328,8 +334,6 @@ export const ActorInspectorProvider = ({
 
 	const { isSuccess: isActorMetadataSuccess } = useQuery({
 		...actorMetadataQueryOptions({ actorId, credentials }),
-		retry: 0,
-		refetchInterval: 5_000,
 	});
 
 	const { isSuccess: isActorDataSuccess } = useActorInspectorData(actorId);

--- a/frontend/src/components/actors/guard-connectable-inspector.tsx
+++ b/frontend/src/components/actors/guard-connectable-inspector.tsx
@@ -429,7 +429,13 @@ function InspectorGuard({
 		actorMetadataQueryOptions,
 	} = useActorInspector();
 
-	const { isLoading } = useQuery(actorMetadataQueryOptions(actorId));
+	const { data, isLoading, error } = useQuery(
+		actorMetadataQueryOptions(actorId),
+	);
+
+	if (!data || error || !isInspectorAvailable) {
+		return <OutdatedInspector>{children}</OutdatedInspector>;
+	}
 
 	if (isLoading) {
 		return (
@@ -437,10 +443,6 @@ function InspectorGuard({
 				{children}
 			</InspectorGuardContext.Provider>
 		);
-	}
-
-	if (!isInspectorAvailable) {
-		return <OutdatedInspector>{children}</OutdatedInspector>;
 	}
 
 	if (connectionStatus === "error") {


### PR DESCRIPTION
### TL;DR

Improved actor inspector reliability by updating query retry logic and fixing the inspector guard component.

### What changed?

- Added retry configuration to actor metadata query options:
  - Set `retry: 0` to prevent automatic retries
  - Added `retryDelay: 5_000` to wait 5 seconds between retries
  - Set `refetchInterval` to periodically refresh data (5 seconds in one case, 1 second in another)
- Moved query configuration from the component level to the query options
- Fixed the `InspectorGuard` component to properly handle error states and data availability:
  - Now checks for missing data or errors before checking loading state
  - Shows the `OutdatedInspector` component when data is unavailable or there's an error

### How to test?

1. Open the actor inspector for any actor
2. Verify that the inspector loads correctly
3. Temporarily disconnect from the network and verify the inspector shows the outdated state
4. Reconnect and verify the inspector recovers properly

### Why make this change?

This change improves the reliability of the actor inspector by ensuring proper error handling and implementing a consistent retry strategy. The updated logic ensures users see appropriate feedback when the inspector can't connect to an actor, and the periodic refetching helps maintain up-to-date information.