### PR TITLE
fix(dashboard): invalidate when skipping onboarding

### DIFF
--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -253,6 +253,7 @@ export function GettingStarted({
 
 function StepperFooter() {
 	const s = stepper.useStepper();
+	const router = useRouter();
 	return (
 		<div className="flex items-center justify-center gap-4">
 			{s.isLast ? (
@@ -272,12 +273,18 @@ function StepperFooter() {
 				variant="link"
 				className="text-muted-foreground"
 				size="xs"
-				asChild
+				onClick={() => {
+					router.invalidate();
+					return router.navigate({
+						to: ".",
+						search: {
+							skipOnboarding: true,
+						},
+					});
+				}}
 				endIcon={<Icon icon={faChevronRight} />}
 			>
-				<Link to="." search={{ skipOnboarding: true }}>
-					Skip Setup
-				</Link>
+				Skip Setup
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
### TL;DR

Updated the "Skip Setup" button in the Getting Started page to use a programmatic navigation approach instead of a Link component.

### What changed?

- Added `useRouter` hook to the `StepperFooter` component
- Replaced the `Link` component with a direct `onClick` handler on the Button
- The onClick handler now:
  - Invalidates the router cache
  - Navigates to the same page with the `skipOnboarding=true` search parameter
- Removed the `asChild` prop from the Button since it no longer wraps a Link

### How to test?

1. Navigate to the Getting Started/onboarding flow
2. Click the "Skip Setup" button at the bottom
3. Verify you're redirected to the main page with onboarding skipped
4. Check that the router cache is properly invalidated

### Why make this change?

This change improves the navigation flow by ensuring the router cache is invalidated before redirecting, which prevents stale data from being displayed after skipping the onboarding process. The programmatic approach gives more control over the navigation behavior compared to the declarative Link component.