### PR TITLE
feat(dashboard): plain: require auth from users

### DIFF
--- a/frontend/vite.cloud.config.ts
+++ b/frontend/vite.cloud.config.ts
@@ -18,6 +18,7 @@ export default defineConfig((config) => {
   script.async = false;
   script.onload = function(){
     Plain.init({
+      requireAuthentication: true,
       appId: 'liveChatApp_01K5D3WHR3CGKA56RPRMBB7FX0',
 	  hideLauncher: true,
 	  theme: 'dark',


### PR DESCRIPTION
### TL;DR

Enable authentication requirement for Plain chat widget.

### What changed?

Added the `requireAuthentication: true` parameter to the Plain.init configuration in the frontend Vite cloud config file.

### How to test?

1. Load the application in cloud environment
2. Verify that the Plain chat widget requires authentication before allowing users to interact with it
3. Confirm that unauthenticated users cannot access the chat functionality

### Why make this change?

This change enhances security by ensuring that only authenticated users can access the live chat support feature, preventing potential abuse from anonymous users and providing better user tracking for support interactions.