### PR TITLE
fix(dashboard): change to proper dsn

### DIFF
--- a/frontend/src/app/env-variables.tsx
+++ b/frontend/src/app/env-variables.tsx
@@ -104,7 +104,7 @@ export const useRivetDsn = ({
 	const adminToken = useAdminToken();
 	const token = kind === "serverless" ? publishableToken : adminToken;
 
-	const dsn = `https://${token}:${dataProvider.engineNamespace}@${endpoint
+	const dsn = `https://${dataProvider.engineNamespace}:${token}@${endpoint
 		.replace("https://", "")
 		.replace("http://", "")}`;
 


### PR DESCRIPTION
### TL;DR

Fixed the DSN format by swapping the token and engine namespace positions.

### What changed?

Corrected the DSN (Data Source Name) string format in the `useRivetDsn` hook. The previous implementation incorrectly placed the token before the engine namespace in the DSN URL. This PR swaps their positions to follow the correct format: `https://{engineNamespace}:{token}@{endpoint}`.

### How to test?

1. Verify that connections to the data provider work correctly with the new DSN format
2. Test both serverless and admin token scenarios to ensure proper authentication
3. Check that endpoints with both HTTP and HTTPS protocols are handled correctly

### Why make this change?

The incorrect DSN format was likely causing authentication issues when connecting to the data provider. This fix ensures that the DSN follows the expected format where the engine namespace comes before the token in the URL, which is required for proper authentication and connection to the service.