### PR TITLE
fix(dashboard): display support dropdown on actor error

### DIFF
--- a/frontend/src/app/context-switcher.tsx
+++ b/frontend/src/app/context-switcher.tsx
@@ -288,7 +288,8 @@ function ProjectList({
 									startIcon={<Icon icon={faPlusCircle} />}
 									onClick={() => {
 										onHover?.(null);
-										navigate({
+										onClose?.();
+										return navigate({
 											to: ".",
 											search: (old) => ({
 												...old,
@@ -344,7 +345,8 @@ function ProjectList({
 							keywords={["create", "new", "project"]}
 							onSelect={() => {
 								onHover?.(null);
-								navigate({
+								onClose?.();
+								return navigate({
 									to: ".",
 									search: (old) => ({
 										...old,
@@ -466,7 +468,8 @@ function NamespaceList({
 									size="sm"
 									startIcon={<Icon icon={faPlusCircle} />}
 									onClick={() => {
-										navigate({
+										onClose?.();
+										return navigate({
 											to: ".",
 											search: (old) => ({
 												...old,
@@ -490,10 +493,11 @@ function NamespaceList({
 									]}
 									className="static w-full"
 									onSelect={() => {
+										onClose?.();
 										clerk.setActive({
 											organization,
 										});
-										navigate({
+										return navigate({
 											to: "/orgs/$organization/projects/$project/ns/$namespace",
 											params: {
 												organization: organization,
@@ -501,7 +505,6 @@ function NamespaceList({
 												namespace: namespace.name,
 											},
 										});
-										onClose?.();
 									}}
 								>
 									<span className="truncate w-full">
@@ -523,7 +526,8 @@ function NamespaceList({
 						<CommandItem
 							keywords={["create", "new", "namespace"]}
 							onSelect={() => {
-								navigate({
+								onClose?.();
+								return navigate({
 									to: ".",
 									search: (old) => ({
 										...old,

--- a/frontend/src/app/runner-config-table.tsx
+++ b/frontend/src/app/runner-config-table.tsx
@@ -40,6 +40,7 @@ import {
 	useEngineCompatDataProvider,
 } from "@/components/actors";
 import { REGION_LABEL } from "@/components/matchmaker/lobby-region";
+import { RivetActorError } from "@/queries/types";
 
 interface RunnerConfigsTableProps {
 	isLoading?: boolean;
@@ -217,7 +218,7 @@ function StatusCell({
 	datacenters: Record<string, Rivet.RunnerConfigResponse>;
 }) {
 	const errors = useMemo(() => {
-		const errorMap: Record<string, object | undefined> = {};
+		const errorMap: Record<string, RivetActorError | undefined> = {};
 		let hasErrors = false;
 		for (const [dc, config] of Object.entries(datacenters)) {
 			if (config.runnerPoolError) {

--- a/frontend/src/components/actors/actor-status-label.tsx
+++ b/frontend/src/components/actors/actor-status-label.tsx
@@ -1,4 +1,3 @@
-import type { Rivet } from "@rivetkit/engine-api-full";
 import { useQuery } from "@tanstack/react-query";
 import { formatISO } from "date-fns";
 import { isObject } from "lodash";
@@ -15,6 +14,7 @@ import { ScrollArea } from "../ui/scroll-area";
 import { Code } from "../ui/typography";
 import { useDataProvider } from "./data-provider";
 import type { ActorId, ActorStatus } from "./queries";
+import { RivetActorError } from "@/queries/types";
 
 export const ACTOR_STATUS_LABEL_MAP = {
 	unknown: "Unknown",
@@ -159,13 +159,7 @@ export function QueriedActorError({ actorId }: { actorId: ActorId }) {
 export function RunnerPoolError({
 	error,
 }: {
-	error:
-		| string
-		| null
-		| { runner_id: string }
-		| { serverless_http_error: unknown }
-		| { serverless_connection_error: unknown }
-		| { serverless_invalid_sse_payload: unknown };
+	error: RivetActorError
 }) {
 	return match(error)
 		.with(P.nullish, () => null)
@@ -241,13 +235,13 @@ export function ErrorDetails({ error }: { error: unknown }) {
 		<Accordion
 			type="single"
 			collapsible
-			className="mt-4 max-w-full min-w-0"
+			className="mt-4 max-w-full min-w-0 pb-0"
 		>
 			<AccordionItem value="error-details">
 				<AccordionTrigger className="gap-1 p-0 max-w-full min-w-0">
 					View Error Details
 				</AccordionTrigger>
-				<AccordionContent className="max-w-full min-w-0 ">
+				<AccordionContent className="max-w-full min-w-0 pb-0 ">
 					{json ? (
 						<div className="not-prose my-4 rounded-lg border p-1 bg-background">
 							<ScrollArea className="w-full">

--- a/frontend/src/components/actors/guard-connectable-inspector.tsx
+++ b/frontend/src/components/actors/guard-connectable-inspector.tsx
@@ -3,6 +3,7 @@
 import {
 	faExclamationTriangle,
 	faPowerOff,
+	faQuestionCircle,
 	faSpinnerThird,
 	Icon,
 } from "@rivet-gg/icons";
@@ -16,6 +17,7 @@ import { useRouteContext, useSearch } from "@tanstack/react-router";
 import { createContext, type ReactNode, useContext, useMemo } from "react";
 import { match, P } from "ts-pattern";
 import { useLocalStorage } from "usehooks-ts";
+import { HelpDropdown } from "@/app/help-dropdown";
 import { isRivetApiError } from "@/lib/errors";
 import { DiscreteCopyButton } from "../copy-area";
 import { getConfig, useConfig } from "../lib/config";
@@ -87,6 +89,15 @@ function UnavailableInfo({
 				<p>Actor is unavailable.</p>
 
 				<QueriedActorError actorId={actorId} />
+
+				<HelpDropdown>
+					<Button
+						variant="outline"
+						startIcon={<Icon icon={faQuestionCircle} />}
+					>
+						Need help?
+					</Button>
+				</HelpDropdown>
 			</Info>
 		))
 		.with("pending", () => <NoRunners />)

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
 			align={align}
 			sideOffset={sideOffset}
 			className={cn(
-				"z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+				"z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fill-mode-forwards data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
 				className,
 			)}
 			{...props}

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -25,3 +25,13 @@ export const Changelog = z.array(ChangelogItem);
 
 export type Changelog = z.infer<typeof Changelog>;
 export type ChangelogItem = z.infer<typeof ChangelogItem>;
+
+
+export type RivetActorError = 
+		| string
+		| null
+		| object
+		| { runner_id: string }
+		| { serverless_http_error: unknown }
+		| { serverless_connection_error: unknown }
+		| { serverless_invalid_sse_payload: unknown };


### PR DESCRIPTION
Closes FRONT-917

### TL;DR

Fixed navigation issues in context switcher and improved UI components for better user experience.

### What changed?

- Fixed context switcher navigation by calling `onClose()` before navigation to prevent UI glitches
- Added a "Need help?" button with a help dropdown to the actor unavailable screen
- Improved error details accordion styling with proper padding
- Enhanced popover animation by adding `fill-mode-forwards` to prevent flickering during transitions
- Removed unused Rivet type import from actor-status-label

### How to test?

1. Test the context switcher by creating new projects and namespaces - verify the dropdown closes properly before navigation
2. Check the actor unavailable screen to ensure the help button appears and functions correctly
3. Verify error details accordion displays properly with correct padding
4. Test popovers throughout the application to ensure smooth animations without flickering

### Why make this change?

These changes address several UI/UX issues:

- The context switcher was not properly closing before navigation, causing visual glitches
- Users needed more guidance when encountering unavailable actors
- Error details display needed better spacing for readability
- Popover animations were flickering during transitions due to missing animation properties