### PR TITLE
fix(dashboard): fetch properly actor counts

### DIFF
--- a/frontend/src/components/actors/actor-status-label.tsx
+++ b/frontend/src/components/actors/actor-status-label.tsx
@@ -116,8 +116,8 @@ export function ActorError({ error }: { error: object | string }) {
 				Actor didn't stop in time.
 			</p>
 		))
-		.with(P.shape({ crashed: P.any }), () => (
-			<p>Actor exited with an error and is now sleeping.</p>
+		.with(P.shape({ crashed: P.shape({ message: P.string }) }), (err) => (
+			<p>Actor crashed. {err.crashed.message} </p>
 		))
 		.otherwise(() => {
 			return <p>Unknown error.</p>;


### PR DESCRIPTION
### TL;DR

Added actor count query functionality and improved the onboarding experience with better error handling and deployment URL formatting.

### What changed?

- Added a new `actorsCountQueryOptions` function to efficiently query the count of actors
- Updated the frontend setup to use the new actor count query instead of fetching all actors
- Improved actor error display to show crash messages
- Fixed deployment URL formatting by properly extracting the base URL
- Added Posthog tracking for when users skip onboarding
- Enhanced the namespace route to use the new actor count query for determining if actors exist
- Improved error handling in the actor status label component to display more specific crash messages

### How to test?

1. Navigate to the getting started flow and verify the actor count is displayed correctly
2. Check that deployment URLs are properly formatted in the frontend setup
3. Trigger an actor crash and verify the error message is displayed correctly
4. Skip onboarding and confirm the Posthog event is captured

### Why make this change?

The previous implementation was inefficient as it fetched all actors just to get a count. This change optimizes performance by providing a dedicated endpoint for actor counts. Additionally, the improved error handling and URL formatting enhance the user experience during onboarding by providing clearer feedback and properly formatted links.