### PR TITLE
feat(dashboard): posthog event for failed runner configs

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -37,6 +37,7 @@ declare module "@tanstack/react-query" {
 		queryMeta: {
 			mightRequireAuth?: boolean;
 			statusCheck?: boolean;
+			reportType?: string;
 		};
 	}
 }

--- a/frontend/src/app/forms/connect-manual-serverless-form.tsx
+++ b/frontend/src/app/forms/connect-manual-serverless-form.tsx
@@ -472,6 +472,9 @@ export function ConnectionCheck({ provider }: { provider: string }) {
 			enabled,
 			retry: 0,
 			refetchInterval: 3_000,
+			meta: {
+				reportType: "runner-config-health-check",
+			},
 		});
 
 	const {

--- a/frontend/src/queries/global.ts
+++ b/frontend/src/queries/global.ts
@@ -4,6 +4,7 @@ import {
 	QueryClient,
 	queryOptions,
 } from "@tanstack/react-query";
+import posthog from "posthog-js";
 import { toast } from "@/components";
 import { isRivetApiError } from "@/lib/errors";
 import { modal } from "@/utils/modal-utils";
@@ -18,6 +19,14 @@ const queryCache = new QueryCache({
 		) {
 			modal.open("ProvideEngineCredentials", { dismissible: false });
 			return;
+		}
+
+		if (query.meta?.reportType) {
+			posthog.capture(query.meta.reportType, {
+				type: "error",
+				error,
+				queryKey: query.queryKey,
+			});
 		}
 	},
 	onSuccess(data, query) {
@@ -50,9 +59,7 @@ export const changelogQueryOptions = () => {
 		queryKey: ["changelog", __APP_BUILD_ID__],
 		staleTime: 1 * 60 * 60 * 1000, // 1 hour
 		queryFn: async () => {
-			const response = await fetch(
-				"https://rivet.dev/changelog.json",
-			);
+			const response = await fetch("https://rivet.dev/changelog.json");
 			if (!response.ok) {
 				throw new Error("Failed to fetch changelog");
 			}


### PR DESCRIPTION
### TL;DR

Added error reporting for runner configuration health checks using PostHog.

### What changed?

- Extended the `queryMeta` interface to include a new `reportType` field
- Added PostHog error reporting in the query cache's `onError` handler when a `reportType` is specified
- Implemented the error reporting specifically for runner configuration health checks by setting `reportType: "runner-config-serverless-health-check"` in the connection check query

### How to test?

1. Trigger a failed runner configuration health check
2. Verify that PostHog captures an event with type "runner-config-health-check" containing the error details and query key

### Why make this change?

This change improves error tracking for runner configuration health checks, allowing us to better understand and diagnose issues users encounter when setting up serverless runners. By capturing these errors in PostHog, we can analyze patterns and improve the configuration experience.