### PR TITLE
fix(dashboard): resource not found when navigating to settings on projects page

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -152,6 +152,7 @@ const Sidebar = ({
 	ref?: RefObject<ImperativePanelHandle | null>;
 } & ComponentProps<typeof ResizablePanel>) => {
 	const sidebarMinWidth = useContext(SidebarDimensionsContext);
+	const matchRoute = useMatchRoute();
 	return (
 		<>
 			<ResizablePanel
@@ -193,16 +194,20 @@ const Sidebar = ({
 								return (
 									<>
 										<div className="flex gap-0.5 my-2 px-2.5 flex-col">
-											<HeaderLink
-												to="/orgs/$organization/projects/$project/ns/$namespace/settings"
-												className="font-normal"
-												icon={faCog}
-											>
-												Settings
-											</HeaderLink>
+											{matchRoute({
+												to: "/orgs/$organization/projects/$project/ns/$namespace",
+												fuzzy: true,
+											}) ? (
+												<HeaderLink
+													to="/orgs/$organization/projects/$project/ns/$namespace/settings"
+													className="font-normal"
+													icon={faCog}
+												>
+													Settings
+												</HeaderLink>
+											) : null}
 											<HelpDropdown>
 												<HeaderButton
-													size="xs"
 													startIcon={
 														<Icon
 															icon={
@@ -218,7 +223,6 @@ const Sidebar = ({
 
 											<Changelog>
 												<HeaderButton
-													size="xs"
 													startIcon={
 														<Icon
 															icon={faGift}
@@ -252,7 +256,7 @@ const Sidebar = ({
 								<>
 									<div className="flex gap-0.5 my-2 px-2.5 flex-col">
 										<Changelog>
-											<HeaderButton size="xs">
+											<HeaderButton asChild>
 												<a
 													href="https://www.rivet.dev/changelog"
 													target="_blank"
@@ -266,7 +270,7 @@ const Sidebar = ({
 												</a>
 											</HeaderButton>
 										</Changelog>
-										<HeaderButton asChild size="xs">
+										<HeaderButton asChild>
 											<Link
 												to="."
 												search={(old) => ({
@@ -278,8 +282,6 @@ const Sidebar = ({
 											</Link>
 										</HeaderButton>
 										<HeaderButton
-											className="text-muted-foreground justify-start py-1 h-auto"
-											size="xs"
 											asChild
 											endIcon={
 												<Icon
@@ -297,9 +299,6 @@ const Sidebar = ({
 											</a>
 										</HeaderButton>
 										<HeaderButton
-											variant="ghost"
-											className="text-muted-foreground justify-start py-1 h-auto"
-											size="xs"
 											asChild
 											endIcon={
 												<Icon
@@ -317,9 +316,6 @@ const Sidebar = ({
 											</a>
 										</HeaderButton>
 										<HeaderButton
-											variant="ghost"
-											size="xs"
-											className="text-muted-foreground justify-start py-1 h-auto"
 											asChild
 											endIcon={
 												<Icon


### PR DESCRIPTION
Closes FRONT-916



### TL;DR

Conditionally render the Settings link in the sidebar and clean up button styling.

### What changed?

- Added conditional rendering for the Settings link in the sidebar, only showing it when the user is on a namespace page
- Removed explicit `size="xs"` attributes from various HeaderButton components
- Removed redundant styling classes from several HeaderButton components
- Added the `useMatchRoute` hook to check the current route for conditional rendering

### How to test?

1. Navigate to a namespace page and verify the Settings link appears in the sidebar
2. Navigate away from a namespace page and verify the Settings link disappears
3. Check that all buttons in the sidebar maintain consistent styling despite the removed attributes

### Why make this change?

This change improves the user experience by only showing relevant navigation options based on context. The Settings link is only useful when viewing a namespace, so it should only appear in that context. Additionally, the code is cleaner by removing redundant styling attributes that are likely handled by default component styles.FRONT-916