### PR TITLE
fix(dashboard): runner endpoint needs to end with /api/rivet

### DIFF
--- a/frontend/src/app/forms/connect-manual-serverless-form.tsx
+++ b/frontend/src/app/forms/connect-manual-serverless-form.tsx
@@ -39,7 +39,8 @@ import { VisibilitySensor } from "@/components/visibility-sensor";
 export const endpointSchema = z
 	.string()
 	.nonempty("Endpoint is required")
-	.url("Please enter a valid URL");
+	.url("Please enter a valid URL")
+	.endsWith("/api/rivet", "Endpoint must end with /api/rivet");
 
 export const configurationSchema = z.object({
 	runnerName: z.string().min(1, "Runner name is required"),


### PR DESCRIPTION
### TL;DR

Added validation to ensure serverless endpoints end with `/api/rivet`

### What changed?

Modified the `endpointSchema` validation in `connect-manual-serverless-form.tsx` to require that endpoints must end with `/api/rivet`. This adds an additional validation check beyond the existing requirements that the endpoint is non-empty and a valid URL.

### How to test?

1. Navigate to the manual serverless connection form
2. Try entering various endpoint URLs:
   - A URL that doesn't end with `/api/rivet` should show the new validation error
   - A URL that properly ends with `/api/rivet` should pass validation
3. Verify the error message "Endpoint must end with /api/rivet" appears when validation fails

### Why make this change?

This validation ensures users provide correctly formatted endpoints that will work with our API. Adding this constraint prevents connection errors that would occur when users attempt to connect with incompatible endpoint formats.