### PR TITLE
feat(examples): add vercel examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,3 +218,7 @@ Data structures often include:
 
 - Write comments as normal, complete sentences. Avoid fragmented structures with parentheticals and dashes like `// Spawn engine (if configured) - regardless of start kind`. Instead, write `// Spawn the engine if configured`. Especially avoid dashes (hyphens are OK).
 - Documenting deltas is not important or useful. A developer who has never worked on the project will not gain extra information if you add a comment stating that something was removed or changed because they don't know what was there before. The only time you would be adding a comment for something NOT being there is if its unintuitive for why its not there in the first place.
+
+### Examples
+
+- When adding new examples, or updating existing ones, ensure that the user also modified the vercel equivalent, if applicable. This ensures parity between local and vercel examples. In order to generate vercel example, run `./scripts/vercel-examples/generate-vercel-examples.ts ` after making changes to examples.

--- a/engine/tests/load/package.json
+++ b/engine/tests/load/package.json
@@ -8,7 +8,7 @@
 		"fmt": "biome check --apply ."
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^1.9.4",
+		"@biomejs/biome": "^2.3",
 		"@types/k6": "^0.47.3",
 		"typescript": "^5.3.3"
 	}

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -442,6 +442,139 @@ This is enforced by the tsconfig options `allowImportingTsExtensions` and `rewri
 6. **Testing** - Use `setupTest()` from `rivetkit/test` for isolated actor testing
 7. **Comments** - Include helpful comments linking to documentation (e.g., `// https://rivet.dev/docs/actors/state`)
 
+## Vercel Examples
+
+Vercel-optimized versions of examples are automatically generated using the script at `scripts/vercel-examples/generate-vercel-examples.ts`. These examples use the `hono/vercel` adapter and are configured specifically for Vercel serverless deployment.
+
+### Generation Script
+
+```bash
+# Generate all changed examples (uses git diff)
+npx tsx scripts/vercel-examples/generate-vercel-examples.ts
+
+# Generate a specific example
+npx tsx scripts/vercel-examples/generate-vercel-examples.ts --example hello-world
+
+# Force regenerate all examples
+npx tsx scripts/vercel-examples/generate-vercel-examples.ts --all
+
+# Dry run (show what would be generated)
+npx tsx scripts/vercel-examples/generate-vercel-examples.ts --dry-run
+```
+
+### Naming Convention
+
+Vercel examples are placed at `examples/{original-name}-vercel/`. For example:
+- `hello-world` → `hello-world-vercel`
+- `chat-room` → `chat-room-vercel`
+
+### Directory Layout
+
+Vercel examples with frontend:
+```
+example-name-vercel/
+├── api/
+│   └── index.ts        # Hono handler with hono/vercel adapter
+├── src/
+│   ├── actors.ts       # Actor definitions (copied from origin)
+│   └── server.ts       # Server entry point (copied from origin)
+├── frontend/
+│   ├── App.tsx         # React component (copied from origin)
+│   └── main.tsx        # React entry point (copied from origin)
+├── index.html          # HTML entry point (copied from origin)
+├── package.json        # Modified for Vercel
+├── tsconfig.json       # Modified for Vercel
+├── vite.config.ts      # Simplified (no srvx)
+├── vercel.json         # Vercel configuration
+├── turbo.json
+└── README.md           # With Vercel-specific note and deploy button
+```
+
+Vercel examples without frontend (API-only):
+```
+example-name-vercel/
+├── api/
+│   └── index.ts        # Hono handler with hono/vercel adapter
+├── src/
+│   ├── actors.ts
+│   └── server.ts
+├── package.json
+├── tsconfig.json
+├── vercel.json
+├── turbo.json
+└── README.md
+```
+
+### Key Files
+
+#### api/index.ts
+
+The API entry point uses the Hono Vercel adapter (built into the `hono` package):
+
+```typescript
+import app from "../src/server.ts";
+
+export default app;
+```
+
+#### vercel.json
+
+For examples with frontend:
+```json
+{
+  "framework": "vite",
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api" }
+  ]
+}
+```
+
+For API-only examples:
+```json
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/api" }
+  ]
+}
+```
+
+#### package.json
+
+Key differences from origin examples:
+- Removes `srvx` and `vite-plugin-srvx`
+- Uses `vercel dev` for development
+- Simplified build scripts
+- Uses `hono/vercel` adapter (built into the `hono` package)
+
+#### README.md
+
+Each Vercel example README includes:
+- A note explaining it's the Vercel-optimized version with a link back to the origin
+- A "Deploy with Vercel" button for one-click deployment
+
+Example header:
+```markdown
+> **Note:** This is the Vercel-optimized version of the [hello-world](../hello-world) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=...)
+```
+
+### Skipped Examples
+
+The following example types are not converted to Vercel:
+- **Next.js examples** (`*-next-js`): Next.js has its own Vercel integration
+- **Cloudflare examples** (`*-cloudflare*`): Different runtime environment
+- **Deno examples**: Different runtime environment
+- **Examples without `src/server.ts`**: Cannot be converted
+
+### Workflow
+
+1. Make changes to an origin example (e.g., `hello-world`)
+2. Run the generation script to update the Vercel version
+3. The script detects changes via git diff and only regenerates modified examples
+4. Commit both the origin and generated Vercel examples
+
 ## TODO: Examples Cleanup
 
 The following issues need to be fixed across examples:

--- a/examples/actor-actions-vercel/.gitignore
+++ b/examples/actor-actions-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/actor-actions-vercel/README.md
+++ b/examples/actor-actions-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [actor-actions](../actor-actions) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Factor-actions-vercel&project-name=actor-actions-vercel)
+
+# Actor Actions
+
+Demonstrates how to define and call actions on Rivet Actors for RPC-style communication between actors and clients.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/actor-actions
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Type-safe actor actions**: Define and call actions with full TypeScript type safety
+- **Actor state management**: Initialize and persist actor state using `createState`
+- **Cross-actor communication**: Create and interact with actors from within other actors
+- **RPC-style patterns**: Call actor methods from client code with automatic type inference
+
+## Implementation
+
+This example demonstrates the fundamentals of defining and calling actor actions:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/actor-actions/src/backend/registry.ts)): Shows how to define actions with parameters, return values, and state management
+
+## Resources
+
+Read more about [actions](/docs/actors/actions), [state](/docs/actors/state), and [actor setup](/docs/setup).
+
+## License
+
+MIT

--- a/examples/actor-actions-vercel/api/index.ts
+++ b/examples/actor-actions-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/actor-actions-vercel/frontend/App.tsx
+++ b/examples/actor-actions-vercel/frontend/App.tsx
@@ -1,0 +1,267 @@
+import { ActorError, createClient } from "rivetkit/client";
+import { useState } from "react";
+import type {
+	CompanyProfile,
+	EmployeeProfile,
+	registry,
+} from "../src/actors.ts";
+
+const client = createClient<typeof registry>(`${window.location.origin}/api/rivet`);
+
+export function App() {
+	const [companyEin, setCompanyEin] = useState("12-3456789");
+	const [companyName, setCompanyName] = useState("Acme Corp");
+	const [companyIndustry, setCompanyIndustry] = useState("Technology");
+	const [companyProfile, setCompanyProfile] = useState<CompanyProfile | null>(
+		null
+	);
+
+	const [employeeName, setEmployeeName] = useState("Jane Smith");
+	const [employeeEmail, setEmployeeEmail] = useState("jane@acme.com");
+	const [employeePosition, setEmployeePosition] = useState("Software Engineer");
+	const [createdEmployee, setCreatedEmployee] =
+		useState<EmployeeProfile | null>(null);
+	const [employeeList, setEmployeeList] = useState<string[]>([]);
+
+	const createCompany = async () => {
+		try {
+			// Create actor with input using EIN as key
+			const company = await client.company.create([companyEin], {
+				input: {
+					name: companyName,
+					industry: companyIndustry,
+				},
+			});
+
+			// Get profile with full type safety
+			const profile = await company.getProfile();
+			setCompanyProfile(profile);
+		} catch (error) {
+			// Handle actor already exists error
+			if (
+				error instanceof ActorError &&
+				error.group === "actor" &&
+				error.code === "already_exists"
+			) {
+				alert(
+					`Company with EIN "${companyEin}" already exists. Use "Load Profile" to view it.`
+				);
+			} else {
+				// Re-throw other errors
+				throw error;
+			}
+		}
+	};
+
+	const loadCompanyProfile = async () => {
+		const company = client.company.get([companyEin]);
+		const profile = await company.getProfile();
+		setCompanyProfile(profile);
+
+		// Also load the list of employees
+		const employees = await company.getEmployees();
+		setEmployeeList(employees);
+	};
+
+	const createEmployee = async () => {
+		try {
+			// Use the company's createEmployee action to spawn an employee actor
+			const company = client.company.get([companyEin]);
+			const employee = await company.createEmployee({
+				name: employeeName,
+				email: employeeEmail,
+				position: employeePosition,
+			});
+			setCreatedEmployee(employee);
+
+			// Refresh the employee list
+			const employees = await company.getEmployees();
+			setEmployeeList(employees);
+		} catch (error) {
+			// Handle actor already exists error
+			if (
+				error instanceof ActorError &&
+				error.group === "actor" &&
+				error.code === "already_exists"
+			) {
+				alert(
+					`Employee with email "${employeeEmail}" already exists. Click on their name in the list to view their profile.`
+				);
+			} else {
+				// Re-throw other errors
+				throw error;
+			}
+		}
+	};
+
+	const loadEmployee = async (email: string) => {
+		const employee = client.employee.get([email]);
+		const profile = await employee.getProfile();
+		setCreatedEmployee(profile);
+	};
+
+
+	return (
+		<div className="container">
+			<div className="header">
+				<h1>Quickstart: Actions</h1>
+				<p>
+					Demonstrates creating actors with input parameters and calling
+					type-safe actions between actors
+				</p>
+			</div>
+
+			<div className="grid">
+				{/* Company Section */}
+				<div className="section">
+					<h2>Company Actor</h2>
+					<div className="form-group">
+						<label>EIN (key):</label>
+						<input
+							type="text"
+							value={companyEin}
+							onChange={(e) => setCompanyEin(e.target.value)}
+							placeholder="Enter EIN"
+						/>
+					</div>
+					<div className="form-group">
+						<label>Company Name:</label>
+						<input
+							type="text"
+							value={companyName}
+							onChange={(e) => setCompanyName(e.target.value)}
+							placeholder="Enter company name"
+						/>
+					</div>
+					<div className="form-group">
+						<label>Industry:</label>
+						<input
+							type="text"
+							value={companyIndustry}
+							onChange={(e) => setCompanyIndustry(e.target.value)}
+							placeholder="Enter industry"
+						/>
+					</div>
+					<div className="button-group">
+						<button
+							onClick={createCompany}
+							className="primary"
+						>
+							Create Company
+						</button>
+						<button
+							onClick={loadCompanyProfile}
+						>
+							Load Profile
+						</button>
+					</div>
+
+					{companyProfile && (
+						<div className="profile">
+							<h3>Company Profile</h3>
+							<div className="profile-field">
+								<strong>ID:</strong> {companyProfile.id}
+							</div>
+							<div className="profile-field">
+								<strong>Name:</strong> {companyProfile.name}
+							</div>
+							<div className="profile-field">
+								<strong>Industry:</strong> {companyProfile.industry}
+							</div>
+							<div className="profile-field">
+								<strong>Founded:</strong>{" "}
+								{new Date(companyProfile.foundedAt).toLocaleString()}
+							</div>
+						</div>
+					)}
+
+					{employeeList.length > 0 && (
+						<div className="profile">
+							<h3>Employees ({employeeList.length})</h3>
+							<div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+								{employeeList.map((email) => (
+									<button
+										key={email}
+										onClick={() => loadEmployee(email)}
+										style={{
+											padding: "8px 12px",
+											textAlign: "left",
+											cursor: "pointer",
+										}}
+									>
+										{email}
+									</button>
+								))}
+							</div>
+						</div>
+					)}
+				</div>
+
+				{/* Employee Section */}
+				<div className="section">
+					<h2>Employee Actor</h2>
+					<p className="section-description">
+						Create employees through the company actor
+					</p>
+					<div className="form-group">
+						<label>Employee Email (key):</label>
+						<input
+							type="email"
+							value={employeeEmail}
+							onChange={(e) => setEmployeeEmail(e.target.value)}
+							placeholder="Enter email"
+						/>
+					</div>
+					<div className="form-group">
+						<label>Name:</label>
+						<input
+							type="text"
+							value={employeeName}
+							onChange={(e) => setEmployeeName(e.target.value)}
+							placeholder="Enter name"
+						/>
+					</div>
+					<div className="form-group">
+						<label>Position:</label>
+						<input
+							type="text"
+							value={employeePosition}
+							onChange={(e) => setEmployeePosition(e.target.value)}
+							placeholder="Enter position"
+						/>
+					</div>
+					<div className="button-group">
+						<button onClick={createEmployee} className="primary">
+							Create Employee via Company
+						</button>
+					</div>
+
+					{createdEmployee && (
+						<div className="profile">
+							<h3>Employee Profile</h3>
+							<div className="profile-field">
+								<strong>Employee ID:</strong> {createdEmployee.employeeId}
+							</div>
+							<div className="profile-field">
+								<strong>Name:</strong> {createdEmployee.name}
+							</div>
+							<div className="profile-field">
+								<strong>Email:</strong> {createdEmployee.email}
+							</div>
+							<div className="profile-field">
+								<strong>Position:</strong> {createdEmployee.position}
+							</div>
+							<div className="profile-field">
+								<strong>Company ID:</strong> {createdEmployee.companyId}
+							</div>
+							<div className="profile-field">
+								<strong>Hired:</strong>{" "}
+								{new Date(createdEmployee.hiredAt).toLocaleString()}
+							</div>
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/examples/actor-actions-vercel/frontend/main.tsx
+++ b/examples/actor-actions-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/actor-actions-vercel/index.html
+++ b/examples/actor-actions-vercel/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quickstart: Actions</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+        .header {
+            background: #28a745;
+            color: white;
+            padding: 30px;
+            text-align: center;
+            border-radius: 8px;
+            margin-bottom: 30px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header h1 {
+            margin: 0 0 10px 0;
+            font-size: 2em;
+        }
+        .header p {
+            margin: 0;
+            opacity: 0.9;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
+            gap: 20px;
+            margin-bottom: 20px;
+        }
+        .section {
+            background: white;
+            border-radius: 8px;
+            padding: 25px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .section h2 {
+            margin: 0 0 20px 0;
+            color: #28a745;
+            font-size: 1.5em;
+            border-bottom: 2px solid #28a745;
+            padding-bottom: 10px;
+        }
+        .form-group {
+            margin-bottom: 15px;
+        }
+        .form-group label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: 500;
+            color: #333;
+        }
+        .form-group input {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 14px;
+            box-sizing: border-box;
+        }
+        .button-group {
+            display: flex;
+            gap: 10px;
+            margin-top: 20px;
+        }
+        button {
+            padding: 12px 20px;
+            background: #6c757d;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 500;
+            flex: 1;
+        }
+        button.primary {
+            background: #28a745;
+        }
+        button.primary:hover:not(:disabled) {
+            background: #218838;
+        }
+        button.secondary {
+            background: #007bff;
+            width: 100%;
+            margin-top: 10px;
+        }
+        button.secondary:hover:not(:disabled) {
+            background: #0056b3;
+        }
+        button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        button:hover:not(:disabled) {
+            background: #5a6268;
+        }
+        .profile {
+            margin-top: 25px;
+            padding: 20px;
+            background: #f8f9fa;
+            border-radius: 8px;
+            border-left: 4px solid #28a745;
+        }
+        .profile h3 {
+            margin: 0 0 15px 0;
+            color: #28a745;
+            font-size: 1.2em;
+        }
+        .profile-field {
+            margin-bottom: 10px;
+            padding: 8px 0;
+            border-bottom: 1px solid #e9ecef;
+        }
+        .profile-field:last-of-type {
+            border-bottom: none;
+        }
+        .profile-field strong {
+            color: #495057;
+            margin-right: 8px;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/actor-actions-vercel/package.json
+++ b/examples/actor-actions-vercel/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "actor-actions-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.2.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.11.3",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"typescript"
+		],
+		"tags": [],
+		"priority": 1000,
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/actor-actions-vercel/src/actors.ts
+++ b/examples/actor-actions-vercel/src/actors.ts
@@ -1,0 +1,137 @@
+import { actor, setup } from "rivetkit";
+
+export interface EmployeeInput {
+	employeeId: string;
+	name: string;
+	email: string;
+	position: string;
+	companyId: string;
+}
+
+export interface EmployeeState {
+	profile: EmployeeProfile;
+}
+
+export interface EmployeeProfile {
+	employeeId: string;
+	name: string;
+	email: string;
+	position: string;
+	companyId: string;
+	hiredAt: number;
+}
+
+export interface CompanyInput {
+	name: string;
+	industry: string;
+}
+
+export interface CompanyState {
+	profile: CompanyProfile;
+	employeeEmails: string[];
+}
+
+export interface CompanyProfile {
+	id: string;
+	name: string;
+	industry: string;
+	foundedAt: number;
+}
+
+export const employee = actor({
+	// Initialize state from input
+	createState: (_c, input: EmployeeInput): EmployeeState => ({
+		profile: {
+			employeeId: input.employeeId,
+			name: input.name,
+			email: input.email,
+			position: input.position,
+			companyId: input.companyId,
+			hiredAt: Date.now(),
+		},
+	}),
+
+	actions: {
+		// Get employee profile
+		getProfile: (c): EmployeeProfile => c.state.profile,
+
+		// Update employee profile
+		updateProfile: (
+			c,
+			updates: Partial<Omit<EmployeeInput, "companyId" | "employeeId">>,
+		) => {
+			if (updates.name) c.state.profile.name = updates.name;
+			if (updates.email) c.state.profile.email = updates.email;
+			if (updates.position) c.state.profile.position = updates.position;
+			return c.state.profile;
+		},
+	},
+});
+
+export const company = actor({
+	// Initialize state from input: https://rivet.dev/docs/actors/input
+	createState: (_c, input: CompanyInput): CompanyState => ({
+		profile: {
+			id: crypto.randomUUID(),
+			name: input.name,
+			industry: input.industry,
+			foundedAt: Date.now(),
+		},
+		employeeEmails: [],
+	}),
+
+	actions: {
+		// Fully type-safe profile retrieval: https://rivet.dev/docs/actors/actions
+		getProfile: (c): CompanyProfile => c.state.profile,
+
+		// Update company profile
+		updateProfile: (c, updates: Partial<CompanyInput>) => {
+			if (updates.name) c.state.profile.name = updates.name;
+			if (updates.industry) c.state.profile.industry = updates.industry;
+			return c.state.profile;
+		},
+
+		// Create an employee actor and track it
+		createEmployee: async (
+			c,
+			employeeData: { name: string; email: string; position: string },
+		): Promise<EmployeeProfile> => {
+			const client = c.client<typeof registry>();
+
+			// Generate a unique employee ID
+			const employeeId = crypto.randomUUID();
+
+			// Create employee actor using their email as the key
+			await client.employee.create([employeeData.email], {
+				input: {
+					employeeId,
+					name: employeeData.name,
+					email: employeeData.email,
+					position: employeeData.position,
+					companyId: c.state.profile.id,
+				},
+			});
+			c.state.employeeEmails.push(employeeData.email);
+
+			// Return the employee profile
+			return {
+				employeeId,
+				name: employeeData.name,
+				email: employeeData.email,
+				position: employeeData.position,
+				companyId: c.state.profile.id,
+				hiredAt: Date.now(),
+			};
+		},
+
+		// Get all employee emails
+		getEmployees: (c) => {
+			return c.state.employeeEmails;
+		},
+	},
+});
+
+// Register actors for use: https://rivet.dev/docs/setup
+export const registry = setup({
+	use: { employee, company },
+});

--- a/examples/actor-actions-vercel/src/server.ts
+++ b/examples/actor-actions-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/actor-actions-vercel/tests/actions.test.ts
+++ b/examples/actor-actions-vercel/tests/actions.test.ts
@@ -1,0 +1,179 @@
+import { setupTest } from "rivetkit/test";
+import { describe, expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+describe("company and employee actors", () => {
+	test("create company actor with input and get profile", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create company with EIN as key
+		const company = await client.company.create(["12-3456789"], {
+			input: {
+				name: "Acme Corp",
+				industry: "Technology",
+			},
+		});
+
+		// Get profile
+		const profile = await company.getProfile();
+
+		expect(profile).toMatchObject({
+			id: expect.any(String),
+			name: "Acme Corp",
+			industry: "Technology",
+			foundedAt: expect.any(Number),
+		});
+	});
+
+	test("update company profile", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create company
+		const company = await client.company.create(["23-4567890"], {
+			input: {
+				name: "Tech Startup",
+				industry: "Software",
+			},
+		});
+
+		// Update profile
+		const updatedProfile = await company.updateProfile({
+			name: "Tech Unicorn",
+			industry: "SaaS",
+		});
+
+		expect(updatedProfile.name).toBe("Tech Unicorn");
+		expect(updatedProfile.industry).toBe("SaaS");
+
+		// Verify changes persist
+		const profile = await company.getProfile();
+		expect(profile.name).toBe("Tech Unicorn");
+		expect(profile.industry).toBe("SaaS");
+	});
+
+	test("company creates employee actor", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create company
+		const company = await client.company.create(["34-5678901"], {
+			input: {
+				name: "Growing Corp",
+				industry: "Technology",
+			},
+		});
+
+		// Company creates employee
+		const employeeProfile = await company.createEmployee({
+			name: "Jane Smith",
+			email: "jane@growingcorp.com",
+			position: "Software Engineer",
+		});
+
+		expect(employeeProfile).toMatchObject({
+			employeeId: expect.any(String),
+			name: "Jane Smith",
+			email: "jane@growingcorp.com",
+			position: "Software Engineer",
+			companyId: expect.any(String),
+			hiredAt: expect.any(Number),
+		});
+
+		// Verify employee is in company's list
+		const employees = await company.getEmployees();
+		expect(employees).toContain("jane@growingcorp.com");
+	});
+
+	test("get employee profile directly", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create company and employee
+		const company = await client.company.create(["45-6789012"], {
+			input: {
+				name: "Test Corp",
+				industry: "Testing",
+			},
+		});
+
+		await company.createEmployee({
+			name: "John Doe",
+			email: "john@testcorp.com",
+			position: "QA Engineer",
+		});
+
+		// Get employee directly using email key
+		const employee = client.employee.get(["john@testcorp.com"]);
+		const profile = await employee.getProfile();
+
+		expect(profile).toMatchObject({
+			name: "John Doe",
+			email: "john@testcorp.com",
+			position: "QA Engineer",
+		});
+	});
+
+	test("update employee profile", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create company and employee
+		const company = await client.company.create(["56-7890123"], {
+			input: {
+				name: "Update Corp",
+				industry: "Technology",
+			},
+		});
+
+		await company.createEmployee({
+			name: "Alice Johnson",
+			email: "alice@updatecorp.com",
+			position: "Junior Developer",
+		});
+
+		// Update employee profile
+		const employee = client.employee.get(["alice@updatecorp.com"]);
+		const updatedProfile = await employee.updateProfile({
+			name: "Alice Johnson-Smith",
+			position: "Senior Developer",
+		});
+
+		expect(updatedProfile.name).toBe("Alice Johnson-Smith");
+		expect(updatedProfile.position).toBe("Senior Developer");
+	});
+
+	test("company tracks multiple employees", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create company
+		const company = await client.company.create(["67-8901234"], {
+			input: {
+				name: "Multi Corp",
+				industry: "Technology",
+			},
+		});
+
+		// Create multiple employees
+		await company.createEmployee({
+			name: "Employee One",
+			email: "one@multicorp.com",
+			position: "Developer",
+		});
+
+		await company.createEmployee({
+			name: "Employee Two",
+			email: "two@multicorp.com",
+			position: "Designer",
+		});
+
+		await company.createEmployee({
+			name: "Employee Three",
+			email: "three@multicorp.com",
+			position: "Manager",
+		});
+
+		// Verify all employees are tracked
+		const employees = await company.getEmployees();
+		expect(employees).toHaveLength(3);
+		expect(employees).toContain("one@multicorp.com");
+		expect(employees).toContain("two@multicorp.com");
+		expect(employees).toContain("three@multicorp.com");
+	});
+});

--- a/examples/actor-actions-vercel/tsconfig.build.json
+++ b/examples/actor-actions-vercel/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src/**/*"]
+}

--- a/examples/actor-actions-vercel/tsconfig.json
+++ b/examples/actor-actions-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/actor-actions-vercel/turbo.json
+++ b/examples/actor-actions-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/actor-actions-vercel/vercel.json
+++ b/examples/actor-actions-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/actor-actions-vercel/vite.config.ts
+++ b/examples/actor-actions-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/actor-actions-vercel/vitest.config.ts
+++ b/examples/actor-actions-vercel/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	server: {
+		port: 5173,
+	},
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/actor-actions/vercel.json
+++ b/examples/actor-actions/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/ai-agent-vercel/.gitignore
+++ b/examples/ai-agent-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/ai-agent-vercel/README.md
+++ b/examples/ai-agent-vercel/README.md
@@ -1,0 +1,45 @@
+> **Note:** This is the Vercel-optimized version of the [ai-agent](../ai-agent) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fai-agent-vercel&project-name=ai-agent-vercel)
+
+# AI Agent Chat
+
+Example project demonstrating AI agent integration.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/ai-agent
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **AI SDK integration**: Use Vercel AI SDK with OpenAI within Rivet Actors
+- **Persistent conversation state**: Message history automatically persisted across actor restarts
+- **Real-time updates**: Broadcast AI responses to connected clients using actor events
+- **Tool calling**: Integrate custom tools (weather lookup) that AI can invoke
+
+## Implementation
+
+The AI agent is implemented as a Rivet Actor that maintains conversation state and integrates with OpenAI. Key implementation details:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/ai-agent/src/backend/registry.ts)): Defines the `aiAgent` actor with persistent message history
+- **Custom Tools** ([`src/backend/my-tools.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/ai-agent/src/backend/my-tools.ts)): Implements the weather lookup tool that the AI can invoke
+- **Message Types** ([`src/backend/types.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/ai-agent/src/backend/types.ts)): TypeScript types for message structure
+
+## Prerequisites
+
+- OpenAI API Key (set as `OPENAI_API_KEY` environment variable)
+
+## Resources
+
+Read more about [actions](/docs/actors/actions), [state](/docs/actors/state), and [events](/docs/actors/events).
+
+## License
+
+MIT

--- a/examples/ai-agent-vercel/api/index.ts
+++ b/examples/ai-agent-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/ai-agent-vercel/frontend/App.tsx
+++ b/examples/ai-agent-vercel/frontend/App.tsx
@@ -1,0 +1,80 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useEffect, useState } from "react";
+import { registry } from "../src/actors.ts";
+import type { Message } from "../src/types.ts";
+
+const { useActor } = createRivetKit<typeof registry>(`${window.location.origin}/api/rivet`);
+
+export function App() {
+	const aiAgent = useActor({
+		name: "aiAgent",
+		key: ["default"],
+	});
+	const [messages, setMessages] = useState<Message[]>([]);
+	const [input, setInput] = useState("");
+	const [isLoading, setIsLoading] = useState(false);
+
+	useEffect(() => {
+		if (aiAgent.connection) {
+			aiAgent.connection.getMessages().then(setMessages);
+		}
+	}, [aiAgent.connection]);
+
+	aiAgent.useEvent("messageReceived", (message: Message) => {
+		setMessages((prev) => [...prev, message]);
+		setIsLoading(false);
+	});
+
+	const handleSendMessage = async () => {
+		if (aiAgent.connection && input.trim()) {
+			setIsLoading(true);
+
+			const userMessage = { role: "user", content: input, timestamp: Date.now() } as Message;
+			setMessages((prev) => [...prev, userMessage]);
+
+			await aiAgent.connection.sendMessage(input);
+			setInput("");
+		}
+	};
+
+	return (
+		<div className="ai-chat">
+			<div className="messages">
+				{messages.length === 0 ? (
+					<div className="empty-message">
+						Ask the AI assistant a question to get started
+					</div>
+				) : (
+					messages.map((msg, i) => (
+						<div key={i} className={`message ${msg.role}`}>
+							<div className="avatar">{msg.role === "user" ? "👤" : "🤖"}</div>
+							<div className="content">{msg.content}</div>
+						</div>
+					))
+				)}
+				{isLoading && (
+					<div className="message assistant loading">
+						<div className="avatar">🤖</div>
+						<div className="content">Thinking...</div>
+					</div>
+				)}
+			</div>
+
+			<div className="input-area">
+				<input
+					value={input}
+					onChange={(e) => setInput(e.target.value)}
+					onKeyPress={(e) => e.key === "Enter" && handleSendMessage()}
+					placeholder="Ask the AI assistant..."
+					disabled={isLoading}
+				/>
+				<button
+					onClick={handleSendMessage}
+					disabled={isLoading || !input.trim()}
+				>
+					Send
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/examples/ai-agent-vercel/frontend/main.tsx
+++ b/examples/ai-agent-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/ai-agent-vercel/index.html
+++ b/examples/ai-agent-vercel/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Agent Example</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .ai-chat {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        .messages {
+            height: 400px;
+            overflow-y: auto;
+            padding: 20px;
+            border-bottom: 1px solid #eee;
+        }
+        .message {
+            display: flex;
+            margin-bottom: 16px;
+            align-items: flex-start;
+        }
+        .message.user {
+            justify-content: flex-end;
+        }
+        .message.assistant {
+            justify-content: flex-start;
+        }
+        .avatar {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #007bff;
+            color: white;
+            font-size: 18px;
+            flex-shrink: 0;
+        }
+        .message.user .avatar {
+            background: #28a745;
+            margin-left: 10px;
+        }
+        .message.assistant .avatar {
+            background: #007bff;
+            margin-right: 10px;
+        }
+        .content {
+            max-width: 60%;
+            padding: 12px 16px;
+            border-radius: 18px;
+            background: #f1f1f1;
+            word-wrap: break-word;
+        }
+        .message.user .content {
+            background: #007bff;
+            color: white;
+        }
+        .message.assistant .content {
+            background: #f1f1f1;
+        }
+        .message.loading .content {
+            background: #e9ecef;
+            font-style: italic;
+        }
+        .empty-message {
+            text-align: center;
+            color: #666;
+            padding: 40px;
+        }
+        .input-area {
+            display: flex;
+            padding: 20px;
+            gap: 10px;
+        }
+        .input-area input {
+            flex: 1;
+            padding: 12px;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            font-size: 16px;
+        }
+        .input-area button {
+            padding: 12px 24px;
+            background: #007bff;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        .input-area button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .input-area button:hover:not(:disabled) {
+            background: #0056b3;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/ai-agent-vercel/package.json
+++ b/examples/ai-agent-vercel/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "example-ai-agent-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@ai-sdk/openai": "^0.0.66",
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"ai": "^4.0.38",
+		"hono": "^4.0.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38",
+		"zod": "^3.25.69"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"typescript"
+		],
+		"tags": [
+			"ai",
+			"real-time"
+		],
+		"priority": 100,
+		"frontendPort": 5173
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/ai-agent-vercel/src/actors.ts
+++ b/examples/ai-agent-vercel/src/actors.ts
@@ -1,0 +1,66 @@
+import { openai } from "@ai-sdk/openai";
+import { generateText, tool } from "ai";
+import { actor, setup } from "rivetkit";
+import { z } from "zod";
+import { getWeather } from "./my-tools.ts";
+import type { Message } from "./types.ts";
+
+export const aiAgent = actor({
+	// Persistent state that survives restarts: https://rivet.dev/docs/actors/state
+	state: {
+		messages: [] as Message[],
+	},
+
+	actions: {
+		// Callable functions from clients: https://rivet.dev/docs/actors/actions
+		getMessages: (c) => c.state.messages,
+
+		sendMessage: async (c, userMessage: string) => {
+			const userMsg: Message = {
+				role: "user",
+				content: userMessage,
+				timestamp: Date.now(),
+			};
+			// State changes are automatically persisted
+			c.state.messages.push(userMsg);
+
+			const { text } = await generateText({
+				model: openai("gpt-4o-mini"),
+				prompt: userMessage,
+				messages: c.state.messages,
+				tools: {
+					weather: tool({
+						description: "Get the weather in a location",
+						parameters: z.object({
+							location: z
+								.string()
+								.describe(
+									"The location to get the weather for",
+								),
+						}),
+						execute: async ({ location }) => {
+							return await getWeather(location);
+						},
+					}),
+				},
+			});
+
+			const assistantMsg: Message = {
+				role: "assistant",
+				content: text,
+				timestamp: Date.now(),
+			};
+			c.state.messages.push(assistantMsg);
+
+			// Send events to all connected clients: https://rivet.dev/docs/actors/events
+			c.broadcast("messageReceived", assistantMsg);
+
+			return assistantMsg;
+		},
+	},
+});
+
+// Register actors for use: https://rivet.dev/docs/setup
+export const registry = setup({
+	use: { aiAgent },
+});

--- a/examples/ai-agent-vercel/src/my-tools.ts
+++ b/examples/ai-agent-vercel/src/my-tools.ts
@@ -1,0 +1,11 @@
+export async function getWeather(location: string) {
+	// Mock weather API response
+	return {
+		location,
+		temperature: Math.floor(Math.random() * 30) + 10,
+		condition: ["sunny", "cloudy", "rainy", "snowy"][
+			Math.floor(Math.random() * 4)
+		],
+		humidity: Math.floor(Math.random() * 50) + 30,
+	};
+}

--- a/examples/ai-agent-vercel/src/server.ts
+++ b/examples/ai-agent-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/ai-agent-vercel/src/types.ts
+++ b/examples/ai-agent-vercel/src/types.ts
@@ -1,0 +1,5 @@
+export type Message = {
+	role: "user" | "assistant";
+	content: string;
+	timestamp: number;
+};

--- a/examples/ai-agent-vercel/tests/ai-agent.test.ts
+++ b/examples/ai-agent-vercel/tests/ai-agent.test.ts
@@ -1,0 +1,117 @@
+import { setupTest } from "rivetkit/test";
+import { expect, test, vi } from "vitest";
+import { registry } from "../src/actors.ts";
+
+// Mock the AI SDK and OpenAI
+vi.mock("@ai-sdk/openai", () => ({
+	openai: () => "mock-model",
+}));
+
+vi.mock("ai", () => ({
+	generateText: vi.fn().mockImplementation(async ({ prompt }) => ({
+		text: `AI response to: ${prompt}`,
+	})),
+	tool: vi.fn().mockImplementation(({ execute }) => ({ execute })),
+}));
+
+vi.mock("../src/my-tools.ts", () => ({
+	getWeather: vi.fn().mockResolvedValue({
+		location: "San Francisco",
+		temperature: 72,
+		condition: "sunny",
+	}),
+}));
+
+test("AI Agent can handle basic actions without connection", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const agent = client.aiAgent.getOrCreate(["test-basic"]);
+
+	// Test initial state
+	const initialMessages = await agent.getMessages();
+	expect(initialMessages).toEqual([]);
+
+	// Send a message
+	const userMessage = "Hello, how are you?";
+	const response = await agent.sendMessage(userMessage);
+
+	// Verify response structure
+	expect(response).toMatchObject({
+		role: "assistant",
+		content: expect.stringContaining("AI response to: Hello, how are you?"),
+		timestamp: expect.any(Number),
+	});
+
+	// Verify messages are stored
+	const messages = await agent.getMessages();
+	expect(messages).toHaveLength(2);
+	expect(messages[0]).toMatchObject({
+		role: "user",
+		content: userMessage,
+		timestamp: expect.any(Number),
+	});
+	expect(messages[1]).toEqual(response);
+});
+
+test("AI Agent maintains conversation history", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const agent = client.aiAgent.getOrCreate(["test-history"]);
+
+	// Send multiple messages
+	await agent.sendMessage("First message");
+	await agent.sendMessage("Second message");
+	await agent.sendMessage("Third message");
+
+	const messages = await agent.getMessages();
+	expect(messages).toHaveLength(6); // 3 user + 3 assistant messages
+
+	// Verify message ordering and roles
+	expect(messages[0].role).toBe("user");
+	expect(messages[0].content).toBe("First message");
+	expect(messages[1].role).toBe("assistant");
+	expect(messages[2].role).toBe("user");
+	expect(messages[2].content).toBe("Second message");
+	expect(messages[3].role).toBe("assistant");
+	expect(messages[4].role).toBe("user");
+	expect(messages[4].content).toBe("Third message");
+	expect(messages[5].role).toBe("assistant");
+});
+
+test("AI Agent handles weather tool usage", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const agent = client.aiAgent.getOrCreate(["test-weather"]);
+
+	// Send a weather-related message
+	const response = await agent.sendMessage(
+		"What's the weather in San Francisco?",
+	);
+
+	// Verify response was generated
+	expect(response.role).toBe("assistant");
+	expect(response.content).toContain(
+		"AI response to: What's the weather in San Francisco?",
+	);
+	expect(response.timestamp).toBeGreaterThan(0);
+
+	// Verify message history includes both user and assistant messages
+	const messages = await agent.getMessages();
+	expect(messages).toHaveLength(2);
+	expect(messages[0].content).toBe("What's the weather in San Francisco?");
+	expect(messages[1]).toEqual(response);
+});
+
+test("AI Agent timestamps are sequential", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const agent = client.aiAgent.getOrCreate(["test-timestamps"]);
+
+	const response1 = await agent.sendMessage("First");
+	const response2 = await agent.sendMessage("Second");
+
+	expect(response2.timestamp).toBeGreaterThanOrEqual(response1.timestamp);
+
+	const messages = await agent.getMessages();
+	for (let i = 1; i < messages.length; i++) {
+		expect(messages[i].timestamp).toBeGreaterThanOrEqual(
+			messages[i - 1].timestamp,
+		);
+	}
+});

--- a/examples/ai-agent-vercel/tsconfig.json
+++ b/examples/ai-agent-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/ai-agent-vercel/turbo.json
+++ b/examples/ai-agent-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/ai-agent-vercel/vercel.json
+++ b/examples/ai-agent-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/ai-agent-vercel/vite.config.ts
+++ b/examples/ai-agent-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/ai-agent-vercel/vitest.config.ts
+++ b/examples/ai-agent-vercel/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+		testTimeout: 30000,
+	},
+});

--- a/examples/ai-agent/vercel.json
+++ b/examples/ai-agent/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/ai-and-user-generated-actors-freestyle/vercel.json
+++ b/examples/ai-and-user-generated-actors-freestyle/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/chat-room-vercel/.gitignore
+++ b/examples/chat-room-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/chat-room-vercel/README.md
+++ b/examples/chat-room-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [chat-room](../chat-room) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fchat-room-vercel&project-name=chat-room-vercel)
+
+# Chat Room
+
+Example project demonstrating real-time messaging and actor state management.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/chat-room
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Real-time messaging**: Broadcast messages to all connected clients instantly
+- **Persistent chat history**: Messages automatically saved in actor state across restarts
+- **Multiple chat rooms**: Each room is a separate actor instance with isolated state
+- **Event-driven architecture**: Use actor events to push updates to clients in real-time
+
+## Implementation
+
+The chat room demonstrates core Rivet Actor patterns for real-time communication:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/chat-room/src/backend/registry.ts)): Defines the `chatRoom` actor with message history state and actions for sending messages and retrieving history
+
+## Resources
+
+Read more about [actions](/docs/actors/actions), [state](/docs/actors/state), and [events](/docs/actors/events).
+
+## License
+
+MIT

--- a/examples/chat-room-vercel/api/index.ts
+++ b/examples/chat-room-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/chat-room-vercel/frontend/App.tsx
+++ b/examples/chat-room-vercel/frontend/App.tsx
@@ -1,0 +1,99 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useEffect, useState } from "react";
+import type { Message, registry } from "../src/actors.ts";
+
+const { useActor } = createRivetKit<typeof registry>(`${location.origin}/api/rivet`);
+
+export function App() {
+	const [roomId, setRoomId] = useState("general");
+	const [username, setUsername] = useState("User");
+	const [input, setInput] = useState("");
+	const [messages, setMessages] = useState<Message[]>([]);
+
+	const chatRoom = useActor({
+		name: "chatRoom",
+		key: [roomId],
+	});
+
+	useEffect(() => {
+		if (chatRoom.connection) {
+			chatRoom.connection.getHistory().then(setMessages);
+		}
+	}, [chatRoom.connection]);
+
+	chatRoom.useEvent("newMessage", (message: Message) => {
+		setMessages((prev) => [...prev, message]);
+	});
+
+	const sendMessage = async () => {
+		if (chatRoom.connection && input.trim()) {
+			await chatRoom.connection.sendMessage(username, input);
+			setInput("");
+		}
+	};
+
+	const handleKeyPress = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter") {
+			sendMessage();
+		}
+	};
+
+	return (
+		<div className="chat-container">
+			<div className="room-header">
+				<h3>Chat Room: {roomId}</h3>
+			</div>
+
+			<div className="room-controls">
+				<label>Room:</label>
+				<input
+					type="text"
+					value={roomId}
+					onChange={(e) => setRoomId(e.target.value)}
+					placeholder="Enter room name"
+				/>
+				<label>Username:</label>
+				<input
+					type="text"
+					value={username}
+					onChange={(e) => setUsername(e.target.value)}
+					placeholder="Enter your username"
+				/>
+			</div>
+
+			<div className="messages">
+				{messages.length === 0 ? (
+					<div className="empty-message">
+						No messages yet. Start the conversation!
+					</div>
+				) : (
+					messages.map((msg, i) => (
+						<div key={i} className="message">
+							<div className="message-sender">{msg.sender}</div>
+							<div className="message-text">{msg.text}</div>
+							<div className="message-timestamp">
+								{new Date(msg.timestamp).toLocaleTimeString()}
+							</div>
+						</div>
+					))
+				)}
+			</div>
+
+			<div className="input-area">
+				<input
+					value={input}
+					onChange={(e) => setInput(e.target.value)}
+					onKeyPress={handleKeyPress}
+					placeholder="Type a message..."
+					disabled={!chatRoom.connection}
+				/>
+				<button
+					onClick={sendMessage}
+					disabled={!chatRoom.connection || !input.trim()}
+				>
+					Send
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/examples/chat-room-vercel/frontend/main.tsx
+++ b/examples/chat-room-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/chat-room-vercel/index.html
+++ b/examples/chat-room-vercel/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chat Room Example</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .chat-container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        .room-header {
+            background: #007bff;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .room-header h3 {
+            margin: 0;
+            font-size: 1.5em;
+        }
+        .room-controls {
+            padding: 20px;
+            border-bottom: 1px solid #eee;
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+        .room-controls label {
+            font-weight: 500;
+        }
+        .room-controls input {
+            padding: 8px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            flex: 1;
+        }
+        .messages {
+            height: 400px;
+            overflow-y: auto;
+            padding: 20px;
+            border-bottom: 1px solid #eee;
+        }
+        .message {
+            margin-bottom: 15px;
+            padding: 12px;
+            background: #f8f9fa;
+            border-radius: 8px;
+            border-left: 4px solid #007bff;
+        }
+        .message-sender {
+            font-weight: bold;
+            color: #007bff;
+            margin-bottom: 5px;
+        }
+        .message-text {
+            margin-bottom: 5px;
+        }
+        .message-timestamp {
+            font-size: 0.85em;
+            color: #666;
+        }
+        .empty-message {
+            text-align: center;
+            color: #666;
+            padding: 40px;
+            font-style: italic;
+        }
+        .input-area {
+            display: flex;
+            padding: 20px;
+            gap: 10px;
+        }
+        .input-area input {
+            flex: 1;
+            padding: 12px;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            font-size: 16px;
+        }
+        .input-area button {
+            padding: 12px 24px;
+            background: #007bff;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        .input-area button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .input-area button:hover:not(:disabled) {
+            background: #0056b3;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/chat-room-vercel/package.json
+++ b/examples/chat-room-vercel/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "chat-room-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.11.3",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"react",
+			"typescript"
+		],
+		"tags": [
+			"real-time"
+		],
+		"priority": 200,
+		"frontendPort": 5173
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/chat-room-vercel/src/actors.ts
+++ b/examples/chat-room-vercel/src/actors.ts
@@ -1,0 +1,29 @@
+import { actor, setup } from "rivetkit";
+
+export type Message = { sender: string; text: string; timestamp: number };
+
+export const chatRoom = actor({
+	// Persistent state that survives restarts: https://rivet.dev/docs/actors/state
+	state: {
+		messages: [] as Message[],
+	},
+
+	actions: {
+		// Callable functions from clients: https://rivet.dev/docs/actors/actions
+		sendMessage: (c, sender: string, text: string) => {
+			const message = { sender, text, timestamp: Date.now() };
+			// State changes are automatically persisted
+			c.state.messages.push(message);
+			// Send events to all connected clients: https://rivet.dev/docs/actors/events
+			c.broadcast("newMessage", message);
+			return message;
+		},
+
+		getHistory: (c) => c.state.messages,
+	},
+});
+
+// Register actors for use: https://rivet.dev/docs/setup
+export const registry = setup({
+	use: { chatRoom },
+});

--- a/examples/chat-room-vercel/src/server.ts
+++ b/examples/chat-room-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/chat-room-vercel/tests/chat-room.test.ts
+++ b/examples/chat-room-vercel/tests/chat-room.test.ts
@@ -1,0 +1,91 @@
+import { setupTest } from "rivetkit/test";
+import { expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+test("Chat room can handle message sending and history", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const room = client.chatRoom.getOrCreate(["test-room"]);
+
+	// Test initial state
+	const initialHistory = await room.getHistory();
+	expect(initialHistory).toEqual([]);
+
+	// Send a message
+	const message1 = await room.sendMessage("Alice", "Hello everyone!");
+
+	// Verify message structure
+	expect(message1).toMatchObject({
+		sender: "Alice",
+		text: "Hello everyone!",
+		timestamp: expect.any(Number),
+	});
+
+	// Send another message
+	const message2 = await room.sendMessage("Bob", "Hi Alice!");
+
+	// Verify messages are stored in order
+	const history = await room.getHistory();
+	expect(history).toHaveLength(2);
+	expect(history[0]).toEqual(message1);
+	expect(history[1]).toEqual(message2);
+});
+
+test("Chat room message timestamps are sequential", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const room = client.chatRoom.getOrCreate(["test-timestamps"]);
+
+	const message1 = await room.sendMessage("User1", "First message");
+	const message2 = await room.sendMessage("User2", "Second message");
+	const message3 = await room.sendMessage("User1", "Third message");
+
+	expect(message2.timestamp).toBeGreaterThanOrEqual(message1.timestamp);
+	expect(message3.timestamp).toBeGreaterThanOrEqual(message2.timestamp);
+
+	const history = await room.getHistory();
+	for (let i = 1; i < history.length; i++) {
+		expect(history[i].timestamp).toBeGreaterThanOrEqual(
+			history[i - 1].timestamp,
+		);
+	}
+});
+
+test("Chat room supports multiple users", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const room = client.chatRoom.getOrCreate(["test-multiuser"]);
+
+	// Multiple users sending messages
+	await room.sendMessage("Alice", "Hello!");
+	await room.sendMessage("Bob", "Hey there!");
+	await room.sendMessage("Charlie", "Good morning!");
+	await room.sendMessage("Alice", "How is everyone?");
+
+	const history = await room.getHistory();
+	expect(history).toHaveLength(4);
+
+	// Verify senders
+	expect(history[0].sender).toBe("Alice");
+	expect(history[1].sender).toBe("Bob");
+	expect(history[2].sender).toBe("Charlie");
+	expect(history[3].sender).toBe("Alice");
+
+	// Verify message content
+	expect(history[0].text).toBe("Hello!");
+	expect(history[1].text).toBe("Hey there!");
+	expect(history[2].text).toBe("Good morning!");
+	expect(history[3].text).toBe("How is everyone?");
+});
+
+test("Chat room handles empty messages", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const room = client.chatRoom.getOrCreate(["test-empty"]);
+
+	// Test empty message
+	const emptyMessage = await room.sendMessage("User", "");
+	expect(emptyMessage.text).toBe("");
+	expect(emptyMessage.sender).toBe("User");
+	expect(emptyMessage.timestamp).toBeGreaterThan(0);
+
+	const history = await room.getHistory();
+	expect(history).toHaveLength(1);
+	expect(history[0]).toEqual(emptyMessage);
+});

--- a/examples/chat-room-vercel/tsconfig.json
+++ b/examples/chat-room-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/chat-room-vercel/turbo.json
+++ b/examples/chat-room-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/chat-room-vercel/vercel.json
+++ b/examples/chat-room-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/chat-room-vercel/vite.config.ts
+++ b/examples/chat-room-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/chat-room-vercel/vitest.config.ts
+++ b/examples/chat-room-vercel/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	server: {
+		port: 5173,
+	},
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/chat-room/vercel.json
+++ b/examples/chat-room/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/cross-actor-actions-vercel/.gitignore
+++ b/examples/cross-actor-actions-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/cross-actor-actions-vercel/README.md
+++ b/examples/cross-actor-actions-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [cross-actor-actions](../cross-actor-actions) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fcross-actor-actions-vercel&project-name=cross-actor-actions-vercel)
+
+# Cross-Actor Actions
+
+Demonstrates how actors can call actions on other actors for inter-actor communication and coordination.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/cross-actor-actions
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Inter-actor communication**: Actors call actions on other actors using the server-side client
+- **Transactional workflows**: Implement checkout process with inventory reservations
+- **Distributed state management**: Each actor manages its own state while coordinating with others
+- **Type-safe cross-actor calls**: Full TypeScript type safety across actor boundaries
+
+## Implementation
+
+This example demonstrates advanced inter-actor communication patterns:
+
+- **Actor Definitions** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/cross-actor-actions/src/backend/registry.ts)): Defines multiple actors (`cart`, `inventory`) that communicate with each other to implement a checkout workflow
+
+## Resources
+
+Read more about [communicating between actors](/docs/actors/communicating-between-actors), [actions](/docs/actors/actions), and [state](/docs/actors/state).
+
+## License
+
+MIT

--- a/examples/cross-actor-actions-vercel/api/index.ts
+++ b/examples/cross-actor-actions-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/cross-actor-actions-vercel/frontend/App.tsx
+++ b/examples/cross-actor-actions-vercel/frontend/App.tsx
@@ -1,0 +1,242 @@
+import { createClient } from "rivetkit/client";
+import { useEffect, useState } from "react";
+import type { registry } from "../src/actors.ts";
+
+const client = createClient<typeof registry>(`${window.location.origin}/api/rivet`);
+
+interface ItemStock {
+	itemName: string;
+	stock: number;
+}
+
+interface CheckoutSummary {
+	customerName: string;
+	items: Array<{
+		itemId: string;
+		itemName: string;
+		quantity: number;
+	}>;
+	completed: boolean;
+	totalItems: number;
+}
+
+export function App() {
+	const [customerName, setCustomerName] = useState("Customer");
+	const [selectedItem, setSelectedItem] = useState("laptop");
+	const [quantity, setQuantity] = useState(1);
+	const [message, setMessage] = useState("");
+
+	const [laptopStock, setLaptopStock] = useState<ItemStock | null>(null);
+	const [phoneStock, setPhoneStock] = useState<ItemStock | null>(null);
+	const [checkoutSummary, setCheckoutSummary] = useState<CheckoutSummary | null>(
+		null
+	);
+
+	const initializeInventory = async () => {
+		// Initialize laptop inventory
+		const laptop = await client.inventory.create(["laptop"], {
+			input: {
+				itemName: "Laptop",
+				initialStock: 10,
+			},
+		});
+		const laptopInfo = await laptop.getStock();
+		setLaptopStock(laptopInfo);
+
+		// Initialize phone inventory
+		const phone = await client.inventory.create(["phone"], {
+			input: {
+				itemName: "Phone",
+				initialStock: 20,
+			},
+		});
+		const phoneInfo = await phone.getStock();
+		setPhoneStock(phoneInfo);
+
+		setMessage("Inventory initialized");
+	};
+
+	const refreshInventory = async () => {
+		const laptopInventory = client.inventory.get(["laptop"]);
+		const laptopInfo = await laptopInventory.getStock();
+		setLaptopStock(laptopInfo);
+
+		const phoneInventory = client.inventory.get(["phone"]);
+		const phoneInfo = await phoneInventory.getStock();
+		setPhoneStock(phoneInfo);
+	};
+
+	const createCheckout = async () => {
+		const checkout = await client.checkout.create(["session-1"], {
+			input: {
+				customerName,
+			},
+		});
+
+		const summary = await checkout.getSummary();
+		setCheckoutSummary(summary);
+		setMessage("Checkout session created");
+	};
+
+	const addItemToCheckout = async () => {
+		const checkout = client.checkout.get(["session-1"]);
+		const result = await checkout.addItem(selectedItem, quantity);
+
+		if (result.success) {
+			setMessage(result.message);
+			// Refresh checkout and inventory
+			const summary = await checkout.getSummary();
+			setCheckoutSummary(summary);
+			await refreshInventory();
+		} else {
+			setMessage(`Error: ${result.message}`);
+		}
+	};
+
+	const completeCheckout = async () => {
+		const checkout = client.checkout.get(["session-1"]);
+		const result = await checkout.completeCheckout();
+		setMessage(result.message);
+
+		const summary = await checkout.getSummary();
+		setCheckoutSummary(summary);
+	};
+
+	const cancelCheckout = async () => {
+		const checkout = client.checkout.get(["session-1"]);
+		const result = await checkout.cancelCheckout();
+		setMessage(result.message);
+
+		const summary = await checkout.getSummary();
+		setCheckoutSummary(summary);
+		await refreshInventory();
+	};
+
+	return (
+		<div className="container">
+			<div className="header">
+				<h1>Quickstart: Cross-Actor Actions</h1>
+				<p>
+					Demonstrates actors communicating with each other - checkout calling
+					inventory
+				</p>
+			</div>
+
+			{message && <div className="message">{message}</div>}
+
+			<div className="grid">
+				{/* Inventory Section */}
+				<div className="section">
+					<h2>Inventory Management</h2>
+					<button onClick={initializeInventory} className="primary">
+						Initialize Inventory
+					</button>
+
+					{laptopStock && (
+						<div className="inventory-item">
+							<h3>{laptopStock.itemName}</h3>
+							<p>Stock: {laptopStock.stock} units</p>
+						</div>
+					)}
+
+					{phoneStock && (
+						<div className="inventory-item">
+							<h3>{phoneStock.itemName}</h3>
+							<p>Stock: {phoneStock.stock} units</p>
+						</div>
+					)}
+				</div>
+
+				{/* Checkout Section */}
+				<div className="section">
+					<h2>Checkout</h2>
+
+					<div className="form-group">
+						<label>Customer Name:</label>
+						<input
+							type="text"
+							value={customerName}
+							onChange={(e) => setCustomerName(e.target.value)}
+							placeholder="Enter customer name"
+						/>
+					</div>
+
+					<button
+						onClick={createCheckout}
+						className="primary"
+					>
+						Create Checkout
+					</button>
+
+					{checkoutSummary && !checkoutSummary.completed && (
+						<div className="checkout-section">
+							<h3>Add Items</h3>
+							<div className="form-group">
+								<label>Item:</label>
+								<select
+									value={selectedItem}
+									onChange={(e) => setSelectedItem(e.target.value)}
+								>
+									<option value="laptop">Laptop</option>
+									<option value="phone">Phone</option>
+								</select>
+							</div>
+
+							<div className="form-group">
+								<label>Quantity:</label>
+								<input
+									type="number"
+									value={quantity}
+									onChange={(e) => setQuantity(Number(e.target.value))}
+									min="1"
+								/>
+							</div>
+
+							<button onClick={addItemToCheckout} className="secondary">
+								Add to Checkout
+							</button>
+						</div>
+					)}
+
+					{checkoutSummary && (
+						<div className="summary">
+							<h3>Checkout Summary</h3>
+							<p>
+								<strong>Customer:</strong> {checkoutSummary.customerName}
+							</p>
+							<p>
+								<strong>Status:</strong>{" "}
+								{checkoutSummary.completed ? "Completed" : "In Progress"}
+							</p>
+							<p>
+								<strong>Total Items:</strong> {checkoutSummary.totalItems}
+							</p>
+
+							{checkoutSummary.items.length > 0 && (
+								<div className="items-list">
+									<h4>Items:</h4>
+									{checkoutSummary.items.map((item, idx) => (
+										<div key={idx} className="item">
+											{item.quantity}x {item.itemName}
+										</div>
+									))}
+								</div>
+							)}
+
+							{!checkoutSummary.completed && (
+								<div className="button-group">
+									<button onClick={completeCheckout} className="success">
+										Complete Checkout
+									</button>
+									<button onClick={cancelCheckout} className="danger">
+										Cancel Checkout
+									</button>
+								</div>
+							)}
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/examples/cross-actor-actions-vercel/frontend/main.tsx
+++ b/examples/cross-actor-actions-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/cross-actor-actions-vercel/index.html
+++ b/examples/cross-actor-actions-vercel/index.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quickstart: Cross-Actor Actions</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+        .header {
+            background: #6f42c1;
+            color: white;
+            padding: 30px;
+            text-align: center;
+            border-radius: 8px;
+            margin-bottom: 30px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header h1 {
+            margin: 0 0 10px 0;
+            font-size: 2em;
+        }
+        .header p {
+            margin: 0;
+            opacity: 0.9;
+        }
+        .message {
+            background: #d4edda;
+            color: #155724;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #c3e6cb;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
+            gap: 20px;
+            margin-bottom: 20px;
+        }
+        .section {
+            background: white;
+            border-radius: 8px;
+            padding: 25px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .section h2 {
+            margin: 0 0 20px 0;
+            color: #6f42c1;
+            font-size: 1.5em;
+            border-bottom: 2px solid #6f42c1;
+            padding-bottom: 10px;
+        }
+        .inventory-item {
+            background: #f8f9fa;
+            padding: 15px;
+            border-radius: 6px;
+            margin-top: 15px;
+            border-left: 4px solid #6f42c1;
+        }
+        .inventory-item h3 {
+            margin: 0 0 10px 0;
+            color: #6f42c1;
+        }
+        .inventory-item p {
+            margin: 0;
+            font-size: 1.1em;
+            font-weight: 500;
+        }
+        .form-group {
+            margin-bottom: 15px;
+        }
+        .form-group label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: 500;
+            color: #333;
+        }
+        .form-group input,
+        .form-group select {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 14px;
+            box-sizing: border-box;
+        }
+        .checkout-section {
+            background: #f8f9fa;
+            padding: 20px;
+            border-radius: 6px;
+            margin-top: 20px;
+        }
+        .checkout-section h3 {
+            margin: 0 0 15px 0;
+            color: #6f42c1;
+        }
+        .summary {
+            background: #f8f9fa;
+            padding: 20px;
+            border-radius: 6px;
+            margin-top: 20px;
+            border-left: 4px solid #6f42c1;
+        }
+        .summary h3 {
+            margin: 0 0 15px 0;
+            color: #6f42c1;
+        }
+        .summary h4 {
+            margin: 15px 0 10px 0;
+            color: #495057;
+        }
+        .summary p {
+            margin: 8px 0;
+        }
+        .items-list {
+            margin-top: 15px;
+        }
+        .item {
+            background: white;
+            padding: 10px;
+            margin-bottom: 8px;
+            border-radius: 4px;
+            border: 1px solid #dee2e6;
+        }
+        button {
+            padding: 12px 20px;
+            background: #6c757d;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 500;
+            width: 100%;
+            margin-top: 10px;
+        }
+        button.primary {
+            background: #6f42c1;
+        }
+        button.primary:hover:not(:disabled) {
+            background: #5a32a3;
+        }
+        button.secondary {
+            background: #007bff;
+        }
+        button.secondary:hover:not(:disabled) {
+            background: #0056b3;
+        }
+        button.success {
+            background: #28a745;
+        }
+        button.success:hover:not(:disabled) {
+            background: #218838;
+        }
+        button.danger {
+            background: #dc3545;
+        }
+        button.danger:hover:not(:disabled) {
+            background: #c82333;
+        }
+        button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        button:hover:not(:disabled) {
+            background: #5a6268;
+        }
+        .button-group {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 10px;
+            margin-top: 15px;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/cross-actor-actions-vercel/package.json
+++ b/examples/cross-actor-actions-vercel/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "cross-actor-actions-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.0.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"typescript"
+		],
+		"tags": [],
+		"priority": 1000,
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/cross-actor-actions-vercel/src/actors.ts
+++ b/examples/cross-actor-actions-vercel/src/actors.ts
@@ -1,0 +1,181 @@
+import { actor, setup } from "rivetkit";
+
+export interface InventoryInput {
+	initialStock: number;
+	itemName: string;
+}
+
+export interface InventoryState {
+	itemName: string;
+	stock: number;
+	reservations: string[]; // Track which checkouts have reserved items
+}
+
+export interface CheckoutInput {
+	customerName: string;
+}
+
+export interface CheckoutItem {
+	itemId: string;
+	itemName: string;
+	quantity: number;
+}
+
+export interface CheckoutResult {
+	success: boolean;
+	message: string;
+	remainingStock?: number;
+}
+
+export interface CheckoutState {
+	customerName: string;
+	items: CheckoutItem[];
+	completed: boolean;
+}
+
+// Inventory actor manages stock for a specific item
+export const inventory = actor({
+	// Each item has its own inventory actor instance
+	createState: (_c, input: InventoryInput): InventoryState => ({
+		itemName: input.itemName,
+		stock: input.initialStock,
+		reservations: [],
+	}),
+
+	actions: {
+		// Check current stock
+		getStock: (c) => ({
+			itemName: c.state.itemName,
+			stock: c.state.stock,
+		}),
+
+		// Reserve items for checkout (called by checkout actor)
+		reserveItems: (c, checkoutId: string, quantity: number) => {
+			if (c.state.stock < quantity) {
+				return {
+					success: false,
+					message: `Insufficient stock. Available: ${c.state.stock}, Requested: ${quantity}`,
+					availableStock: c.state.stock,
+				};
+			}
+
+			// Reserve the items
+			c.state.stock -= quantity;
+			c.state.reservations.push(checkoutId);
+
+			return {
+				success: true,
+				message: `Reserved ${quantity} items for checkout ${checkoutId}`,
+				remainingStock: c.state.stock,
+			};
+		},
+
+		// Release reserved items if checkout is cancelled
+		releaseItems: (c, checkoutId: string, quantity: number) => {
+			const index = c.state.reservations.indexOf(checkoutId);
+			if (index > -1) {
+				c.state.reservations.splice(index, 1);
+				c.state.stock += quantity;
+			}
+			return {
+				success: true,
+				remainingStock: c.state.stock,
+			};
+		},
+	},
+});
+
+// Checkout actor manages the checkout process and communicates with inventory
+export const checkout = actor({
+	createState: (_c, input: CheckoutInput): CheckoutState => ({
+		customerName: input.customerName,
+		items: [],
+		completed: false,
+	}),
+
+	actions: {
+		// Add item to checkout and reserve from inventory
+		addItem: async (
+			c,
+			itemId: string,
+			quantity: number,
+		): Promise<CheckoutResult> => {
+			// Use server-side client to communicate with inventory actor
+			// https://rivet.dev/docs/actors/communicating-between-actors
+			const inventoryActor = c.client().inventory.getOrCreate([itemId]);
+
+			// Get item details
+			const itemInfo = await inventoryActor.getStock();
+
+			// Try to reserve items from inventory
+			const reservation = await inventoryActor.reserveItems(
+				c.actorId, // Use checkout ID as reservation ID
+				quantity,
+			);
+
+			if (!reservation.success) {
+				return {
+					success: false,
+					message: reservation.message,
+				};
+			}
+
+			// Add item to checkout
+			c.state.items.push({
+				itemId,
+				itemName: itemInfo.itemName,
+				quantity,
+			});
+
+			return {
+				success: true,
+				message: `Added ${quantity} ${itemInfo.itemName} to checkout`,
+				remainingStock: reservation.remainingStock,
+			};
+		},
+
+		// Get checkout summary
+		getSummary: (c) => ({
+			customerName: c.state.customerName,
+			items: c.state.items,
+			completed: c.state.completed,
+			totalItems: c.state.items.reduce(
+				(sum, item) => sum + item.quantity,
+				0,
+			),
+		}),
+
+		// Complete the checkout
+		completeCheckout: (c) => {
+			c.state.completed = true;
+			return {
+				success: true,
+				message: "Checkout completed successfully",
+			};
+		},
+
+		// Cancel checkout and release all reservations
+		cancelCheckout: async (c) => {
+			// Release all reserved items
+			for (const item of c.state.items) {
+				const inventoryActor = c
+					.client()
+					.inventory.getOrCreate([item.itemId]);
+				await inventoryActor.releaseItems(c.actorId, item.quantity);
+			}
+
+			// Clear the cart
+			c.state.items = [];
+
+			return {
+				success: true,
+				message: "Checkout cancelled, items returned to inventory",
+			};
+		},
+	},
+});
+
+// Register actors for use: https://rivet.dev/docs/setup
+export const registry = setup({
+	use: { inventory, checkout },
+});

--- a/examples/cross-actor-actions-vercel/src/server.ts
+++ b/examples/cross-actor-actions-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/cross-actor-actions-vercel/tests/cross-actor.test.ts
+++ b/examples/cross-actor-actions-vercel/tests/cross-actor.test.ts
@@ -1,0 +1,292 @@
+import { setupTest } from "rivetkit/test";
+import { describe, expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+describe("cross-actor communication", () => {
+	test("checkout reserves items from inventory", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create inventory with 10 laptops
+		const inventory = await client.inventory.create(["laptop"], {
+			input: {
+				itemName: "Laptop",
+				initialStock: 10,
+			},
+		});
+
+		// Verify initial stock
+		let stock = await inventory.getStock();
+		expect(stock.stock).toBe(10);
+
+		// Create checkout
+		const checkout = await client.checkout.create(["checkout-1"], {
+			input: {
+				customerName: "Alice",
+			},
+		});
+
+		// Add item to checkout (this calls inventory actor)
+		const result = await checkout.addItem("laptop", 3);
+
+		expect(result.success).toBe(true);
+		expect(result.message).toContain("Added 3 Laptop");
+		expect(result.remainingStock).toBe(7);
+
+		// Verify inventory was updated
+		stock = await inventory.getStock();
+		expect(stock.stock).toBe(7);
+
+		// Verify checkout has the items
+		const summary = await checkout.getSummary();
+		expect(summary.items).toHaveLength(1);
+		expect(summary.items[0]).toMatchObject({
+			itemId: "laptop",
+			itemName: "Laptop",
+			quantity: 3,
+		});
+		expect(summary.totalItems).toBe(3);
+	});
+
+	test("insufficient inventory prevents reservation", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create inventory with only 5 phones
+		await client.inventory.create(["phone"], {
+			input: {
+				itemName: "Phone",
+				initialStock: 5,
+			},
+		});
+
+		// Create checkout
+		const checkout = await client.checkout.create(["checkout-2"], {
+			input: {
+				customerName: "Bob",
+			},
+		});
+
+		// Try to add more items than available
+		const result = await checkout.addItem("phone", 10);
+
+		expect(result.success).toBe(false);
+		expect(result.message).toContain("Insufficient stock");
+
+		// Verify checkout is empty
+		const summary = await checkout.getSummary();
+		expect(summary.items).toHaveLength(0);
+	});
+
+	test("cancel checkout releases reserved items", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create inventory
+		const inventory = await client.inventory.create(["laptop-cancel"], {
+			input: {
+				itemName: "Laptop",
+				initialStock: 20,
+			},
+		});
+
+		// Create checkout and add items
+		const checkout = await client.checkout.create(["checkout-cancel"], {
+			input: {
+				customerName: "Charlie",
+			},
+		});
+
+		await checkout.addItem("laptop-cancel", 5);
+
+		// Verify stock decreased
+		let stock = await inventory.getStock();
+		expect(stock.stock).toBe(15);
+
+		// Cancel checkout
+		const cancelResult = await checkout.cancelCheckout();
+		expect(cancelResult.success).toBe(true);
+
+		// Verify items returned to inventory
+		stock = await inventory.getStock();
+		expect(stock.stock).toBe(20);
+
+		// Verify checkout is empty
+		const summary = await checkout.getSummary();
+		expect(summary.items).toHaveLength(0);
+	});
+
+	test("multiple checkouts can reserve from same inventory", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create inventory with 50 items
+		const inventory = await client.inventory.create(["shared-item"], {
+			input: {
+				itemName: "Shared Item",
+				initialStock: 50,
+			},
+		});
+
+		// Create two checkouts
+		const checkout1 = await client.checkout.create(["checkout-multi-1"], {
+			input: {
+				customerName: "Customer 1",
+			},
+		});
+
+		const checkout2 = await client.checkout.create(["checkout-multi-2"], {
+			input: {
+				customerName: "Customer 2",
+			},
+		});
+
+		// Both checkouts add items
+		await checkout1.addItem("shared-item", 20);
+		await checkout2.addItem("shared-item", 15);
+
+		// Verify total stock decreased correctly
+		const stock = await inventory.getStock();
+		expect(stock.stock).toBe(15); // 50 - 20 - 15 = 15
+
+		// Verify each checkout has their items
+		const summary1 = await checkout1.getSummary();
+		const summary2 = await checkout2.getSummary();
+
+		expect(summary1.totalItems).toBe(20);
+		expect(summary2.totalItems).toBe(15);
+	});
+
+	test("complete checkout keeps reservation", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create inventory
+		const inventory = await client.inventory.create(["laptop-complete"], {
+			input: {
+				itemName: "Laptop",
+				initialStock: 30,
+			},
+		});
+
+		// Create checkout
+		const checkout = await client.checkout.create(["checkout-complete"], {
+			input: {
+				customerName: "Dave",
+			},
+		});
+
+		// Add items
+		await checkout.addItem("laptop-complete", 10);
+
+		// Verify stock decreased
+		let stock = await inventory.getStock();
+		expect(stock.stock).toBe(20);
+
+		// Complete checkout
+		const completeResult = await checkout.completeCheckout();
+		expect(completeResult.success).toBe(true);
+
+		// Verify stock is still decreased (items are purchased)
+		stock = await inventory.getStock();
+		expect(stock.stock).toBe(20);
+
+		// Verify checkout is marked as completed
+		const summary = await checkout.getSummary();
+		expect(summary.completed).toBe(true);
+		expect(summary.totalItems).toBe(10);
+	});
+
+	test("checkout with multiple item types", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create multiple inventories
+		await client.inventory.create(["laptop-multi"], {
+			input: {
+				itemName: "Laptop",
+				initialStock: 10,
+			},
+		});
+
+		await client.inventory.create(["phone-multi"], {
+			input: {
+				itemName: "Phone",
+				initialStock: 20,
+			},
+		});
+
+		// Create checkout
+		const checkout = await client.checkout.create(
+			["checkout-multi-items"],
+			{
+				input: {
+					customerName: "Eve",
+				},
+			},
+		);
+
+		// Add multiple item types
+		await checkout.addItem("laptop-multi", 2);
+		await checkout.addItem("phone-multi", 5);
+
+		// Verify checkout summary
+		const summary = await checkout.getSummary();
+		expect(summary.items).toHaveLength(2);
+		expect(summary.totalItems).toBe(7); // 2 + 5
+
+		// Find laptop and phone items
+		const laptopItem = summary.items.find(
+			(i) => i.itemId === "laptop-multi",
+		);
+		const phoneItem = summary.items.find((i) => i.itemId === "phone-multi");
+
+		expect(laptopItem).toMatchObject({
+			itemName: "Laptop",
+			quantity: 2,
+		});
+
+		expect(phoneItem).toMatchObject({
+			itemName: "Phone",
+			quantity: 5,
+		});
+	});
+
+	test("release items for specific checkout", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create inventory
+		const inventory = await client.inventory.create(["laptop-release"], {
+			input: {
+				itemName: "Laptop",
+				initialStock: 100,
+			},
+		});
+
+		// Create two checkouts
+		const checkout1 = await client.checkout.create(["checkout-release-1"], {
+			input: {
+				customerName: "Customer 1",
+			},
+		});
+
+		const checkout2 = await client.checkout.create(["checkout-release-2"], {
+			input: {
+				customerName: "Customer 2",
+			},
+		});
+
+		// Both reserve items
+		await checkout1.addItem("laptop-release", 30);
+		await checkout2.addItem("laptop-release", 40);
+
+		// Stock should be 30 (100 - 30 - 40)
+		let stock = await inventory.getStock();
+		expect(stock.stock).toBe(30);
+
+		// Cancel only checkout1
+		await checkout1.cancelCheckout();
+
+		// Stock should increase by 30
+		stock = await inventory.getStock();
+		expect(stock.stock).toBe(60);
+
+		// checkout2 should still have its items
+		const summary2 = await checkout2.getSummary();
+		expect(summary2.totalItems).toBe(40);
+	});
+});

--- a/examples/cross-actor-actions-vercel/tsconfig.json
+++ b/examples/cross-actor-actions-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/cross-actor-actions-vercel/turbo.json
+++ b/examples/cross-actor-actions-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/cross-actor-actions-vercel/vercel.json
+++ b/examples/cross-actor-actions-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/cross-actor-actions-vercel/vite.config.ts
+++ b/examples/cross-actor-actions-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/cross-actor-actions-vercel/vitest.config.ts
+++ b/examples/cross-actor-actions-vercel/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	server: {
+		port: 5173,
+	},
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/cross-actor-actions/vercel.json
+++ b/examples/cross-actor-actions/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/cursors-raw-websocket-vercel/.gitignore
+++ b/examples/cursors-raw-websocket-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/cursors-raw-websocket-vercel/README.md
+++ b/examples/cursors-raw-websocket-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [cursors-raw-websocket](../cursors-raw-websocket) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fcursors-raw-websocket-vercel&project-name=cursors-raw-websocket-vercel)
+
+# Real-time Collaborative Cursors (Raw WebSocket)
+
+Demonstrates real-time cursor tracking and collaborative canvas using raw WebSocket handlers instead of RivetKit's higher-level WebSocket abstraction.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/cursors-raw-websocket
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Raw WebSocket handlers**: Use `onWebsocket` for low-level WebSocket control and custom protocols
+- **Real-time cursor tracking**: Broadcast cursor positions to all connected users instantly
+- **Persistent canvas state**: Text labels automatically saved in actor state across sessions
+- **Multiple rooms**: Each room is a separate actor instance with isolated state
+
+## Implementation
+
+This example demonstrates low-level WebSocket handling for real-time collaboration:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/cursors-raw-websocket/src/backend/registry.ts)): Uses raw `onWebsocket` handler for custom WebSocket protocol implementation
+
+## Resources
+
+Read more about [WebSockets](/docs/actors/websockets), [state](/docs/actors/state), and [events](/docs/actors/events).
+
+## License
+
+MIT

--- a/examples/cursors-raw-websocket-vercel/api/index.ts
+++ b/examples/cursors-raw-websocket-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/cursors-raw-websocket-vercel/frontend/App.tsx
+++ b/examples/cursors-raw-websocket-vercel/frontend/App.tsx
@@ -1,0 +1,442 @@
+import { createClient } from "@rivetkit/react";
+import { useEffect, useRef, useState } from "react";
+import type {
+	CursorPosition,
+	TextLabel,
+	registry,
+} from "../src/actors.ts";
+
+// HTTP requests go through Vite proxy
+const rivetUrl = `${location.origin}/api/rivet`;
+// WebSocket connections go directly to RivetKit server (vite-plugin-srvx doesn't proxy WS)
+const rivetWsUrl = "ws://localhost:6420";
+
+const client = createClient<typeof registry>(rivetUrl);
+
+// Generate a random user ID
+const generateUserId = () =>
+	`user-${Math.random().toString(36).substring(2, 9)}`;
+
+// Generate a random session ID
+const generateSessionId = () =>
+	`session-${Math.random().toString(36).substring(2, 15)}`;
+
+// Cursor colors for different users (darker palette)
+const CURSOR_COLORS = [
+	"#E63946",
+	"#2A9D8F",
+	"#1B8AAE",
+	"#F77F00",
+	"#06A77D",
+	"#D4A017",
+	"#9B59B6",
+	"#5DADE2",
+];
+
+function getColorForUser(userId: string): string {
+	let hash = 0;
+	for (let i = 0; i < userId.length; i++) {
+		hash = userId.charCodeAt(i) + ((hash << 5) - hash);
+	}
+	return CURSOR_COLORS[Math.abs(hash) % CURSOR_COLORS.length];
+}
+
+// Virtual canvas size - all coordinates are in this space
+const CANVAS_WIDTH = 1920;
+const CANVAS_HEIGHT = 1080;
+
+export function App() {
+	const [roomId, setRoomId] = useState("general");
+	const [userId] = useState(generateUserId());
+	const [sessionId] = useState(generateSessionId());
+	const [cursors, setCursors] = useState<Record<string, CursorPosition>>({});
+	const [textLabels, setTextLabels] = useState<TextLabel[]>([]);
+	const [textInput, setTextInput] = useState("");
+	const [isTyping, setIsTyping] = useState(false);
+	const [typingPosition, setTypingPosition] = useState({ x: 0, y: 0 });
+	const [currentTextId, setCurrentTextId] = useState<string | null>(null);
+	const [scale, setScale] = useState(1);
+	const [connected, setConnected] = useState(false);
+	const canvasRef = useRef<HTMLDivElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const wsRef = useRef<WebSocket | null>(null);
+
+	// Calculate scale factor to fit canvas in viewport
+	useEffect(() => {
+		const updateScale = () => {
+			if (!containerRef.current) return;
+
+			const containerWidth = containerRef.current.clientWidth;
+			const containerHeight = containerRef.current.clientHeight;
+
+			// Calculate scale to fit canvas while maintaining aspect ratio
+			const scaleX = containerWidth / CANVAS_WIDTH;
+			const scaleY = containerHeight / CANVAS_HEIGHT;
+			const newScale = Math.min(scaleX, scaleY);
+
+			setScale(newScale);
+		};
+
+		updateScale();
+		window.addEventListener("resize", updateScale);
+		return () => window.removeEventListener("resize", updateScale);
+	}, []);
+
+	// Connect to WebSocket
+	useEffect(() => {
+		let ws: WebSocket | null = null;
+
+		const connect = async () => {
+			try {
+				// Get or create the actor for this room
+				const actorId = await client.cursorRoom.getOrCreate(roomId).resolve();
+				console.log("found actor", actorId);
+
+				// Connect directly to RivetKit server for WebSocket (vite-plugin-srvx doesn't proxy WS)
+				const wsUrl = `${rivetWsUrl}/gateway/${actorId}/websocket?sessionId=${encodeURIComponent(sessionId)}`;
+
+				console.log("ws url:", wsUrl);
+
+				// Create raw WebSocket connection (no subprotocols needed)
+				ws = new WebSocket(wsUrl);
+				wsRef.current = ws;
+
+				ws.addEventListener("open", () => {
+					console.log("websocket connected");
+					setConnected(true);
+				});
+
+				ws.addEventListener("message", (event) => {
+					try {
+						const message = JSON.parse(event.data);
+
+						switch (message.type) {
+							case "init": {
+								// Initial state from server
+								setCursors(message.data.cursors);
+								setTextLabels(message.data.textLabels);
+								break;
+							}
+
+							case "cursorMoved": {
+								setCursors((prev) => ({
+									...prev,
+									[message.data.userId]: message.data,
+								}));
+								break;
+							}
+
+							case "textUpdated": {
+								setTextLabels((prev) => {
+									const existingIndex = prev.findIndex(
+										(l) => l.id === message.data.id,
+									);
+									if (existingIndex >= 0) {
+										const newLabels = [...prev];
+										newLabels[existingIndex] = message.data;
+										return newLabels;
+									} else {
+										return [...prev, message.data];
+									}
+								});
+								break;
+							}
+
+							case "textRemoved": {
+								setTextLabels((prev) =>
+									prev.filter((label) => label.id !== message.data),
+								);
+								break;
+							}
+
+							case "cursorRemoved": {
+								setCursors((prev) => {
+									const newCursors = { ...prev };
+									delete newCursors[message.data.userId];
+									return newCursors;
+								});
+								break;
+							}
+						}
+					} catch (error) {
+						console.error("error parsing websocket message:", error);
+					}
+				});
+
+				ws.addEventListener("close", () => {
+					console.log("websocket disconnected");
+					setConnected(false);
+					wsRef.current = null;
+				});
+
+				ws.addEventListener("error", (error) => {
+					console.error("websocket error:", error);
+				});
+			} catch (error) {
+				console.error("error connecting:", error);
+			}
+		};
+
+		connect();
+
+		// Cleanup
+		return () => {
+			if (ws) {
+				ws.close();
+			}
+		};
+	}, [roomId, sessionId]);
+
+	// Convert screen coordinates to canvas coordinates
+	const screenToCanvas = (screenX: number, screenY: number) => {
+		if (!canvasRef.current) return { x: 0, y: 0 };
+
+		const rect = canvasRef.current.getBoundingClientRect();
+		const x = (screenX - rect.left) / scale;
+		const y = (screenY - rect.top) / scale;
+
+		return { x, y };
+	};
+
+	// Handle mouse movement on canvas
+	const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+		if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN && canvasRef.current) {
+			const { x, y } = screenToCanvas(e.clientX, e.clientY);
+			wsRef.current.send(
+				JSON.stringify({
+					type: "updateCursor",
+					data: { userId, x, y },
+				}),
+			);
+		}
+	};
+
+	// Handle canvas click
+	const handleCanvasClick = (e: React.MouseEvent<HTMLDivElement>) => {
+		if (!canvasRef.current) return;
+
+		const { x, y } = screenToCanvas(e.clientX, e.clientY);
+		const newTextId = `${userId}-${Date.now()}`;
+		setTypingPosition({ x, y });
+		setCurrentTextId(newTextId);
+		setIsTyping(true);
+		setTextInput("");
+	};
+
+	// Handle text input changes
+	const handleTextChange = (newText: string) => {
+		setTextInput(newText);
+		if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN && currentTextId && newText.trim()) {
+			wsRef.current.send(
+				JSON.stringify({
+					type: "updateText",
+					data: {
+						id: currentTextId,
+						userId,
+						text: newText,
+						x: typingPosition.x,
+						y: typingPosition.y,
+					},
+				}),
+			);
+		}
+	};
+
+	// Handle key press while typing
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter") {
+			// Finalize the text
+			if (textInput.trim() && wsRef.current && wsRef.current.readyState === WebSocket.OPEN && currentTextId) {
+				wsRef.current.send(
+					JSON.stringify({
+						type: "updateText",
+						data: {
+							id: currentTextId,
+							userId,
+							text: textInput,
+							x: typingPosition.x,
+							y: typingPosition.y,
+						},
+					}),
+				);
+			} else if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN && currentTextId) {
+				// Remove empty text
+				wsRef.current.send(
+					JSON.stringify({
+						type: "removeText",
+						data: { id: currentTextId },
+					}),
+				);
+			}
+			setTextInput("");
+			setIsTyping(false);
+			setCurrentTextId(null);
+		} else if (e.key === "Escape") {
+			// Cancel typing and remove text
+			if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN && currentTextId) {
+				wsRef.current.send(
+					JSON.stringify({
+						type: "removeText",
+						data: { id: currentTextId },
+					}),
+				);
+			}
+			setTextInput("");
+			setIsTyping(false);
+			setCurrentTextId(null);
+		}
+	};
+
+	return (
+		<div className="app-container">
+			<div className="controls">
+				<div className="control-group">
+					<label>Room:</label>
+					<input
+						type="text"
+						value={roomId}
+						onChange={(e) => setRoomId(e.target.value)}
+						placeholder="Enter room name"
+					/>
+				</div>
+				<div className="user-info">
+					Your ID: <span style={{ color: getColorForUser(userId) }}>{userId}</span>
+				</div>
+			</div>
+
+			<div ref={containerRef} className="canvas-container">
+				<div
+					ref={canvasRef}
+					className="canvas"
+					style={{
+						width: `${CANVAS_WIDTH}px`,
+						height: `${CANVAS_HEIGHT}px`,
+						transform: `translate(-50%, -50%) scale(${scale})`,
+					}}
+					onMouseMove={handleMouseMove}
+					onClick={handleCanvasClick}
+					tabIndex={0}
+					onKeyDown={handleKeyDown}
+				>
+					{/* Render text labels */}
+					{textLabels
+						.filter((label) => label.id !== currentTextId)
+						.map((label) => (
+							<div
+								key={label.id}
+								className="text-label"
+								style={{
+									left: label.x,
+									top: label.y,
+									color: getColorForUser(label.userId),
+								}}
+							>
+								{label.text}
+							</div>
+						))}
+
+					{/* Render text being typed */}
+					{isTyping && (
+						<div
+							className="typing-container"
+							style={{
+								left: typingPosition.x,
+								top: typingPosition.y,
+							}}
+						>
+							<div
+								className="typing-text"
+								style={{
+									color: getColorForUser(userId),
+								}}
+							>
+								{textInput}
+								<span className="typing-cursor">|</span>
+							</div>
+							<div
+								className="enter-hint"
+								style={{
+									borderColor: getColorForUser(userId),
+									color: getColorForUser(userId),
+								}}
+							>
+								enter
+							</div>
+						</div>
+					)}
+
+					{/* Render cursors */}
+					{Object.entries(cursors).map(([id, cursor]) => {
+						const color = getColorForUser(cursor.userId);
+						const isOwnCursor = id === userId;
+						return (
+							<div
+								key={id}
+								className="cursor"
+								style={{
+									left: cursor.x,
+									top: cursor.y,
+								}}
+							>
+								<svg
+									width="20"
+									height="24"
+									viewBox="0 0 20 24"
+									fill="none"
+									xmlns="http://www.w3.org/2000/svg"
+									className="cursor-svg"
+								>
+									<path
+										d="M10 4 L4 18 L16 18 Z"
+										fill={color}
+										stroke="white"
+										strokeWidth="1.5"
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										transform="rotate(-45 10 12)"
+									/>
+								</svg>
+								<div
+									className="cursor-label"
+									style={{
+										backgroundColor: color,
+										borderColor: `${color}40`,
+									}}
+								>
+									{isOwnCursor ? "you" : cursor.userId}
+								</div>
+							</div>
+						);
+					})}
+
+					{!connected && (
+						<div className="loading-overlay">Connecting to room...</div>
+					)}
+
+					{/* Hidden input to capture typing */}
+					{isTyping && (
+						<input
+							type="text"
+							className="hidden-input"
+							value={textInput}
+							onChange={(e) => handleTextChange(e.target.value)}
+							onBlur={() => {
+								if (!textInput.trim() && wsRef.current && wsRef.current.readyState === WebSocket.OPEN && currentTextId) {
+									wsRef.current.send(
+										JSON.stringify({
+											type: "removeText",
+											data: { id: currentTextId },
+										}),
+									);
+									setCurrentTextId(null);
+								}
+								setIsTyping(false);
+							}}
+							autoFocus
+						/>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/examples/cursors-raw-websocket-vercel/frontend/main.tsx
+++ b/examples/cursors-raw-websocket-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/cursors-raw-websocket-vercel/index.html
+++ b/examples/cursors-raw-websocket-vercel/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cursors Example</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #0a0a0a;
+            color: #e0e0e0;
+            overflow: hidden;
+            height: 100vh;
+        }
+        .app-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+        }
+        .controls {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            right: 20px;
+            z-index: 200;
+            background: rgba(26, 26, 26, 0.9);
+            backdrop-filter: blur(10px);
+            padding: 16px 20px;
+            border-radius: 8px;
+            border: 1px solid #2a2a2a;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-shrink: 0;
+        }
+        .control-group {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+        .control-group label {
+            font-weight: 500;
+            color: #a0a0a0;
+        }
+        .control-group input {
+            padding: 8px 12px;
+            border: 1px solid #333;
+            border-radius: 4px;
+            min-width: 200px;
+            background: #2a2a2a;
+            color: #e0e0e0;
+        }
+        .control-group input:focus {
+            outline: none;
+            border-color: #4a9eff;
+        }
+        .user-info {
+            font-size: 14px;
+            color: #808080;
+        }
+        .canvas-container {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            overflow: hidden;
+            background: #0a0a0a;
+        }
+        .canvas {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform-origin: center center;
+            background: #1a1a1a;
+            cursor: none;
+            overflow: hidden;
+        }
+        .cursor {
+            position: absolute;
+            pointer-events: none;
+            z-index: 100;
+        }
+        .cursor-svg {
+            filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+        }
+        .cursor-label {
+            position: absolute;
+            top: 20px;
+            left: 18px;
+            padding: 4px 8px;
+            border-radius: 8px;
+            color: white;
+            font-size: 12px;
+            white-space: nowrap;
+            border: 1px solid;
+        }
+        .text-label {
+            position: absolute;
+            font-size: 16px;
+            font-weight: 500;
+            pointer-events: none;
+            white-space: nowrap;
+            transform: translate(0, -50%);
+            text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+            line-height: 1;
+        }
+        .typing-container {
+            position: absolute;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            pointer-events: none;
+            transform: translate(0, -50%);
+        }
+        .typing-text {
+            font-size: 16px;
+            font-weight: 500;
+            white-space: nowrap;
+            text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+            line-height: 1;
+        }
+        .typing-cursor {
+            animation: blink 1s infinite;
+            margin-left: 2px;
+            display: inline-block;
+            position: relative;
+            top: -2px;
+        }
+        @keyframes blink {
+            0%, 50% { opacity: 1; }
+            51%, 100% { opacity: 0; }
+        }
+        .enter-hint {
+            font-size: 11px;
+            font-weight: 500;
+            white-space: nowrap;
+            padding: 2px 6px;
+            border: 1px solid;
+            border-radius: 4px;
+            background: rgba(0, 0, 0, 0.5);
+            opacity: 0.7;
+        }
+        .hidden-input {
+            position: absolute;
+            top: -9999px;
+            left: -9999px;
+            width: 1px;
+            height: 1px;
+            opacity: 0;
+            pointer-events: none;
+        }
+        .loading-overlay {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            font-size: 18px;
+            color: #808080;
+        }
+        .instructions {
+            background: #1a1a1a;
+            padding: 20px;
+            border-radius: 8px;
+            border: 1px solid #2a2a2a;
+            margin: 20px;
+        }
+        .instructions h4 {
+            margin-top: 0;
+            color: #4a9eff;
+        }
+        .instructions ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+        .instructions li {
+            margin-bottom: 8px;
+            color: #a0a0a0;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/cursors-raw-websocket-vercel/package.json
+++ b/examples/cursors-raw-websocket-vercel/package.json
@@ -1,0 +1,42 @@
+{
+	"name": "example-cursors-raw-websocket-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.0.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"websocket",
+			"typescript"
+		],
+		"tags": [
+			"real-time"
+		],
+		"frontendPort": 5173
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/cursors-raw-websocket-vercel/src/actors.ts
+++ b/examples/cursors-raw-websocket-vercel/src/actors.ts
@@ -1,0 +1,211 @@
+import { actor, setup, type UniversalWebSocket, type RivetMessageEvent, type RivetCloseEvent } from "rivetkit";
+
+export interface CursorPosition {
+	userId: string;
+	x: number;
+	y: number;
+	timestamp: number;
+}
+
+export interface TextLabel {
+	id: string;
+	userId: string;
+	text: string;
+	x: number;
+	y: number;
+	timestamp: number;
+}
+
+interface Vars {
+	websockets: Map<
+		string,
+		{ socket: UniversalWebSocket; cursor: CursorPosition | null }
+	>;
+}
+
+export const cursorRoom = actor({
+	state: {
+		textLabels: [] as TextLabel[],
+	},
+
+	createVars: (): Vars => {
+		return {
+			websockets: new Map(),
+		};
+	},
+
+	actions: {
+		// Get or create the actor (for frontend to resolve actor ID)
+		getOrCreate: () => {
+			return { status: "ok" };
+		},
+
+		// Get all room state (cursors and text labels)
+		getRoomState: (c) => {
+			const cursors: Record<string, CursorPosition> = {};
+			for (const [sessionId, { cursor }] of c.vars.websockets.entries()) {
+				if (cursor) {
+					cursors[sessionId] = cursor;
+				}
+			}
+			return {
+				cursors,
+				textLabels: c.state.textLabels,
+			};
+		},
+	},
+
+	// Handle WebSocket connections
+	onWebSocket: async (c, websocket: UniversalWebSocket) => {
+		if (!c.request) {
+			websocket.close(1008, "no request");
+			return;
+		}
+
+		const url = new URL(c.request.url);
+		const sessionId = url.searchParams.get("sessionId");
+
+		if (!sessionId) {
+			websocket.close(1008, "Missing sessionId");
+			return;
+		}
+
+		console.log(
+			`websocket connected: sessionId=${sessionId}, actorId=${c.actorId}`,
+		);
+
+		// Store the websocket
+		c.vars.websockets.set(sessionId, { socket: websocket, cursor: null });
+
+		// Send initial state to the new connection
+		const cursors: Record<string, CursorPosition> = {};
+		for (const [id, { cursor }] of c.vars.websockets.entries()) {
+			if (cursor) {
+				cursors[id] = cursor;
+			}
+		}
+		websocket.send(
+			JSON.stringify({
+				type: "init",
+				data: {
+					cursors,
+					textLabels: c.state.textLabels,
+				},
+			}),
+		);
+
+		// Handle incoming messages
+		websocket.addEventListener("message", (event: RivetMessageEvent) => {
+			try {
+				const message = JSON.parse(event.data as string);
+
+				switch (message.type) {
+					case "updateCursor": {
+						const { userId, x, y } = message.data;
+						const cursor: CursorPosition = {
+							userId,
+							x,
+							y,
+							timestamp: Date.now(),
+						};
+
+						// Update the cursor for this session
+						const session = c.vars.websockets.get(sessionId);
+						if (session) {
+							session.cursor = cursor;
+						}
+
+						// Broadcast to all connections (including sender)
+						for (const { socket } of c.vars.websockets.values()) {
+							socket.send(
+								JSON.stringify({
+									type: "cursorMoved",
+									data: cursor,
+								}),
+							);
+						}
+						break;
+					}
+
+					case "updateText": {
+						const { id, userId, text, x, y } = message.data;
+						const textLabel: TextLabel = {
+							id,
+							userId,
+							text,
+							x,
+							y,
+							timestamp: Date.now(),
+						};
+
+						// Find and update existing text label or add new one
+						const existingIndex = c.state.textLabels.findIndex(
+							(label) => label.id === id,
+						);
+						if (existingIndex >= 0) {
+							c.state.textLabels[existingIndex] = textLabel;
+						} else {
+							c.state.textLabels.push(textLabel);
+						}
+
+						// Broadcast to all connections
+						for (const { socket } of c.vars.websockets.values()) {
+							socket.send(
+								JSON.stringify({
+									type: "textUpdated",
+									data: textLabel,
+								}),
+							);
+						}
+						break;
+					}
+
+					case "removeText": {
+						const { id } = message.data;
+						c.state.textLabels = c.state.textLabels.filter(
+							(label) => label.id !== id,
+						);
+
+						// Broadcast to all connections
+						for (const { socket } of c.vars.websockets.values()) {
+							socket.send(
+								JSON.stringify({
+									type: "textRemoved",
+									data: id,
+								}),
+							);
+						}
+						break;
+					}
+				}
+			} catch (error) {
+				console.error("error handling websocket message:", error);
+			}
+		});
+
+		// Handle connection close
+		websocket.addEventListener("close", () => {
+			console.log(`websocket disconnected: sessionId=${sessionId}`);
+			const session = c.vars.websockets.get(sessionId);
+			if (session?.cursor) {
+				// Broadcast cursor removal to all other connections
+				for (const [id, { socket }] of c.vars.websockets.entries()) {
+					if (id !== sessionId) {
+						socket.send(
+							JSON.stringify({
+								type: "cursorRemoved",
+								data: session.cursor,
+							}),
+						);
+					}
+				}
+			}
+			c.vars.websockets.delete(sessionId);
+		});
+	},
+});
+
+// Register actors for use: https://rivet.dev/docs/setup
+export const registry = setup({
+	use: { cursorRoom },
+});

--- a/examples/cursors-raw-websocket-vercel/src/server.ts
+++ b/examples/cursors-raw-websocket-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/cursors-raw-websocket-vercel/tests/cursors.test.ts
+++ b/examples/cursors-raw-websocket-vercel/tests/cursors.test.ts
@@ -1,0 +1,24 @@
+import { setupTest } from "rivetkit/test";
+import { expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+test("Cursor room can be created and initialized", async (ctx: any) => {
+	const { client } = await setupTest(ctx, registry);
+	const room = client.cursorRoom.getOrCreate(["test-room"]);
+
+	// Test that the getOrCreate action works
+	const result = await room.getOrCreate();
+	expect(result).toEqual({ status: "ok" });
+});
+
+test("Cursor room can get initial room state", async (ctx: any) => {
+	const { client } = await setupTest(ctx, registry);
+	const room = client.cursorRoom.getOrCreate(["test-state"]);
+
+	// Test initial state
+	const state = await room.getRoomState();
+	expect(state).toEqual({
+		cursors: {},
+		textLabels: [],
+	});
+});

--- a/examples/cursors-raw-websocket-vercel/tsconfig.json
+++ b/examples/cursors-raw-websocket-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/cursors-raw-websocket-vercel/turbo.json
+++ b/examples/cursors-raw-websocket-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/cursors-raw-websocket-vercel/vercel.json
+++ b/examples/cursors-raw-websocket-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/cursors-raw-websocket-vercel/vite.config.ts
+++ b/examples/cursors-raw-websocket-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/cursors-raw-websocket-vercel/vitest.config.ts
+++ b/examples/cursors-raw-websocket-vercel/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	server: {
+		port: 5173,
+	},
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/cursors-raw-websocket/vercel.json
+++ b/examples/cursors-raw-websocket/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/cursors-vercel/.gitignore
+++ b/examples/cursors-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/cursors-vercel/README.md
+++ b/examples/cursors-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [cursors](../cursors) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fcursors-vercel&project-name=cursors-vercel)
+
+# Real-time Collaborative Cursors
+
+Example project demonstrating real-time cursor tracking and collaborative canvas.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/cursors
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Real-time cursor tracking**: Broadcast cursor positions to all connected users instantly
+- **Event-driven architecture**: Use actor events to push updates to WebSocket clients
+- **Persistent canvas state**: Text labels automatically saved in actor state across sessions
+- **Multiple rooms**: Each room is a separate actor instance with isolated state
+
+## Implementation
+
+This example demonstrates real-time collaboration using WebSockets and Rivet Actors:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/cursors/src/backend/registry.ts)): Implements the `canvasRoom` actor for tracking cursor positions and managing collaborative canvas state
+
+## Resources
+
+Read more about [WebSockets](/docs/actors/websockets), [state](/docs/actors/state), and [events](/docs/actors/events).
+
+## License
+
+MIT

--- a/examples/cursors-vercel/api/index.ts
+++ b/examples/cursors-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/cursors-vercel/frontend/App.tsx
+++ b/examples/cursors-vercel/frontend/App.tsx
@@ -1,0 +1,350 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useEffect, useRef, useState } from "react";
+import type {
+	CursorPosition,
+	TextLabel,
+	registry,
+} from "../src/actors.ts";
+
+const { useActor } = createRivetKit<typeof registry>(`${window.location.origin}/api/rivet`);
+
+// Generate a random user ID
+const generateUserId = () =>
+	`user-${Math.random().toString(36).substring(2, 9)}`;
+
+// Cursor colors for different users (darker palette)
+const CURSOR_COLORS = [
+	"#E63946",
+	"#2A9D8F",
+	"#1B8AAE",
+	"#F77F00",
+	"#06A77D",
+	"#D4A017",
+	"#9B59B6",
+	"#5DADE2",
+];
+
+function getColorForUser(userId: string): string {
+	let hash = 0;
+	for (let i = 0; i < userId.length; i++) {
+		hash = userId.charCodeAt(i) + ((hash << 5) - hash);
+	}
+	return CURSOR_COLORS[Math.abs(hash) % CURSOR_COLORS.length];
+}
+
+// Virtual canvas size - all coordinates are in this space
+const CANVAS_WIDTH = 1920;
+const CANVAS_HEIGHT = 1080;
+
+export function App() {
+	const [roomId, setRoomId] = useState("general");
+	const [userId] = useState(generateUserId());
+	const [cursors, setCursors] = useState<Record<string, CursorPosition>>({});
+	const [textLabels, setTextLabels] = useState<TextLabel[]>([]);
+	const [textInput, setTextInput] = useState("");
+	const [isTyping, setIsTyping] = useState(false);
+	const [typingPosition, setTypingPosition] = useState({ x: 0, y: 0 });
+	const [currentTextId, setCurrentTextId] = useState<string | null>(null);
+	const [scale, setScale] = useState(1);
+	const canvasRef = useRef<HTMLDivElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	const cursorRoom = useActor({
+		name: "cursorRoom",
+		key: [roomId],
+	});
+
+	// Calculate scale factor to fit canvas in viewport
+	useEffect(() => {
+		const updateScale = () => {
+			if (!containerRef.current) return;
+
+			const containerWidth = containerRef.current.clientWidth;
+			const containerHeight = containerRef.current.clientHeight;
+
+			// Calculate scale to fit canvas while maintaining aspect ratio
+			const scaleX = containerWidth / CANVAS_WIDTH;
+			const scaleY = containerHeight / CANVAS_HEIGHT;
+			const newScale = Math.min(scaleX, scaleY);
+
+			setScale(newScale);
+		};
+
+		updateScale();
+		window.addEventListener("resize", updateScale);
+		return () => window.removeEventListener("resize", updateScale);
+	}, []);
+
+	// Load initial state
+	useEffect(() => {
+		if (cursorRoom.connection) {
+			cursorRoom.connection.getRoomState().then((state) => {
+				setCursors(state.cursors);
+				setTextLabels(state.textLabels);
+			}).catch((error) => {
+				console.error('error loading room state', error);
+			});
+		}
+	}, [cursorRoom.connection]);
+
+	// Listen for cursor movements
+	cursorRoom.useEvent("cursorMoved", (cursor: CursorPosition) => {
+		setCursors((prev) => ({
+			...prev,
+			[cursor.userId]: cursor,
+		}));
+	});
+
+	// Listen for text updates
+	cursorRoom.useEvent("textUpdated", (label: TextLabel) => {
+		setTextLabels((prev) => {
+			const existingIndex = prev.findIndex(l => l.id === label.id);
+			if (existingIndex >= 0) {
+				const newLabels = [...prev];
+				newLabels[existingIndex] = label;
+				return newLabels;
+			} else {
+				return [...prev, label];
+			}
+		});
+	});
+
+	// Listen for text removal
+	cursorRoom.useEvent("textRemoved", (id: string) => {
+		setTextLabels((prev) => prev.filter(label => label.id !== id));
+	});
+
+	// Listen for cursor removal (when connection closes)
+	cursorRoom.useEvent("cursorRemoved", (cursor: CursorPosition) => {
+		setCursors((prev) => {
+			const newCursors = { ...prev };
+			delete newCursors[cursor.userId];
+			return newCursors;
+		});
+	});
+
+	// Convert screen coordinates to canvas coordinates
+	const screenToCanvas = (screenX: number, screenY: number) => {
+		if (!canvasRef.current) return { x: 0, y: 0 };
+
+		const rect = canvasRef.current.getBoundingClientRect();
+		const x = (screenX - rect.left) / scale;
+		const y = (screenY - rect.top) / scale;
+
+		return { x, y };
+	};
+
+	// Handle mouse movement on canvas
+	const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+		if (cursorRoom.connection && canvasRef.current) {
+			const { x, y } = screenToCanvas(e.clientX, e.clientY);
+			cursorRoom.connection.updateCursor(userId, x, y);
+		}
+	};
+
+	// Handle canvas click
+	const handleCanvasClick = (e: React.MouseEvent<HTMLDivElement>) => {
+		if (!canvasRef.current) return;
+
+		const { x, y } = screenToCanvas(e.clientX, e.clientY);
+		const newTextId = `${userId}-${Date.now()}`;
+		setTypingPosition({ x, y });
+		setCurrentTextId(newTextId);
+		setIsTyping(true);
+		setTextInput("");
+	};
+
+	// Handle text input changes
+	const handleTextChange = (newText: string) => {
+		setTextInput(newText);
+		if (cursorRoom.connection && currentTextId && newText.trim()) {
+			cursorRoom.connection.updateText(
+				currentTextId,
+				userId,
+				newText,
+				typingPosition.x,
+				typingPosition.y,
+			);
+		}
+	};
+
+	// Handle key press while typing
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter") {
+			// Finalize the text
+			if (textInput.trim() && cursorRoom.connection && currentTextId) {
+				cursorRoom.connection.updateText(
+					currentTextId,
+					userId,
+					textInput,
+					typingPosition.x,
+					typingPosition.y,
+				);
+			} else if (cursorRoom.connection && currentTextId) {
+				// Remove empty text
+				cursorRoom.connection.removeText(currentTextId);
+			}
+			setTextInput("");
+			setIsTyping(false);
+			setCurrentTextId(null);
+		} else if (e.key === "Escape") {
+			// Cancel typing and remove text
+			if (cursorRoom.connection && currentTextId) {
+				cursorRoom.connection.removeText(currentTextId);
+			}
+			setTextInput("");
+			setIsTyping(false);
+			setCurrentTextId(null);
+		}
+	};
+
+	// Cursor is automatically removed when connection closes via connState cleanup
+
+	return (
+		<div className="app-container">
+			<div className="controls">
+				<div className="control-group">
+					<label>Room:</label>
+					<input
+						type="text"
+						value={roomId}
+						onChange={(e) => setRoomId(e.target.value)}
+						placeholder="Enter room name"
+					/>
+				</div>
+				<div className="user-info">
+					Your ID: <span style={{ color: getColorForUser(userId) }}>{userId}</span>
+				</div>
+			</div>
+
+			<div ref={containerRef} className="canvas-container">
+				<div
+					ref={canvasRef}
+					className="canvas"
+					style={{
+						width: `${CANVAS_WIDTH}px`,
+						height: `${CANVAS_HEIGHT}px`,
+						transform: `translate(-50%, -50%) scale(${scale})`,
+					}}
+					onMouseMove={handleMouseMove}
+					onClick={handleCanvasClick}
+					tabIndex={0}
+					onKeyDown={handleKeyDown}
+				>
+					{/* Render text labels */}
+					{textLabels
+						.filter((label) => label.id !== currentTextId)
+						.map((label) => (
+							<div
+								key={label.id}
+								className="text-label"
+								style={{
+									left: label.x,
+									top: label.y,
+									color: getColorForUser(label.userId),
+								}}
+							>
+								{label.text}
+							</div>
+						))}
+
+					{/* Render text being typed */}
+					{isTyping && (
+						<div
+							className="typing-container"
+							style={{
+								left: typingPosition.x,
+								top: typingPosition.y,
+							}}
+						>
+							<div
+								className="typing-text"
+								style={{
+									color: getColorForUser(userId),
+								}}
+							>
+								{textInput}
+								<span className="typing-cursor">|</span>
+							</div>
+							<div
+								className="enter-hint"
+								style={{
+									borderColor: getColorForUser(userId),
+									color: getColorForUser(userId),
+								}}
+							>
+								enter
+							</div>
+						</div>
+					)}
+
+					{/* Render cursors */}
+					{Object.entries(cursors).map(([id, cursor]) => {
+						const color = getColorForUser(cursor.userId);
+						const isOwnCursor = id === userId;
+						return (
+							<div
+								key={id}
+								className="cursor"
+								style={{
+									left: cursor.x,
+									top: cursor.y,
+								}}
+							>
+								<svg
+									width="20"
+									height="24"
+									viewBox="0 0 20 24"
+									fill="none"
+									xmlns="http://www.w3.org/2000/svg"
+									className="cursor-svg"
+								>
+									<path
+										d="M10 4 L4 18 L16 18 Z"
+										fill={color}
+										stroke="white"
+										strokeWidth="1.5"
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										transform="rotate(-45 10 12)"
+									/>
+								</svg>
+								<div
+									className="cursor-label"
+									style={{
+										backgroundColor: color,
+										borderColor: `${color}40`,
+									}}
+								>
+									{isOwnCursor ? "you" : cursor.userId}
+								</div>
+							</div>
+						);
+					})}
+
+					{!cursorRoom.connection && (
+						<div className="loading-overlay">Connecting to room...</div>
+					)}
+
+					{/* Hidden input to capture typing */}
+					{isTyping && (
+						<input
+							type="text"
+							className="hidden-input"
+							value={textInput}
+							onChange={(e) => handleTextChange(e.target.value)}
+							onBlur={() => {
+								if (!textInput.trim() && cursorRoom.connection && currentTextId) {
+									cursorRoom.connection.removeText(currentTextId);
+									setCurrentTextId(null);
+								}
+								setIsTyping(false);
+							}}
+							autoFocus
+						/>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/examples/cursors-vercel/frontend/main.tsx
+++ b/examples/cursors-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/cursors-vercel/index.html
+++ b/examples/cursors-vercel/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cursors Example</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #0a0a0a;
+            color: #e0e0e0;
+            overflow: hidden;
+            height: 100vh;
+        }
+        .app-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+        }
+        .controls {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            right: 20px;
+            z-index: 200;
+            background: rgba(26, 26, 26, 0.9);
+            backdrop-filter: blur(10px);
+            padding: 16px 20px;
+            border-radius: 8px;
+            border: 1px solid #2a2a2a;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-shrink: 0;
+        }
+        .control-group {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+        .control-group label {
+            font-weight: 500;
+            color: #a0a0a0;
+        }
+        .control-group input {
+            padding: 8px 12px;
+            border: 1px solid #333;
+            border-radius: 4px;
+            min-width: 200px;
+            background: #2a2a2a;
+            color: #e0e0e0;
+        }
+        .control-group input:focus {
+            outline: none;
+            border-color: #4a9eff;
+        }
+        .user-info {
+            font-size: 14px;
+            color: #808080;
+        }
+        .canvas-container {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            overflow: hidden;
+            background: #0a0a0a;
+        }
+        .canvas {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform-origin: center center;
+            background: #1a1a1a;
+            cursor: none;
+            overflow: hidden;
+        }
+        .cursor {
+            position: absolute;
+            pointer-events: none;
+            z-index: 100;
+        }
+        .cursor-svg {
+            filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+        }
+        .cursor-label {
+            position: absolute;
+            top: 20px;
+            left: 18px;
+            padding: 4px 8px;
+            border-radius: 8px;
+            color: white;
+            font-size: 12px;
+            white-space: nowrap;
+            border: 1px solid;
+        }
+        .text-label {
+            position: absolute;
+            font-size: 16px;
+            font-weight: 500;
+            pointer-events: none;
+            white-space: nowrap;
+            transform: translate(0, -50%);
+            text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+            line-height: 1;
+        }
+        .typing-container {
+            position: absolute;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            pointer-events: none;
+            transform: translate(0, -50%);
+        }
+        .typing-text {
+            font-size: 16px;
+            font-weight: 500;
+            white-space: nowrap;
+            text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+            line-height: 1;
+        }
+        .typing-cursor {
+            animation: blink 1s infinite;
+            margin-left: 2px;
+            display: inline-block;
+            position: relative;
+            top: -2px;
+        }
+        @keyframes blink {
+            0%, 50% { opacity: 1; }
+            51%, 100% { opacity: 0; }
+        }
+        .enter-hint {
+            font-size: 11px;
+            font-weight: 500;
+            white-space: nowrap;
+            padding: 2px 6px;
+            border: 1px solid;
+            border-radius: 4px;
+            background: rgba(0, 0, 0, 0.5);
+            opacity: 0.7;
+        }
+        .hidden-input {
+            position: absolute;
+            top: -9999px;
+            left: -9999px;
+            width: 1px;
+            height: 1px;
+            opacity: 0;
+            pointer-events: none;
+        }
+        .loading-overlay {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            font-size: 18px;
+            color: #808080;
+        }
+        .instructions {
+            background: #1a1a1a;
+            padding: 20px;
+            border-radius: 8px;
+            border: 1px solid #2a2a2a;
+            margin: 20px;
+        }
+        .instructions h4 {
+            margin-top: 0;
+            color: #4a9eff;
+        }
+        .instructions ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+        .instructions li {
+            margin-bottom: 8px;
+            color: #a0a0a0;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/cursors-vercel/package.json
+++ b/examples/cursors-vercel/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "example-cursors-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"react",
+			"typescript"
+		],
+		"tags": [
+			"real-time"
+		],
+		"priority": 300,
+		"frontendPort": 5173
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/cursors-vercel/src/actors.ts
+++ b/examples/cursors-vercel/src/actors.ts
@@ -1,0 +1,101 @@
+import { actor, setup } from "rivetkit";
+
+export interface CursorPosition {
+	userId: string;
+	x: number;
+	y: number;
+	timestamp: number;
+}
+
+export interface TextLabel {
+	id: string;
+	userId: string;
+	text: string;
+	x: number;
+	y: number;
+	timestamp: number;
+}
+
+export const cursorRoom = actor({
+	state: {
+		textLabels: [] as TextLabel[],
+	},
+
+	connState: {
+		cursor: null as CursorPosition | null,
+	},
+
+	actions: {
+		// Update cursor position
+		updateCursor: (c, userId: string, x: number, y: number) => {
+			const cursor: CursorPosition = {
+				userId,
+				x,
+				y,
+				timestamp: Date.now(),
+			};
+			c.conn.state.cursor = cursor;
+			c.broadcast("cursorMoved", cursor);
+			return cursor;
+		},
+
+		// Update text on the canvas (creates or updates)
+		updateText: (
+			c,
+			id: string,
+			userId: string,
+			text: string,
+			x: number,
+			y: number,
+		) => {
+			const textLabel: TextLabel = {
+				id,
+				userId,
+				text,
+				x,
+				y,
+				timestamp: Date.now(),
+			};
+
+			// Find and update existing text label or add new one
+			const existingIndex = c.state.textLabels.findIndex(
+				(label) => label.id === id,
+			);
+			if (existingIndex >= 0) {
+				c.state.textLabels[existingIndex] = textLabel;
+			} else {
+				c.state.textLabels.push(textLabel);
+			}
+
+			c.broadcast("textUpdated", textLabel);
+			return textLabel;
+		},
+
+		// Remove text from the canvas
+		removeText: (c, id: string) => {
+			c.state.textLabels = c.state.textLabels.filter(
+				(label) => label.id !== id,
+			);
+			c.broadcast("textRemoved", id);
+		},
+
+		// Get all room state (cursors and text labels)
+		getRoomState: (c) => {
+			const cursors: Record<string, CursorPosition> = {};
+			for (const conn of c.conns.values()) {
+				if (conn.state.cursor) {
+					cursors[conn.state.cursor.userId] = conn.state.cursor;
+				}
+			}
+			return {
+				cursors,
+				textLabels: c.state.textLabels,
+			};
+		},
+	},
+});
+
+// Register actors for use: https://rivet.dev/docs/setup
+export const registry = setup({
+	use: { cursorRoom },
+});

--- a/examples/cursors-vercel/src/server.ts
+++ b/examples/cursors-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/cursors-vercel/tsconfig.json
+++ b/examples/cursors-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/cursors-vercel/turbo.json
+++ b/examples/cursors-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/cursors-vercel/vercel.json
+++ b/examples/cursors-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/cursors-vercel/vite.config.ts
+++ b/examples/cursors-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/cursors-vercel/vitest.config.ts
+++ b/examples/cursors-vercel/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	server: {
+		port: 5173,
+	},
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/cursors/vercel.json
+++ b/examples/cursors/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/custom-serverless-vercel/.gitignore
+++ b/examples/custom-serverless-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/custom-serverless-vercel/README.md
+++ b/examples/custom-serverless-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [custom-serverless](../custom-serverless) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fcustom-serverless-vercel&project-name=custom-serverless-vercel)
+
+# Custom Serverless
+
+Example demonstrating custom serverless actor deployment with automatic engine configuration.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/custom-serverless
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Custom serverless deployment**: Configure and deploy actors to your own serverless infrastructure
+- **Automatic engine configuration**: RivetKit automatically manages actor engine settings
+- **Minimal setup**: Simple starter template for building custom deployments
+- **Type-safe actions**: Full TypeScript support for actor definitions
+
+## Implementation
+
+This example shows how to deploy Rivet Actors to custom serverless platforms:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/custom-serverless/src/backend/registry.ts)): Demonstrates actor configuration for custom serverless deployment
+
+## Resources
+
+Read more about [setup](/docs/setup), [actions](/docs/actors/actions), and [state](/docs/actors/state).
+
+## License
+
+MIT

--- a/examples/custom-serverless-vercel/api/index.ts
+++ b/examples/custom-serverless-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/custom-serverless-vercel/package.json
+++ b/examples/custom-serverless-vercel/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "custom-serverless-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"hono": "^4.0.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"tsup": "^8.0.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.7.3",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"typescript"
+		],
+		"tags": [
+			"starter"
+		],
+		"noFrontend": true
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/custom-serverless-vercel/src/actors.ts
+++ b/examples/custom-serverless-vercel/src/actors.ts
@@ -1,0 +1,23 @@
+import { actor, setup } from "rivetkit";
+
+const counter = actor({
+	state: {
+		count: 0,
+	},
+	actions: {
+		increment: (c, x: number) => {
+			c.state.count += x;
+			c.broadcast("newCount", c.state.count);
+			return c.state.count;
+		},
+		getCount: (c) => {
+			return c.state.count;
+		},
+	},
+});
+
+export const registry = setup({
+	use: { counter },
+});
+
+export type Registry = typeof registry;

--- a/examples/custom-serverless-vercel/src/server.ts
+++ b/examples/custom-serverless-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/custom-serverless-vercel/tests/counter.test.ts
+++ b/examples/custom-serverless-vercel/tests/counter.test.ts
@@ -1,0 +1,35 @@
+import { setupTest } from "rivetkit/test";
+import { expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+test("it should count", async (test) => {
+	const { client } = await setupTest(test, registry);
+	const counter = client.counter.getOrCreate().connect();
+
+	// Test initial count
+	expect(await counter.getCount()).toBe(0);
+
+	// Test event emission
+	let eventCount = -1;
+	counter.on("newCount", (count: number) => {
+		eventCount = count;
+	});
+
+	// Test increment
+	const incrementAmount = 5;
+	const result = await counter.increment(incrementAmount);
+	expect(result).toBe(incrementAmount);
+
+	// Verify event was emitted with correct count
+	expect(eventCount).toBe(incrementAmount);
+
+	// Test multiple increments
+	for (let i = 1; i <= 3; i++) {
+		const newCount = await counter.increment(incrementAmount);
+		expect(newCount).toBe(incrementAmount * (i + 1));
+		expect(eventCount).toBe(incrementAmount * (i + 1));
+	}
+
+	// Verify final count
+	expect(await counter.getCount()).toBe(incrementAmount * 4);
+});

--- a/examples/custom-serverless-vercel/tsconfig.json
+++ b/examples/custom-serverless-vercel/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext"
+		],
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*"
+	]
+}

--- a/examples/custom-serverless-vercel/tsup.config.ts
+++ b/examples/custom-serverless-vercel/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: {
+		server: "src/server.ts",
+	},
+	format: ["esm"],
+	outDir: "dist",
+	bundle: true,
+	splitting: false,
+	shims: true,
+});

--- a/examples/custom-serverless-vercel/turbo.json
+++ b/examples/custom-serverless-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/custom-serverless-vercel/vercel.json
+++ b/examples/custom-serverless-vercel/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/custom-serverless/vercel.json
+++ b/examples/custom-serverless/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/drizzle-vercel/.env.sample
+++ b/examples/drizzle-vercel/.env.sample
@@ -1,0 +1,1 @@
+DB_FILE_NAME=file:local.db

--- a/examples/drizzle-vercel/.gitignore
+++ b/examples/drizzle-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/drizzle-vercel/README.md
+++ b/examples/drizzle-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [drizzle](../drizzle) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fdrizzle-vercel&project-name=drizzle-vercel)
+
+# Drizzle Integration
+
+Demonstrates Drizzle ORM integration with Rivet Actors for type-safe database operations.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/drizzle
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Drizzle ORM integration**: Use Drizzle for type-safe database operations within actors
+- **Automatic migrations**: Database schema migrations managed automatically
+- **Type-safe queries**: Full TypeScript type safety from schema to queries
+- **Actor-scoped database**: Each actor can have its own isolated database instance
+
+## Implementation
+
+This example demonstrates database integration with Rivet Actors using Drizzle ORM:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/drizzle/src/backend/registry.ts)): Shows how to integrate Drizzle ORM for type-safe database operations within actors
+
+## Resources
+
+Read more about [database integration](/docs/actors/database), [actions](/docs/actors/actions), and [state](/docs/actors/state).
+
+## License
+
+MIT

--- a/examples/drizzle-vercel/api/index.ts
+++ b/examples/drizzle-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/drizzle-vercel/drizzle.config.ts
+++ b/examples/drizzle-vercel/drizzle.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "@rivetkit/db/drizzle";
+
+export default defineConfig({
+	out: "./drizzle",
+	schema: "./src/db/schema.ts",
+});

--- a/examples/drizzle-vercel/drizzle/0000_wonderful_iron_patriot.sql
+++ b/examples/drizzle-vercel/drizzle/0000_wonderful_iron_patriot.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `users_table` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`age` integer NOT NULL,
+	`email` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_table_email_unique` ON `users_table` (`email`);

--- a/examples/drizzle-vercel/drizzle/meta/0000_snapshot.json
+++ b/examples/drizzle-vercel/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,62 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "22f3d49c-97d5-46ca-b0f1-99950c3efec7",
+	"prevId": "00000000-0000-0000-0000-000000000000",
+	"tables": {
+		"users_table": {
+			"name": "users_table",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"age": {
+					"name": "age",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"users_table_email_unique": {
+					"name": "users_table_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/examples/drizzle-vercel/drizzle/meta/_journal.json
+++ b/examples/drizzle-vercel/drizzle/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "6",
+			"when": 1750711614205,
+			"tag": "0000_wonderful_iron_patriot",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "6",
+			"when": 1750716663518,
+			"tag": "0001_rich_susan_delgado",
+			"breakpoints": true
+		}
+	]
+}

--- a/examples/drizzle-vercel/drizzle/migrations.js
+++ b/examples/drizzle-vercel/drizzle/migrations.js
@@ -1,0 +1,9 @@
+import m0000 from "./0000_wonderful_iron_patriot.sql";
+import journal from "./meta/_journal.json";
+
+export default {
+	journal,
+	migrations: {
+		m0000,
+	},
+};

--- a/examples/drizzle-vercel/package.json
+++ b/examples/drizzle-vercel/package.json
@@ -1,0 +1,37 @@
+{
+	"name": "example-sqlite-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/db": "^2.0.38",
+		"drizzle-kit": "^0.31.2",
+		"drizzle-orm": "^0.44.2",
+		"hono": "^4.0.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"rivetkit": "^2.0.38",
+		"tsup": "^8.0.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2"
+	},
+	"template": {
+		"technologies": [
+			"drizzle",
+			"typescript"
+		],
+		"tags": [
+			"database"
+		],
+		"noFrontend": true
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/drizzle-vercel/src/actors.ts
+++ b/examples/drizzle-vercel/src/actors.ts
@@ -1,0 +1,22 @@
+// import { actor, setup } from "rivetkit";
+// import { db } from "@rivetkit/db/drizzle";
+// import * as schema from "./db/schema.ts";
+// import migrations from "../drizzle/migrations.js";
+
+// export const counter = actor({
+// 	db: db({ schema, migrations }),
+// 	state: {
+// 		count: 0,
+// 	},
+// 	actions: {
+// 		increment: (c, x: number) => {
+// 			// createState or state fix fix fix
+// 			c.db.c.state.count += x;
+// 			return c.state.count;
+// 		},
+// 	},
+// });
+
+// export const registry = setup({
+// 	use: { counter },
+// });

--- a/examples/drizzle-vercel/src/db/schema.ts
+++ b/examples/drizzle-vercel/src/db/schema.ts
@@ -1,0 +1,9 @@
+// import { int, sqliteTable, text } from "@rivetkit/db/drizzle";
+
+// export const usersTable = sqliteTable("users_table", {
+// 	id: int().primaryKey({ autoIncrement: true }),
+// 	name: text().notNull(),
+// 	age: int().notNull(),
+// 	email: text().notNull().unique(),
+// 	email2: text().notNull().unique(),
+// });

--- a/examples/drizzle-vercel/src/server.ts
+++ b/examples/drizzle-vercel/src/server.ts
@@ -1,0 +1,6 @@
+// import { Hono } from "hono";
+// import { registry } from "./actors.ts";
+
+// const app = new Hono();
+// app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+// export default app;

--- a/examples/drizzle-vercel/tsconfig.json
+++ b/examples/drizzle-vercel/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext"
+		],
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*"
+	]
+}

--- a/examples/drizzle-vercel/tsup.config.ts
+++ b/examples/drizzle-vercel/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: {
+		server: "src/server.ts",
+	},
+	format: ["esm"],
+	outDir: "dist",
+	bundle: true,
+	splitting: false,
+	shims: true,
+});

--- a/examples/drizzle-vercel/turbo.json
+++ b/examples/drizzle-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/drizzle-vercel/vercel.json
+++ b/examples/drizzle-vercel/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/drizzle/vercel.json
+++ b/examples/drizzle/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/elysia-vercel/.gitignore
+++ b/examples/elysia-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/elysia-vercel/README.md
+++ b/examples/elysia-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [elysia](../elysia) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Felysia-vercel&project-name=elysia-vercel)
+
+# Elysia Integration
+
+Example project demonstrating Elysia web framework integration.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/elysia
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Elysia web framework**: Use Elysia for HTTP routing and request handling with actors
+- **High-performance routing**: Built on Bun for fast request processing
+- **Type-safe endpoints**: Full TypeScript type safety across HTTP and actor layers
+- **Actor integration**: Call actor actions from Elysia route handlers
+
+## Implementation
+
+This example demonstrates integrating Elysia web framework with Rivet Actors:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/elysia/src/backend/registry.ts)): Shows how to use Elysia router with actors for HTTP endpoints
+
+## Resources
+
+Read more about [actions](/docs/actors/actions) and [setup](/docs/setup).
+
+## License
+
+MIT

--- a/examples/elysia-vercel/api/index.ts
+++ b/examples/elysia-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/elysia-vercel/package.json
+++ b/examples/elysia-vercel/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "example-elysia-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"elysia": "^1.4.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2"
+	},
+	"template": {
+		"technologies": [
+			"elysia",
+			"typescript"
+		],
+		"tags": [],
+		"noFrontend": true
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/elysia-vercel/src/actors.ts
+++ b/examples/elysia-vercel/src/actors.ts
@@ -1,0 +1,15 @@
+import { actor, setup } from "rivetkit";
+
+export const counter = actor({
+	state: { count: 0 },
+	actions: {
+		increment: (c, x: number) => {
+			c.state.count += x;
+			return c.state.count;
+		},
+	},
+});
+
+export const registry = setup({
+	use: { counter },
+});

--- a/examples/elysia-vercel/src/server.ts
+++ b/examples/elysia-vercel/src/server.ts
@@ -1,0 +1,15 @@
+import { Elysia } from "elysia";
+import { createClient } from "rivetkit/client";
+import { registry } from "./actors.ts";
+
+const client = createClient<typeof registry>();
+
+const app = new Elysia()
+	.all("/api/rivet/*", (c) => registry.handler(c.request))
+	.get("/increment/:name", async ({ params }) => {
+		const counter = client.counter.getOrCreate(params.name);
+		const newCount = await counter.increment(1);
+		return `New Count: ${newCount}`;
+	});
+
+export default app;

--- a/examples/elysia-vercel/tsconfig.json
+++ b/examples/elysia-vercel/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext"
+		],
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*"
+	]
+}

--- a/examples/elysia-vercel/turbo.json
+++ b/examples/elysia-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/elysia-vercel/vercel.json
+++ b/examples/elysia-vercel/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/elysia/vercel.json
+++ b/examples/elysia/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "elysia"
-}

--- a/examples/experimental-durable-streams-ai-agent-vercel/.gitignore
+++ b/examples/experimental-durable-streams-ai-agent-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/experimental-durable-streams-ai-agent-vercel/README.md
+++ b/examples/experimental-durable-streams-ai-agent-vercel/README.md
@@ -1,0 +1,57 @@
+> **Note:** This is the Vercel-optimized version of the [experimental-durable-streams-ai-agent](../experimental-durable-streams-ai-agent) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fexperimental-durable-streams-ai-agent-vercel&project-name=experimental-durable-streams-ai-agent-vercel)
+
+# AI Agent with Durable Streams (Experimental)
+
+Example project demonstrating how to build an AI agent that communicates through durable streams for reliable message delivery and persistence.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/experimental-durable-streams-ai-agent
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Durable message delivery**: Prompts and responses flow through durable streams, ensuring reliable delivery even if components restart
+- **Streaming AI responses**: AI responses stream in real-time through durable streams to the frontend
+- **Actor-based processing**: AI agent runs as a Rivet Actor with persistent state tracking processed prompts
+
+## Prerequisites
+
+- Anthropic API Key (set as `ANTHROPIC_API_KEY` environment variable)
+- (Optional) Durable Streams Test UI for inspecting streams and debugging message flow:
+  ```sh
+  git clone https://github.com/durable-streams/durable-streams.git
+  cd durable-streams/packages/test-ui
+  pnpm dev
+  ```
+
+## Implementation
+
+The architecture uses two durable streams per conversation:
+
+1. **Prompt Stream** (`/conversations/{id}/prompts`): Frontend writes user messages, actor consumes them
+2. **Response Stream** (`/conversations/{id}/responses`): Actor writes AI response chunks, frontend consumes them
+
+Key implementation details:
+
+- **AI Agent Actor** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/experimental-durable-streams-ai-agent/src/backend/registry.ts)): Defines the `aiAgent` actor that consumes prompts from durable streams and writes AI responses back
+- **Frontend** ([`src/frontend/App.tsx`](https://github.com/rivet-dev/rivet/tree/main/examples/experimental-durable-streams-ai-agent/src/frontend/App.tsx)): React chat UI that reads/writes to durable streams
+- **Streams Server** ([`src/streams-server/server.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/experimental-durable-streams-ai-agent/src/streams-server/server.ts)): In-memory durable streams server for development
+- **Message Types** ([`src/backend/types.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/experimental-durable-streams-ai-agent/src/backend/types.ts)): TypeScript types for prompt and response messages
+
+## Resources
+
+- [Durable Streams](https://github.com/durable-streams/durable-streams) - Reliable message delivery and persistence
+- [Architecture Slides](https://link.excalidraw.com/p/readonly/K9IN9fZ41gkLfPedMbZg) - Visual overview of the durable streams architecture
+
+## License
+
+MIT

--- a/examples/experimental-durable-streams-ai-agent-vercel/api/index.ts
+++ b/examples/experimental-durable-streams-ai-agent-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/experimental-durable-streams-ai-agent-vercel/frontend/App.css
+++ b/examples/experimental-durable-streams-ai-agent-vercel/frontend/App.css
@@ -1,0 +1,484 @@
+* {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+
+html, body, #root {
+	height: 100%;
+	background: #0a0a0a;
+}
+
+.app {
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', Roboto, sans-serif;
+	color: #fff;
+}
+
+/* Header */
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px 20px;
+	border-bottom: 1px solid #1c1c1e;
+	background: #0a0a0a;
+	flex-shrink: 0;
+}
+
+.header-left {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.logo {
+	width: 28px;
+	height: 28px;
+	background: #ff4f00;
+	border-radius: 6px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-weight: 700;
+	font-size: 12px;
+}
+
+.header h1 {
+	font-size: 14px;
+	font-weight: 600;
+	color: #fff;
+}
+
+.conversation-input {
+	background: #1c1c1e;
+	border: 1px solid #2c2c2e;
+	border-radius: 6px;
+	padding: 6px 10px;
+	font-size: 12px;
+	color: #fff;
+	font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, monospace;
+	width: 140px;
+	outline: none;
+	transition: border-color 0.15s;
+}
+
+.conversation-input:focus {
+	border-color: #ff4f00;
+}
+
+.conversation-input::placeholder {
+	color: #4a4a4c;
+}
+
+/* Main Layout */
+.main-layout {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	flex: 1;
+	overflow: hidden;
+}
+
+/* Chat Panel */
+.chat-panel {
+	display: flex;
+	flex-direction: column;
+	border-right: 1px solid #1c1c1e;
+	overflow: hidden;
+}
+
+.panel-header {
+	padding: 10px 16px;
+	border-bottom: 1px solid #1c1c1e;
+	background: #0f0f0f;
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.panel-title {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: #6e6e73;
+}
+
+.messages-container {
+	flex: 1;
+	overflow-y: auto;
+	padding: 16px;
+}
+
+.messages {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.empty-state {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	color: #6e6e73;
+	text-align: center;
+	padding: 24px;
+}
+
+.empty-state p {
+	font-size: 13px;
+	max-width: 280px;
+	line-height: 1.5;
+}
+
+.message {
+	display: flex;
+	gap: 10px;
+	max-width: 100%;
+}
+
+.message.user {
+	flex-direction: row-reverse;
+}
+
+.avatar {
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 11px;
+	font-weight: 600;
+	flex-shrink: 0;
+}
+
+.message.user .avatar {
+	background: #ff4f00;
+	color: #fff;
+}
+
+.message.assistant .avatar {
+	background: #2c2c2e;
+	color: #fff;
+}
+
+.message-content {
+	padding: 10px 14px;
+	border-radius: 12px;
+	max-width: 80%;
+	line-height: 1.4;
+	font-size: 13px;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+}
+
+.message.user .message-content {
+	background: #ff4f00;
+	color: #fff;
+	border-bottom-right-radius: 4px;
+}
+
+.message.assistant .message-content {
+	background: #1c1c1e;
+	color: #e5e5e7;
+	border-bottom-left-radius: 4px;
+}
+
+.cursor {
+	display: inline-block;
+	width: 2px;
+	height: 14px;
+	background: #ff4f00;
+	margin-left: 2px;
+	vertical-align: text-bottom;
+	animation: blink 0.8s ease-in-out infinite;
+}
+
+@keyframes blink {
+	0%, 50% { opacity: 1; }
+	51%, 100% { opacity: 0; }
+}
+
+/* Input */
+.input-container {
+	padding: 12px 16px;
+	background: #0a0a0a;
+	border-top: 1px solid #1c1c1e;
+	flex-shrink: 0;
+}
+
+.input-wrapper {
+	display: flex;
+	gap: 10px;
+	background: #1c1c1e;
+	border: 1px solid #2c2c2e;
+	border-radius: 12px;
+	padding: 10px 12px;
+	transition: border-color 0.15s;
+}
+
+.input-wrapper:focus-within {
+	border-color: #ff4f00;
+}
+
+.input-wrapper textarea {
+	flex: 1;
+	background: transparent;
+	border: none;
+	color: #fff;
+	font-size: 13px;
+	font-family: inherit;
+	resize: none;
+	outline: none;
+	line-height: 1.4;
+	max-height: 80px;
+}
+
+.input-wrapper textarea::placeholder {
+	color: #6e6e73;
+}
+
+.send-button {
+	align-self: flex-end;
+	width: 28px;
+	height: 28px;
+	background: #ff4f00;
+	border: none;
+	border-radius: 6px;
+	color: #fff;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: all 0.15s;
+	flex-shrink: 0;
+}
+
+.send-button:hover:not(:disabled) {
+	background: #ff6a00;
+}
+
+.send-button:disabled {
+	background: #3a3a3c;
+	cursor: not-allowed;
+}
+
+.send-button svg {
+	width: 14px;
+	height: 14px;
+}
+
+/* Right Panel */
+.right-panel {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+/* Diagram */
+.diagram-container {
+	padding: 16px;
+	border-bottom: 1px solid #1c1c1e;
+	background: #0a0a0a;
+	flex-shrink: 0;
+}
+
+.diagram-node-rect {
+	fill: #1c1c1e;
+	stroke: #3a3a3c;
+	stroke-width: 1;
+}
+
+.diagram-node-rect.stream {
+	fill: #0f0f0f;
+	stroke: #2c2c2e;
+	transition: stroke 0.15s, filter 0.15s;
+}
+
+.diagram-node-rect.stream.active {
+	stroke: #ff4f00;
+	filter: drop-shadow(0 0 8px rgba(255, 79, 0, 0.4));
+}
+
+.diagram-node-text {
+	fill: #fff;
+	font-size: 11px;
+	font-weight: 500;
+}
+
+.diagram-node-count {
+	fill: #6e6e73;
+	font-size: 10px;
+	transition: fill 0.15s;
+}
+
+.diagram-node-count.active {
+	fill: #ff4f00;
+}
+
+.arrow {
+	stroke: #3a3a3c;
+	fill: none;
+	stroke-width: 1.5;
+	transition: stroke 0.15s, filter 0.15s;
+}
+
+.arrow.active {
+	stroke: #ff4f00;
+	filter: drop-shadow(0 0 4px rgba(255, 79, 0, 0.5));
+}
+
+.arrow-head {
+	fill: #3a3a3c;
+	transition: fill 0.15s;
+}
+
+.arrow-head.active {
+	fill: #ff4f00;
+}
+
+/* Streams Panel */
+.streams-panel {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	flex: 1;
+	overflow: hidden;
+}
+
+.stream-section {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	border-right: 1px solid #1c1c1e;
+}
+
+.stream-section:last-child {
+	border-right: none;
+}
+
+.stream-header {
+	padding: 10px 12px;
+	border-bottom: 1px solid #1c1c1e;
+	background: #0f0f0f;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-shrink: 0;
+}
+
+.stream-header-left {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.stream-title {
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: #6e6e73;
+}
+
+.stream-badge {
+	background: #1c1c1e;
+	color: #8e8e93;
+	font-size: 9px;
+	padding: 2px 5px;
+	border-radius: 4px;
+	font-weight: 500;
+}
+
+.stream-link {
+	font-size: 10px;
+	color: #ff4f00;
+	text-decoration: none;
+	display: flex;
+	align-items: center;
+	gap: 3px;
+}
+
+.stream-link:hover {
+	text-decoration: underline;
+}
+
+.stream-link svg {
+	width: 9px;
+	height: 9px;
+}
+
+.stream-content {
+	flex: 1;
+	overflow-y: auto;
+	padding: 10px;
+	background: #0a0a0a;
+}
+
+.stream-empty {
+	color: #4a4a4c;
+	font-size: 11px;
+	text-align: center;
+	padding: 16px;
+	font-style: italic;
+}
+
+.stream-entry {
+	font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, monospace;
+	font-size: 10px;
+	line-height: 1.4;
+	padding: 6px 8px;
+	background: #1c1c1e;
+	border-radius: 4px;
+	margin-bottom: 6px;
+	color: #e5e5e7;
+	word-break: break-all;
+	white-space: pre-wrap;
+}
+
+.stream-entry:last-child {
+	margin-bottom: 0;
+}
+
+.stream-entry .key {
+	color: #ff9500;
+}
+
+.stream-entry .string {
+	color: #30d158;
+}
+
+.stream-entry .number {
+	color: #64d2ff;
+}
+
+.stream-entry .boolean {
+	color: #bf5af2;
+}
+
+/* Scrollbar */
+.messages-container::-webkit-scrollbar,
+.stream-content::-webkit-scrollbar {
+	width: 6px;
+}
+
+.messages-container::-webkit-scrollbar-track,
+.stream-content::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.messages-container::-webkit-scrollbar-thumb,
+.stream-content::-webkit-scrollbar-thumb {
+	background: #3a3a3c;
+	border-radius: 3px;
+}
+
+.messages-container::-webkit-scrollbar-thumb:hover,
+.stream-content::-webkit-scrollbar-thumb:hover {
+	background: #48484a;
+}

--- a/examples/experimental-durable-streams-ai-agent-vercel/frontend/App.tsx
+++ b/examples/experimental-durable-streams-ai-agent-vercel/frontend/App.tsx
@@ -1,0 +1,517 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useEffect, useState, useRef, useCallback } from "react";
+import { registry } from "../src/registry";
+import { type PromptMessage, type ResponseChunk } from "../src/shared/types";
+import { getStreams, getStreamPaths } from "../src/shared/streams";
+import "./App.css";
+
+const { useActor } = createRivetKit<typeof registry>(`${window.location.origin}/api/rivet`);
+
+interface Message {
+	id: string;
+	role: "user" | "assistant";
+	content: string;
+	isStreaming?: boolean;
+}
+
+export function App() {
+	const [conversationId, setConversationId] = useState("my-chat");
+	const [conversationInput, setConversationInput] = useState("my-chat");
+	const [messages, setMessages] = useState<Message[]>([]);
+	const [input, setInput] = useState("");
+	const [isLoading, setIsLoading] = useState(false);
+	const [rawPrompts, setRawPrompts] = useState<string[]>([]);
+	const [rawResponses, setRawResponses] = useState<string[]>([]);
+	const [promptArrowActive, setPromptArrowActive] = useState(false);
+	const [responseArrowActive, setResponseArrowActive] = useState(false);
+	const responseStreamRef = useRef<AbortController | null>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const promptsEndRef = useRef<HTMLDivElement>(null);
+	const responsesEndRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLTextAreaElement>(null);
+
+	const handleConversationChange = () => {
+		if (conversationInput.trim() && conversationInput !== conversationId) {
+			// Abort existing response stream
+			responseStreamRef.current?.abort();
+			// Reset state for new conversation
+			setConversationId(conversationInput.trim());
+			setMessages([]);
+			setRawPrompts([]);
+			setRawResponses([]);
+			setIsLoading(false);
+		}
+	};
+
+	// Connect to the AI agent actor for this conversation
+	const _aiAgent = useActor({
+		name: "aiAgent",
+		key: [conversationId],
+		createWithInput: { conversationId },
+		enabled: true,
+	});
+
+	// Auto-scroll to bottom when messages change
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [messages]);
+
+	useEffect(() => {
+		promptsEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [rawPrompts]);
+
+	useEffect(() => {
+		responsesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [rawResponses]);
+
+	// Set up stream listeners and load history
+	useEffect(() => {
+		const abortController = new AbortController();
+		responseStreamRef.current = abortController;
+
+		// Store prompts and responses with timestamps for proper ordering
+		const promptsMap = new Map<string, PromptMessage>();
+		const responsesMap = new Map<string, { content: string; isComplete: boolean; timestamp: number }>();
+
+		const rebuildMessages = () => {
+			const newMessages: Message[] = [];
+
+			// Sort prompts by timestamp
+			const sortedPrompts = Array.from(promptsMap.values()).sort((a, b) => a.timestamp - b.timestamp);
+
+			for (const prompt of sortedPrompts) {
+				// Add user message
+				newMessages.push({
+					id: `prompt-${prompt.id}`,
+					role: "user",
+					content: prompt.content,
+				});
+
+				// Add corresponding response if exists
+				const response = responsesMap.get(prompt.id);
+				if (response && response.content) {
+					newMessages.push({
+						id: `response-${prompt.id}`,
+						role: "assistant",
+						content: response.content,
+						isStreaming: !response.isComplete,
+					});
+				}
+			}
+
+			setMessages(newMessages);
+		};
+
+		const loadStreams = async () => {
+			const { promptStream, responseStream } = await getStreams(conversationId);
+
+			// Track if we're still loading history (don't flash arrows during history load)
+			let isLoadingHistory = true;
+
+			// Load prompt history and continue listening
+			const consumePrompts = async () => {
+				try {
+					for await (const data of promptStream.json<PromptMessage | PromptMessage[]>({ live: "long-poll" })) {
+						if (abortController.signal.aborted) break;
+
+						const prompts = Array.isArray(data) ? data : [data];
+
+						for (const prompt of prompts) {
+							if (!prompt.id) continue;
+
+							// Add raw prompt to debug panel
+							setRawPrompts((prev) => {
+								if (prev.some(p => p.includes(prompt.id))) return prev;
+								return [...prev, JSON.stringify(prompt)];
+							});
+
+							// Store prompt and rebuild messages
+							if (!promptsMap.has(prompt.id)) {
+								promptsMap.set(prompt.id, prompt);
+								rebuildMessages();
+							}
+
+							if (!isLoadingHistory) {
+								setPromptArrowActive(true);
+								setTimeout(() => setPromptArrowActive(false), 300);
+							}
+						}
+					}
+				} catch (error) {
+					if (!abortController.signal.aborted) {
+						console.error("Error consuming prompts:", error);
+					}
+				}
+			};
+
+			// Load response history and continue listening
+			const consumeResponses = async () => {
+				try {
+					for await (const data of responseStream.json<ResponseChunk | ResponseChunk[]>({ live: "long-poll" })) {
+						if (abortController.signal.aborted) break;
+
+						const responses = Array.isArray(data) ? data : [data];
+
+						for (const response of responses) {
+							if (!response.promptId) continue;
+
+							// Add raw response to debug panel
+							setRawResponses((prev) => [...prev, JSON.stringify(response)]);
+
+							// Update response map
+							const existing = responsesMap.get(response.promptId);
+							if (response.isComplete) {
+								if (existing) {
+									existing.isComplete = true;
+								} else {
+									responsesMap.set(response.promptId, {
+										content: response.content,
+										isComplete: true,
+										timestamp: response.timestamp,
+									});
+								}
+							} else {
+								if (existing) {
+									existing.content += response.content;
+								} else {
+									responsesMap.set(response.promptId, {
+										content: response.content,
+										isComplete: false,
+										timestamp: response.timestamp,
+									});
+								}
+							}
+
+							rebuildMessages();
+
+							if (!isLoadingHistory) {
+								setResponseArrowActive(true);
+								setTimeout(() => setResponseArrowActive(false), 300);
+							}
+
+							if (response.isComplete) {
+								setIsLoading(false);
+							}
+						}
+					}
+				} catch (error) {
+					if (!abortController.signal.aborted) {
+						console.error("Error consuming responses:", error);
+					}
+				}
+			};
+
+			// Start consuming both streams
+			consumePrompts();
+			consumeResponses();
+
+			// After a short delay, consider history loaded
+			setTimeout(() => {
+				isLoadingHistory = false;
+			}, 500);
+		};
+
+		loadStreams();
+
+		return () => {
+			abortController.abort();
+		};
+	}, [conversationId]);
+
+	const handleSendMessage = useCallback(async () => {
+		if (!input.trim() || isLoading) return;
+
+		const promptId = crypto.randomUUID();
+		const prompt: PromptMessage = {
+			id: promptId,
+			content: input.trim(),
+			timestamp: Date.now(),
+		};
+
+		setInput("");
+		setIsLoading(true);
+
+		const { promptStream } = await getStreams(conversationId);
+
+		// Write to stream - the stream listener will pick it up and update UI
+		await promptStream.append(JSON.stringify(prompt) + "\n", { contentType: "application/json" });
+	}, [input, isLoading, conversationId]);
+
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			handleSendMessage();
+		}
+	};
+
+	const { promptStreamPath, responseStreamPath } = getStreamPaths(conversationId);
+
+	return (
+		<div className="app">
+				<header className="header">
+					<div className="header-left">
+						<div className="logo">DS</div>
+						<h1>Durable Streams AI Agent</h1>
+					</div>
+				</header>
+
+				<div className="main-layout">
+					<div className="chat-panel">
+						<div className="panel-header">
+							<span className="panel-title">Chat:</span>
+							<input
+								type="text"
+								className="conversation-input"
+								value={conversationInput}
+								onChange={(e) => setConversationInput(e.target.value)}
+								onKeyDown={(e) => e.key === "Enter" && handleConversationChange()}
+								onBlur={handleConversationChange}
+								placeholder="chat-name"
+							/>
+						</div>
+						<div className="messages-container">
+							{messages.length === 0 ? (
+								<div className="empty-state">
+									<p>Send a message to see how it flows through durable streams to the AI agent.</p>
+								</div>
+							) : (
+								<div className="messages">
+									{messages.map((msg) => (
+										<div key={msg.id} className={`message ${msg.role}`}>
+											<div className="avatar">
+												{msg.role === "user" ? "U" : "AI"}
+											</div>
+											<div className="message-content">
+												{msg.content}
+												{msg.isStreaming && <span className="cursor" />}
+											</div>
+										</div>
+									))}
+									<div ref={messagesEndRef} />
+								</div>
+							)}
+						</div>
+						<div className="input-container">
+							<div className="input-wrapper">
+								<textarea
+									ref={inputRef}
+									value={input}
+									onChange={(e) => setInput(e.target.value)}
+									onKeyDown={handleKeyDown}
+									placeholder="Send a message..."
+									disabled={isLoading}
+									rows={1}
+								/>
+								<button
+									className="send-button"
+									onClick={handleSendMessage}
+									disabled={isLoading || !input.trim()}
+								>
+									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+										<line x1="22" y1="2" x2="11" y2="13" />
+										<polygon points="22 2 15 22 11 13 2 9 22 2" />
+									</svg>
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<div className="right-panel">
+						<div className="diagram-container">
+							<svg width="100%" height="280" viewBox="0 0 400 280">
+								{/* Define arrow markers */}
+								<defs>
+									<marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+										<polygon points="0 0, 10 3.5, 0 7" className={`arrow-head`} />
+									</marker>
+									<marker id="arrowhead-active" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+										<polygon points="0 0, 10 3.5, 0 7" className={`arrow-head active`} />
+									</marker>
+								</defs>
+
+								{/* Prompts Stream - top center */}
+								<rect x="150" y="20" width="100" height="50" rx="12" className={`diagram-node-rect stream ${promptArrowActive ? 'active' : ''}`} />
+								<text x="200" y="40" textAnchor="middle" className="diagram-node-text">Prompts</text>
+								<text x="200" y="55" textAnchor="middle" className="diagram-node-text">Stream</text>
+								<text x="200" y="80" textAnchor="middle" className={`diagram-node-count ${promptArrowActive ? 'active' : ''}`}>{rawPrompts.length} entries</text>
+
+								{/* Browser - left middle */}
+								<rect x="20" y="115" width="90" height="50" rx="12" className="diagram-node-rect" />
+								<text x="65" y="145" textAnchor="middle" className="diagram-node-text">Browser</text>
+
+								{/* Agent Actor - right middle */}
+								<rect x="290" y="115" width="90" height="50" rx="12" className="diagram-node-rect" />
+								<text x="335" y="135" textAnchor="middle" className="diagram-node-text">Agent</text>
+								<text x="335" y="150" textAnchor="middle" className="diagram-node-text">Actor</text>
+
+								{/* Response Stream - bottom center */}
+								<rect x="150" y="210" width="100" height="50" rx="12" className={`diagram-node-rect stream ${responseArrowActive ? 'active' : ''}`} />
+								<text x="200" y="230" textAnchor="middle" className="diagram-node-text">Response</text>
+								<text x="200" y="245" textAnchor="middle" className="diagram-node-text">Stream</text>
+								<text x="200" y="200" textAnchor="middle" className={`diagram-node-count ${responseArrowActive ? 'active' : ''}`}>{rawResponses.length} entries</text>
+
+								{/* Browser -> Prompts Stream */}
+								<path
+									d="M 95 115 Q 120 80 150 55"
+									className={`arrow ${promptArrowActive ? 'active' : ''}`}
+									markerEnd={promptArrowActive ? "url(#arrowhead-active)" : "url(#arrowhead)"}
+								/>
+								<text x="100" y="75" fontSize="10" fill={promptArrowActive ? '#ff4f00' : '#6e6e73'}>Prompt</text>
+
+								{/* Prompts Stream -> Agent */}
+								<path
+									d="M 250 55 Q 280 80 305 115"
+									className={`arrow ${promptArrowActive ? 'active' : ''}`}
+									markerEnd={promptArrowActive ? "url(#arrowhead-active)" : "url(#arrowhead)"}
+								/>
+								<text x="270" y="75" fontSize="10" fill={promptArrowActive ? '#ff4f00' : '#6e6e73'}>Prompt</text>
+
+								{/* Agent -> Response Stream */}
+								<path
+									d="M 305 165 Q 280 200 250 225"
+									className={`arrow ${responseArrowActive ? 'active' : ''}`}
+									markerEnd={responseArrowActive ? "url(#arrowhead-active)" : "url(#arrowhead)"}
+								/>
+								<text x="270" y="205" fontSize="10" fill={responseArrowActive ? '#ff4f00' : '#6e6e73'}>Tokens</text>
+
+								{/* Response Stream -> Browser */}
+								<path
+									d="M 150 225 Q 120 200 95 165"
+									className={`arrow ${responseArrowActive ? 'active' : ''}`}
+									markerEnd={responseArrowActive ? "url(#arrowhead-active)" : "url(#arrowhead)"}
+								/>
+								<text x="100" y="205" fontSize="10" fill={responseArrowActive ? '#ff4f00' : '#6e6e73'}>Tokens</text>
+							</svg>
+						</div>
+
+						<div className="streams-panel">
+							<div className="stream-section">
+								<div className="stream-header">
+									<div className="stream-header-left">
+										<span className="stream-title">Prompts</span>
+										<span className="stream-badge">{rawPrompts.length}</span>
+									</div>
+									<a
+										className="stream-link"
+										href={`http://localhost:3000/stream/${encodeURIComponent(promptStreamPath)}`}
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										Open
+										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+											<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+											<polyline points="15 3 21 3 21 9" />
+											<line x1="10" y1="14" x2="21" y2="3" />
+										</svg>
+									</a>
+								</div>
+								<div className="stream-content">
+									{rawPrompts.length === 0 ? (
+										<div className="stream-empty">No prompts yet</div>
+									) : (
+										<>
+											{rawPrompts.map((entry, i) => (
+												<div key={i} className="stream-entry">
+													{formatJson(entry)}
+												</div>
+											))}
+											<div ref={promptsEndRef} />
+										</>
+									)}
+								</div>
+							</div>
+
+							<div className="stream-section">
+								<div className="stream-header">
+									<div className="stream-header-left">
+										<span className="stream-title">Responses</span>
+										<span className="stream-badge">{rawResponses.length}</span>
+									</div>
+									<a
+										className="stream-link"
+										href={`http://localhost:3000/stream/${encodeURIComponent(responseStreamPath)}`}
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										Open
+										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+											<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+											<polyline points="15 3 21 3 21 9" />
+											<line x1="10" y1="14" x2="21" y2="3" />
+										</svg>
+									</a>
+								</div>
+								<div className="stream-content">
+									{rawResponses.length === 0 ? (
+										<div className="stream-empty">No responses yet</div>
+									) : (
+										<>
+											{rawResponses.map((entry, i) => (
+												<div key={i} className="stream-entry">
+													{formatJson(entry)}
+												</div>
+											))}
+											<div ref={responsesEndRef} />
+										</>
+									)}
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+	);
+}
+
+function formatJson(jsonStr: string): React.ReactNode {
+	try {
+		const obj = JSON.parse(jsonStr);
+		return formatValue(obj);
+	} catch {
+		return jsonStr;
+	}
+}
+
+function formatValue(value: unknown, depth = 0): React.ReactNode {
+	if (value === null) return <span className="boolean">null</span>;
+	if (typeof value === "boolean") return <span className="boolean">{String(value)}</span>;
+	if (typeof value === "number") return <span className="number">{value}</span>;
+	if (typeof value === "string") return <span className="string">"{value}"</span>;
+
+	if (Array.isArray(value)) {
+		if (value.length === 0) return "[]";
+		return (
+			<>
+				{"[\n"}
+				{value.map((item, i) => (
+					<span key={i}>
+						{"  ".repeat(depth + 1)}
+						{formatValue(item, depth + 1)}
+						{i < value.length - 1 ? ",\n" : "\n"}
+					</span>
+				))}
+				{"  ".repeat(depth)}]
+			</>
+		);
+	}
+
+	if (typeof value === "object") {
+		const entries = Object.entries(value);
+		if (entries.length === 0) return "{}";
+		return (
+			<>
+				{"{\n"}
+				{entries.map(([key, val], i) => (
+					<span key={key}>
+						{"  ".repeat(depth + 1)}
+						<span className="key">"{key}"</span>: {formatValue(val, depth + 1)}
+						{i < entries.length - 1 ? ",\n" : "\n"}
+					</span>
+				))}
+				{"  ".repeat(depth)}{"}"}
+			</>
+		);
+	}
+
+	return String(value);
+}

--- a/examples/experimental-durable-streams-ai-agent-vercel/frontend/main.tsx
+++ b/examples/experimental-durable-streams-ai-agent-vercel/frontend/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")!).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/experimental-durable-streams-ai-agent-vercel/index.html
+++ b/examples/experimental-durable-streams-ai-agent-vercel/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>AI Agent with Durable Streams</title>
+		<style>
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				padding: 0;
+				background: rgb(10, 10, 10);
+			}
+		</style>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/frontend/main.tsx"></script>
+	</body>
+</html>

--- a/examples/experimental-durable-streams-ai-agent-vercel/package.json
+++ b/examples/experimental-durable-streams-ai-agent-vercel/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "example-experimental-durable-streams-ai-agent-vercel",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@ai-sdk/anthropic": "^1.0.0",
+		"@durable-streams/client": "https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/client@0323b8b",
+		"@durable-streams/server": "https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/server@0323b8b",
+		"@durable-streams/writer": "https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/writer@0323b8b",
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"ai": "^4.0.38",
+		"hono": "^4.11.3",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38",
+		"zod": "^4.1.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"typescript",
+			"durable-streams"
+		],
+		"tags": [
+			"ai",
+			"real-time",
+			"experimental"
+		],
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/experimental-durable-streams-ai-agent-vercel/src/actors.ts
+++ b/examples/experimental-durable-streams-ai-agent-vercel/src/actors.ts
@@ -1,0 +1,222 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import type { DurableStream } from "@durable-streams/client";
+import { streamText } from "ai";
+import { type ActorContextOf, actor, setup } from "rivetkit";
+import { getStreams } from "./shared/streams.ts";
+import type { PromptMessage, ResponseChunk } from "./shared/types.ts";
+
+interface State {
+	conversationId: string;
+	promptStreamOffset: string | undefined;
+}
+
+export const aiAgent = actor({
+	createState: (_c, input: { conversationId: string }): State => ({
+		conversationId: input.conversationId,
+		// Offset tracking for durable stream consumption
+		// undefined means start from the beginning of the stream
+		promptStreamOffset: undefined as string | undefined,
+	}),
+
+	onWake: (c) => {
+		consumeStream(c);
+	},
+
+	actions: {
+		getConversationId: (c) => c.state.conversationId,
+		getPromptStreamOffset: (c) => c.state.promptStreamOffset,
+	},
+
+	options: {
+		// IMPORTANT: Keep actor alive to continuously consume prompts
+		//
+		// Future versions will enable sleep/wake for durable streams
+		noSleep: true,
+	},
+});
+
+async function consumeStream(c: ActorContextOf<typeof aiAgent>) {
+	c.log.info({
+		msg: "consumeStream started",
+		conversationId: c.state.conversationId,
+		offset: c.state.promptStreamOffset,
+	});
+
+	const { promptStream, responseStream } = await getStreams(
+		c.state.conversationId,
+	);
+
+	c.log.info({ msg: "streams obtained" });
+
+	const decoder = new TextDecoder();
+
+	try {
+		// NOTE: promptStream.json does not provide offsets, have to manually
+		// parse
+		c.log.info({
+			msg: "starting read loop",
+			offset: c.state.promptStreamOffset,
+		});
+		const streamIter = promptStream.read({
+			offset: c.state.promptStreamOffset,
+			live: "long-poll",
+			signal: c.abortSignal,
+		});
+		for await (const chunk of streamIter) {
+			c.log.info({
+				msg: "received chunk",
+				dataLength: chunk.data.length,
+				offset: chunk.offset,
+			});
+
+			if (c.abortSignal.aborted) break;
+
+			c.state.promptStreamOffset = chunk.offset;
+
+			if (chunk.data.length === 0) continue;
+
+			const text = decoder.decode(chunk.data);
+			const lines = text.split("\n").filter((l) => l.trim());
+
+			c.log.info({ msg: "parsed lines", lineCount: lines.length, text });
+
+			for (const line of lines) {
+				let prompts: PromptMessage[];
+				try {
+					prompts = JSON.parse(line);
+				} catch (e) {
+					c.log.error({
+						msg: "failed to parse json",
+						line,
+						error: e,
+					});
+					continue;
+				}
+
+				if (!Array.isArray(prompts)) {
+					throw new Error(
+						`Expected array of prompts, got: ${typeof prompts}`,
+					);
+				}
+
+				for (const prompt of prompts) {
+					c.log.info({
+						msg: "parsed prompt",
+						promptId: prompt.id,
+						content: prompt.content,
+					});
+
+					// Skip if prompt is invalid
+					if (!prompt.id) {
+						c.log.warn({ msg: "skipping prompt with no id" });
+						continue;
+					}
+
+					c.log.info({
+						msg: "processing prompt",
+						promptId: prompt.id,
+					});
+					await processPrompt(c, prompt, responseStream);
+					c.log.info({
+						msg: "finished processing prompt",
+						promptId: prompt.id,
+					});
+				}
+			}
+		}
+		c.log.info({ msg: "read loop ended" });
+	} catch (error) {
+		c.log.error({
+			msg: "error in consumeStream",
+			error,
+			aborted: c.abortSignal.aborted,
+		});
+		if (!c.abortSignal.aborted) {
+			c.log.error({ msg: "error consuming prompts", error });
+		}
+	}
+}
+
+async function processPrompt(
+	c: ActorContextOf<typeof aiAgent>,
+	prompt: PromptMessage,
+	responseStream: DurableStream,
+) {
+	c.log.info({ msg: "processPrompt starting", promptId: prompt.id });
+
+	let streamError: Error | null = null;
+
+	c.log.info({ msg: "calling streamText", promptContent: prompt.content });
+	const result = streamText({
+		model: anthropic("claude-sonnet-4-20250514"),
+		prompt: prompt.content,
+		onError: (error) => {
+			c.log.error({ msg: "streamText onError", error: error.error });
+			streamError =
+				error.error instanceof Error
+					? error.error
+					: new Error(String(error.error));
+		},
+	});
+
+	let fullResponse = "";
+	let chunkCount = 0;
+
+	c.log.info({ msg: "starting to consume textStream" });
+	for await (const textPart of result.textStream) {
+		chunkCount++;
+		fullResponse += textPart;
+
+		const responseChunk: ResponseChunk = {
+			promptId: prompt.id,
+			content: textPart,
+			isComplete: false,
+			timestamp: Date.now(),
+		};
+
+		await responseStream.append(JSON.stringify(responseChunk) + "\n", {
+			contentType: "application/json",
+		});
+	}
+
+	c.log.info({
+		msg: "finished consuming textStream",
+		chunkCount,
+		fullResponseLength: fullResponse.length,
+	});
+
+	if (streamError !== null) {
+		const errorChunk: ResponseChunk = {
+			promptId: prompt.id,
+			content: `Error: ${(streamError as Error).message}`,
+			isComplete: true,
+			timestamp: Date.now(),
+		};
+
+		await responseStream.append(JSON.stringify(errorChunk) + "\n", {
+			contentType: "application/json",
+		});
+		c.broadcast("responseError", {
+			promptId: prompt.id,
+			error: errorChunk.content,
+		});
+		return;
+	}
+
+	// Send completion marker
+	const completeChunk: ResponseChunk = {
+		promptId: prompt.id,
+		content: "",
+		isComplete: true,
+		timestamp: Date.now(),
+	};
+
+	await responseStream.append(JSON.stringify(completeChunk) + "\n", {
+		contentType: "application/json",
+	});
+	c.broadcast("responseComplete", { promptId: prompt.id, fullResponse });
+}
+
+export const registry = setup({
+	use: { aiAgent },
+});

--- a/examples/experimental-durable-streams-ai-agent-vercel/src/server.ts
+++ b/examples/experimental-durable-streams-ai-agent-vercel/src/server.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+if (!process.env.ANTHROPIC_API_KEY) {
+	throw new Error("ANTHROPIC_API_KEY environment variable is required");
+}
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/experimental-durable-streams-ai-agent-vercel/src/shared/streams.ts
+++ b/examples/experimental-durable-streams-ai-agent-vercel/src/shared/streams.ts
@@ -1,0 +1,48 @@
+import { DurableStream } from "@durable-streams/client";
+
+export const STREAMS_SERVER_URL = "http://127.0.0.1:8787/v1/stream";
+
+export interface ConversationStreams {
+	promptStream: DurableStream;
+	responseStream: DurableStream;
+}
+
+export async function getStreams(
+	conversationId: string,
+): Promise<ConversationStreams> {
+	const promptStreamUrl = `${STREAMS_SERVER_URL}/conversations/${conversationId}/prompts`;
+	const responseStreamUrl = `${STREAMS_SERVER_URL}/conversations/${conversationId}/responses`;
+
+	let promptStream: DurableStream;
+	let responseStream: DurableStream;
+
+	try {
+		promptStream = await DurableStream.create({
+			url: promptStreamUrl,
+			contentType: "application/json",
+		});
+	} catch {
+		promptStream = new DurableStream({ url: promptStreamUrl });
+	}
+
+	try {
+		responseStream = await DurableStream.create({
+			url: responseStreamUrl,
+			contentType: "application/json",
+		});
+	} catch {
+		responseStream = new DurableStream({ url: responseStreamUrl });
+	}
+
+	return { promptStream, responseStream };
+}
+
+/**
+ * Get the stream paths for a conversation (useful for UI display)
+ */
+export function getStreamPaths(conversationId: string) {
+	return {
+		promptStreamPath: `conversations/${conversationId}/prompts`,
+		responseStreamPath: `conversations/${conversationId}/responses`,
+	};
+}

--- a/examples/experimental-durable-streams-ai-agent-vercel/src/shared/types.ts
+++ b/examples/experimental-durable-streams-ai-agent-vercel/src/shared/types.ts
@@ -1,0 +1,12 @@
+export interface PromptMessage {
+	id: string;
+	content: string;
+	timestamp: number;
+}
+
+export interface ResponseChunk {
+	promptId: string;
+	content: string;
+	isComplete: boolean;
+	timestamp: number;
+}

--- a/examples/experimental-durable-streams-ai-agent-vercel/src/streams-server/server.ts
+++ b/examples/experimental-durable-streams-ai-agent-vercel/src/streams-server/server.ts
@@ -1,0 +1,13 @@
+import { DurableStreamTestServer } from "@durable-streams/server";
+
+const PORT = 8787;
+
+const server = new DurableStreamTestServer({
+	port: PORT,
+	host: "127.0.0.1",
+	longPollTimeout: 30_000,
+});
+
+const url = await server.start();
+
+console.log(`Durable streams server running at ${url}`);

--- a/examples/experimental-durable-streams-ai-agent-vercel/tests/durable-streams.test.ts
+++ b/examples/experimental-durable-streams-ai-agent-vercel/tests/durable-streams.test.ts
@@ -1,0 +1,85 @@
+// import { DurableStreamTestServer } from "@durable-streams/server";
+// import { setupTest } from "rivetkit/test";
+// import { afterAll, beforeAll, expect, test, vi } from "vitest";
+//
+// // Start a real durable streams test server
+// let streamsServer: DurableStreamTestServer;
+//
+// beforeAll(async () => {
+// 	streamsServer = new DurableStreamTestServer({
+// 		port: 0, // Use random available port
+// 		host: "127.0.0.1",
+// 		longPollTimeout: 5_000,
+// 	});
+// 	const url = await streamsServer.start();
+// 	// Set the URL for the registry to use
+// 	process.env.STREAMS_SERVER_URL = url;
+// });
+//
+// afterAll(async () => {
+// 	// Close all connections immediately - the actors have long-poll connections that would otherwise hang
+// 	// @ts-expect-error - closeAllConnections() available in Node 18.2+
+// 	streamsServer["server"]?.closeAllConnections?.();
+// 	await streamsServer.stop();
+// }, 5_000);
+//
+// // Only mock Anthropic AI SDK if the API key is not set
+// if (!process.env.ANTHROPIC_API_KEY) {
+// 	vi.mock("@ai-sdk/anthropic", () => ({
+// 		anthropic: () => "mock-anthropic-model",
+// 	}));
+//
+// 	vi.mock("ai", () => ({
+// 		streamText: vi.fn().mockImplementation(({ prompt }) => ({
+// 			textStream: (async function* () {
+// 				yield `Response to: ${prompt}`;
+// 			})(),
+// 		})),
+// 	}));
+// }
+//
+// // Import registry after environment is set up
+// const { registry } = await import("../src/actors.ts");
+//
+// test("AI Agent initializes with conversation ID", async (ctx) => {
+// 	const { client } = await setupTest(ctx, registry);
+//
+// 	const conversationId = "test-conversation-123";
+// 	const agent = client.aiAgent.getOrCreate([conversationId], {
+// 		createWithInput: { conversationId },
+// 	});
+//
+// 	const result = await agent.getConversationId();
+// 	expect(result).toBe(conversationId);
+// });
+//
+// test("AI Agent starts with empty processed prompts", async (ctx) => {
+// 	const { client } = await setupTest(ctx, registry);
+//
+// 	const conversationId = "test-empty-prompts";
+// 	const agent = client.aiAgent.getOrCreate([conversationId], {
+// 		createWithInput: { conversationId },
+// 	});
+//
+// 	const processed = await agent.getProcessedPrompts();
+// 	expect(processed).toEqual([]);
+// });
+//
+// test("AI Agent maintains separate state per conversation", async (ctx) => {
+// 	const { client } = await setupTest(ctx, registry);
+//
+// 	const agent1 = client.aiAgent.getOrCreate(["conversation-1"], {
+// 		createWithInput: { conversationId: "conversation-1" },
+// 	});
+//
+// 	const agent2 = client.aiAgent.getOrCreate(["conversation-2"], {
+// 		createWithInput: { conversationId: "conversation-2" },
+// 	});
+//
+// 	const id1 = await agent1.getConversationId();
+// 	const id2 = await agent2.getConversationId();
+//
+// 	expect(id1).toBe("conversation-1");
+// 	expect(id2).toBe("conversation-2");
+// 	expect(id1).not.toBe(id2);
+// });

--- a/examples/experimental-durable-streams-ai-agent-vercel/tsconfig.json
+++ b/examples/experimental-durable-streams-ai-agent-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/experimental-durable-streams-ai-agent-vercel/turbo.json
+++ b/examples/experimental-durable-streams-ai-agent-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/experimental-durable-streams-ai-agent-vercel/vercel.json
+++ b/examples/experimental-durable-streams-ai-agent-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/experimental-durable-streams-ai-agent-vercel/vite.config.ts
+++ b/examples/experimental-durable-streams-ai-agent-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/experimental-durable-streams-ai-agent-vercel/vitest.config.ts
+++ b/examples/experimental-durable-streams-ai-agent-vercel/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+		testTimeout: 30000,
+	},
+});

--- a/examples/experimental-durable-streams-ai-agent/vercel.json
+++ b/examples/experimental-durable-streams-ai-agent/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/hello-world-vercel/.gitignore
+++ b/examples/hello-world-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/hello-world-vercel/README.md
+++ b/examples/hello-world-vercel/README.md
@@ -1,0 +1,41 @@
+> **Note:** This is the Vercel-optimized version of the [hello-world](../hello-world) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fhello-world-vercel&project-name=hello-world-vercel)
+
+# Hello World
+
+A minimal example demonstrating RivetKit with a real-time counter shared across multiple clients.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/hello-world
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Actor state management**: Persistent counter state managed by Rivet Actors
+- **Real-time updates**: Counter values synchronized across all connected clients via events
+- **Multiple actor instances**: Each counter ID creates a separate actor instance
+- **React integration**: Uses `@rivetkit/react` for seamless React hooks integration
+
+## Implementation
+
+This example demonstrates the core RivetKit concepts with a simple counter:
+
+- **Actor Definition** ([`src/actors.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/hello-world/src/actors.ts)): Counter actor with persistent state and broadcast events
+- **Server Setup** ([`src/server.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/hello-world/src/server.ts)): Minimal Hono server with RivetKit handler
+- **React Frontend** ([`frontend/App.tsx`](https://github.com/rivet-dev/rivet/tree/main/examples/hello-world/frontend/App.tsx)): Counter component using `useActor` hook and event subscriptions
+
+## Resources
+
+Read more about [actions](/docs/actors/actions), [state](/docs/actors/state), and [events](/docs/actors/events).
+
+## License
+
+MIT

--- a/examples/hello-world-vercel/api/index.ts
+++ b/examples/hello-world-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/hello-world-vercel/frontend/App.tsx
+++ b/examples/hello-world-vercel/frontend/App.tsx
@@ -1,0 +1,93 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useEffect, useState } from "react";
+import type { registry } from "../src/actors.ts";
+
+const { useActor } = createRivetKit<typeof registry>(`${location.origin}/api/rivet`);
+
+export function App() {
+	const [counterId, setCounterId] = useState("default");
+	const [count, setCount] = useState<number>(0);
+
+	const counter = useActor({
+		name: "counter",
+		key: [counterId],
+	});
+
+	useEffect(() => {
+		if (counter.connection) {
+			counter.connection.getCount().then(setCount);
+		}
+	}, [counter.connection]);
+
+	counter.useEvent("newCount", (newCount: number) => {
+		setCount(newCount);
+	});
+
+	const increment = async (amount: number) => {
+		if (counter.connection) {
+			await counter.connection.increment(amount);
+		}
+	};
+
+	return (
+		<div className="counter-app">
+			<div className="counter-container">
+				<div className="counter-header">
+					<h1>Hello World</h1>
+					<div className={`status-indicator ${counter.connection ? 'connected' : 'disconnected'}`}>
+						<div className="status-dot"></div>
+						<span>{counter.connection ? 'Connected' : 'Connecting...'}</span>
+					</div>
+				</div>
+
+				<div className="counter-settings">
+					<div className="setting-group">
+						<label htmlFor="counterId">Counter ID</label>
+						<input
+							id="counterId"
+							type="text"
+							value={counterId}
+							onChange={(e) => setCounterId(e.target.value)}
+							placeholder="Enter counter ID"
+							className="setting-input"
+						/>
+					</div>
+				</div>
+
+				<div className="counter-display">
+					<div className="count-value">{count}</div>
+					<p className="count-label">Current Count</p>
+				</div>
+
+				<div className="counter-controls">
+					<button
+						onClick={() => increment(1)}
+						disabled={!counter.connection}
+						className="counter-button"
+					>
+						+1
+					</button>
+					<button
+						onClick={() => increment(5)}
+						disabled={!counter.connection}
+						className="counter-button"
+					>
+						+5
+					</button>
+					<button
+						onClick={() => increment(10)}
+						disabled={!counter.connection}
+						className="counter-button"
+					>
+						+10
+					</button>
+				</div>
+
+				<div className="info-box">
+					<p>This counter is shared across all clients using the same Counter ID.</p>
+					<p>Try opening this page in multiple tabs or browsers!</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/examples/hello-world-vercel/frontend/main.tsx
+++ b/examples/hello-world-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/hello-world-vercel/index.html
+++ b/examples/hello-world-vercel/index.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World Example</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', Roboto, sans-serif;
+            background: #000000;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #ffffff;
+            padding: 20px;
+        }
+        .counter-app {
+            width: 100%;
+            max-width: 500px;
+            margin: 0 auto;
+        }
+        .counter-container {
+            background: #1c1c1e;
+            border-radius: 16px;
+            border: 1px solid #2c2c2e;
+            overflow: hidden;
+        }
+        .counter-header {
+            padding: 24px;
+            border-bottom: 1px solid #2c2c2e;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .counter-header h1 {
+            font-size: 24px;
+            font-weight: 600;
+            color: #ffffff;
+        }
+        .status-indicator {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 14px;
+            font-weight: 500;
+        }
+        .status-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            transition: background-color 0.2s ease;
+        }
+        .status-indicator.connected .status-dot {
+            background-color: #30d158;
+        }
+        .status-indicator.disconnected .status-dot {
+            background-color: #ff3b30;
+        }
+        .status-indicator.connected {
+            color: #30d158;
+        }
+        .status-indicator.disconnected {
+            color: #ff3b30;
+        }
+        .counter-settings {
+            padding: 24px;
+            border-bottom: 1px solid #2c2c2e;
+        }
+        .setting-group label {
+            display: block;
+            font-size: 14px;
+            font-weight: 600;
+            color: #8e8e93;
+            margin-bottom: 8px;
+        }
+        .setting-input {
+            width: 100%;
+            padding: 10px 14px;
+            border: 1px solid #3a3a3c;
+            border-radius: 8px;
+            font-size: 14px;
+            transition: all 0.2s ease;
+            background: #2c2c2e;
+            color: #ffffff;
+        }
+        .setting-input:focus {
+            outline: none;
+            border-color: #007aff;
+            box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1);
+        }
+        .setting-input::placeholder {
+            color: #8e8e93;
+        }
+        .counter-display {
+            padding: 48px 24px;
+            text-align: center;
+            background: #000000;
+        }
+        .count-value {
+            font-size: 72px;
+            font-weight: 700;
+            color: #007aff;
+            line-height: 1;
+            margin-bottom: 12px;
+            font-variant-numeric: tabular-nums;
+        }
+        .count-label {
+            font-size: 16px;
+            color: #8e8e93;
+            font-weight: 500;
+        }
+        .counter-controls {
+            padding: 24px;
+            display: flex;
+            gap: 12px;
+            border-bottom: 1px solid #2c2c2e;
+        }
+        .counter-button {
+            flex: 1;
+            padding: 16px;
+            border: none;
+            border-radius: 12px;
+            font-size: 18px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            color: white;
+            background: #007aff;
+        }
+        .counter-button:hover:not(:disabled) {
+            background: #0056cc;
+            transform: translateY(-2px);
+        }
+        .counter-button:disabled {
+            background: #3a3a3c;
+            cursor: not-allowed;
+            color: #8e8e93;
+            transform: none;
+        }
+        .info-box {
+            padding: 24px;
+            background: #2c2c2e;
+        }
+        .info-box p {
+            font-size: 14px;
+            color: #8e8e93;
+            line-height: 1.6;
+            margin-bottom: 8px;
+        }
+        .info-box p:last-child {
+            margin-bottom: 0;
+        }
+        @media (max-width: 480px) {
+            .counter-header h1 {
+                font-size: 20px;
+            }
+            .count-value {
+                font-size: 56px;
+            }
+            .counter-controls {
+                flex-direction: column;
+            }
+            .counter-button {
+                width: 100%;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/hello-world-vercel/package.json
+++ b/examples/hello-world-vercel/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "hello-world-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.11.3",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"react",
+			"typescript"
+		],
+		"tags": [
+			"starter"
+		],
+		"priority": 100,
+		"frontendPort": 5173
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/hello-world-vercel/src/actors.ts
+++ b/examples/hello-world-vercel/src/actors.ts
@@ -1,0 +1,25 @@
+import { actor, setup } from "rivetkit";
+
+export const counter = actor({
+	// Persistent state that survives restarts: https://rivet.dev/docs/actors/state
+	state: {
+		count: 0,
+	},
+
+	actions: {
+		// Callable functions from clients: https://rivet.dev/docs/actors/actions
+		increment: (c, amount: number) => {
+			c.state.count += amount;
+			// Send events to all connected clients: https://rivet.dev/docs/actors/events
+			c.broadcast("newCount", c.state.count);
+			return c.state.count;
+		},
+
+		getCount: (c) => c.state.count,
+	},
+});
+
+// Register actors for use: https://rivet.dev/docs/setup
+export const registry = setup({
+	use: { counter },
+});

--- a/examples/hello-world-vercel/src/server.ts
+++ b/examples/hello-world-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/hello-world-vercel/tsconfig.json
+++ b/examples/hello-world-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/hello-world-vercel/turbo.json
+++ b/examples/hello-world-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/hello-world-vercel/vercel.json
+++ b/examples/hello-world-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/hello-world-vercel/vite.config.ts
+++ b/examples/hello-world-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/hello-world-vercel/vitest.config.ts
+++ b/examples/hello-world-vercel/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	server: {
+		port: 5173,
+	},
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/hello-world/vercel.json
+++ b/examples/hello-world/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/hono-react-vercel/.gitignore
+++ b/examples/hono-react-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/hono-react-vercel/README.md
+++ b/examples/hono-react-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [hono-react](../hono-react) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fhono-react-vercel&project-name=hono-react-vercel)
+
+# Hono + React
+
+Example demonstrating full-stack Hono backend with React frontend integration.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/hono-react
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Full-stack Hono**: Hono web framework for HTTP routing and serving React frontend
+- **React integration**: Complete frontend-backend integration with type-safe APIs
+- **Actor backend**: Rivet Actors handle business logic and state management
+- **Single codebase**: Frontend and backend in one project with shared types
+
+## Implementation
+
+This example demonstrates full-stack development with Hono and React:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/hono-react/src/backend/registry.ts)): Shows full-stack integration with Hono backend and React frontend
+
+## Resources
+
+Read more about [actions](/docs/actors/actions), [state](/docs/actors/state), and [setup](/docs/setup).
+
+## License
+
+MIT

--- a/examples/hono-react-vercel/api/index.ts
+++ b/examples/hono-react-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/hono-react-vercel/frontend/App.tsx
+++ b/examples/hono-react-vercel/frontend/App.tsx
@@ -1,0 +1,36 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useState } from "react";
+import type { registry } from "../src/actors.ts";
+
+const { useActor } = createRivetKit<typeof registry>(`${window.location.origin}/api/rivet`);
+
+function App() {
+	const [count, setCount] = useState(0);
+	const [counterName, setCounterName] = useState("test-counter");
+
+	const counter = useActor({
+		name: "counter",
+		key: [counterName],
+	});
+
+	counter.useEvent("newCount", (x: number) => setCount(x));
+
+	const increment = async () => {
+		await counter.connection?.increment(1);
+	};
+
+	return (
+		<div>
+			<h1>Counter: {count}</h1>
+			<input
+				type="text"
+				value={counterName}
+				onChange={(e) => setCounterName(e.target.value)}
+				placeholder="Counter name"
+			/>
+			<button onClick={increment}>Increment</button>
+		</div>
+	);
+}
+
+export default App;

--- a/examples/hono-react-vercel/frontend/main.tsx
+++ b/examples/hono-react-vercel/frontend/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
+);

--- a/examples/hono-react-vercel/index.html
+++ b/examples/hono-react-vercel/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hono React Counter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+  </body>
+</html>

--- a/examples/hono-react-vercel/package.json
+++ b/examples/hono-react-vercel/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "hono-react-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.1",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.7.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"hono",
+			"react",
+			"typescript"
+		],
+		"tags": [
+			"starter"
+		],
+		"frontendPort": 5173
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/hono-react-vercel/src/actors.ts
+++ b/examples/hono-react-vercel/src/actors.ts
@@ -1,0 +1,16 @@
+import { actor, setup } from "rivetkit";
+
+export const counter = actor({
+	state: { count: 0 },
+	actions: {
+		increment: (c, x: number) => {
+			c.state.count += x;
+			c.broadcast("newCount", c.state.count);
+			return c.state.count;
+		},
+	},
+});
+
+export const registry = setup({
+	use: { counter },
+});

--- a/examples/hono-react-vercel/src/server.ts
+++ b/examples/hono-react-vercel/src/server.ts
@@ -1,0 +1,21 @@
+import { Hono } from "hono";
+import { createClient } from "rivetkit/client";
+import { registry } from "./actors.ts";
+
+const client = createClient<typeof registry>();
+
+const app = new Hono();
+
+// Example HTTP endpoint
+app.post("/increment/:name", async (c) => {
+	const name = c.req.param("name");
+
+	const counter = client.counter.getOrCreate(name);
+	const newCount = await counter.increment(1);
+
+	return c.text(String(newCount));
+});
+
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+
+export default app;

--- a/examples/hono-react-vercel/tsconfig.json
+++ b/examples/hono-react-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/hono-react-vercel/turbo.json
+++ b/examples/hono-react-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/hono-react-vercel/vercel.json
+++ b/examples/hono-react-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/hono-react-vercel/vite.config.ts
+++ b/examples/hono-react-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/hono-react/vercel.json
+++ b/examples/hono-react/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/hono-vercel/.gitignore
+++ b/examples/hono-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/hono-vercel/README.md
+++ b/examples/hono-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [hono](../hono) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fhono-vercel&project-name=hono-vercel)
+
+# Hono Integration
+
+Example project demonstrating Hono web framework integration.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/hono
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Hono web framework**: Lightweight, fast HTTP routing for actor APIs
+- **Actor integration**: Call actor actions from Hono route handlers
+- **Type-safe endpoints**: Full TypeScript type safety across HTTP and actor layers
+- **Middleware support**: Use Hono middleware for authentication, logging, and more
+
+## Implementation
+
+This example demonstrates integrating Hono web framework with Rivet Actors:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/hono/src/backend/registry.ts)): Shows how to use Hono for HTTP routing with actors
+
+## Resources
+
+Read more about [actions](/docs/actors/actions) and [setup](/docs/setup).
+
+## License
+
+MIT

--- a/examples/hono-vercel/api/index.ts
+++ b/examples/hono-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/hono-vercel/package.json
+++ b/examples/hono-vercel/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "example-hono-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.1",
+		"@hono/node-ws": "^1.3.0",
+		"hono": "^4.7.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2"
+	},
+	"template": {
+		"technologies": [
+			"hono",
+			"typescript"
+		],
+		"tags": [],
+		"noFrontend": true
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/hono-vercel/src/actors.ts
+++ b/examples/hono-vercel/src/actors.ts
@@ -1,0 +1,15 @@
+import { actor, setup } from "rivetkit";
+
+export const counter = actor({
+	state: { count: 0 },
+	actions: {
+		increment: (c, x: number) => {
+			c.state.count += x;
+			return c.state.count;
+		},
+	},
+});
+
+export const registry = setup({
+	use: { counter },
+});

--- a/examples/hono-vercel/src/server.ts
+++ b/examples/hono-vercel/src/server.ts
@@ -1,0 +1,20 @@
+import { Hono } from "hono";
+import { createClient } from "rivetkit/client";
+import { registry } from "./actors.ts";
+
+const client = createClient<typeof registry>();
+
+const app = new Hono();
+
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+
+app.post("/increment/:name", async (c) => {
+	const name = c.req.param("name");
+
+	const counter = client.counter.getOrCreate(name);
+	const newCount = await counter.increment(1);
+
+	return c.text(`New Count: ${newCount}`);
+});
+
+export default app;

--- a/examples/hono-vercel/tsconfig.json
+++ b/examples/hono-vercel/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext"
+		],
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*"
+	]
+}

--- a/examples/hono-vercel/turbo.json
+++ b/examples/hono-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/hono-vercel/vercel.json
+++ b/examples/hono-vercel/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/hono/vercel.json
+++ b/examples/hono/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/kitchen-sink-vercel/.gitignore
+++ b/examples/kitchen-sink-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/kitchen-sink-vercel/README.md
+++ b/examples/kitchen-sink-vercel/README.md
@@ -1,0 +1,41 @@
+> **Note:** This is the Vercel-optimized version of the [kitchen-sink](../kitchen-sink) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fkitchen-sink-vercel&project-name=kitchen-sink-vercel)
+
+# Kitchen Sink Example
+
+Example project demonstrating all RivetKit features.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/kitchen-sink
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Complete feature showcase**: Demonstrates all major RivetKit concepts in one example
+- **Lifecycle hooks**: Use `onWake`, `onSleep`, `onConnect`, and `onDisconnect` for actor lifecycle management
+- **Scheduling**: Schedule delayed actions with `schedule.at()` and `schedule.after()`
+- **HTTP and WebSocket**: Handle both HTTP requests and WebSocket connections in actors
+- **Event broadcasting**: Broadcast events to all connected clients with `c.broadcast()`
+- **Connection management**: Track and manage multiple client connections per actor
+
+## Implementation
+
+This comprehensive example brings together all Rivet Actor features in one place:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/kitchen-sink/src/backend/registry.ts)): Demonstrates the complete feature set including lifecycle hooks, scheduling, events, state management, and WebSocket handling
+
+## Resources
+
+Read more about [actions](/docs/actors/actions), [state](/docs/actors/state), [lifecycle hooks](/docs/actors/lifecycle), [scheduling](/docs/actors/scheduling), [events](/docs/actors/events), and [WebSockets](/docs/actors/websockets).
+
+## License
+
+MIT

--- a/examples/kitchen-sink-vercel/SPEC.md
+++ b/examples/kitchen-sink-vercel/SPEC.md
@@ -1,0 +1,126 @@
+# Kitchen Sink Example Specification
+
+## Overview
+Comprehensive example demonstrating all RivetKit features with a simple React frontend.
+
+## UI Structure
+
+### Header (Always visible)
+
+**Configuration Row 1:**
+- **Transport**: WebSocket ↔ SSE toggle
+- **Encoding**: JSON ↔ CBOR ↔ Bare dropdown
+- **Connection Mode**: Handle ↔ Connection toggle
+
+**Actor Management Row 2:**
+- **Actor Name**: dropdown
+- **Key**: input
+- **Region**: input
+- **Input JSON**: textarea
+- **Buttons**: `create()` | `get()` | `getOrCreate()` | `getForId()` (when no actor connected)
+- **OR Button**: `dispose()` (when actor connected)
+
+**Status Row 3:**
+- Connection status indicator with actor info (Name | Key | Actor ID | Status)
+
+### Main Content (8 Tabs - disabled until actor connected)
+
+#### 1. Actions
+- Action name dropdown/input
+- Arguments JSON textarea
+- Call button
+- Response display
+
+#### 2. Events
+- Event listener controls
+- Live event feed with timestamps
+- Event type filter
+
+#### 3. Schedule
+- `schedule.at()` with timestamp input
+- `schedule.after()` with delay input
+- Scheduled task history
+- Custom alarm data input
+
+#### 4. Sleep
+- `sleep()` button
+- Sleep timeout configuration
+- Lifecycle event display (`onWake`, `onSleep`)
+
+#### 5. Connections (Only visible in Connection Mode)
+- Connection state display
+- Connection info (ID, transport, encoding)
+- Connection-specific event history
+
+#### 6. Raw HTTP
+- HTTP method dropdown
+- Path input
+- Headers textarea
+- Body textarea
+- Send button & response display
+
+#### 7. Raw WebSocket
+- Message input (text/binary toggle)
+- Send button
+- Message history (sent/received with timestamps)
+
+#### 8. Metadata
+- Actor name, tags, region display
+
+## User Flow
+1. Configure transport/encoding/connection mode
+2. Fill actor details (name, key, region, input)
+3. Click create/get/getOrCreate/getForId
+4. Status shows connection info, tabs become enabled
+5. Use tabs to test features
+6. Click dispose() to disconnect and return to step 1
+
+## Actors
+
+### 1. `demo` - Main comprehensive actor
+- All action types (sync/async/promise)
+- Events and state management
+- Scheduling capabilities (`schedule.at()`, `schedule.after()`)
+- Sleep functionality with configurable timeout
+- Connection state support
+- Lifecycle hooks (`onWake`, `onSleep`, `onConnect`, `onDisconnect`)
+- Metadata access
+
+### 2. `http` - Raw HTTP handling
+- `onFetch()` handler
+- Multiple endpoint examples
+- Various HTTP methods support
+
+### 3. `websocket` - Raw WebSocket handling
+- `onWebSocket()` handler
+- Text and binary message support
+- Connection lifecycle management
+
+## Features Demonstrated
+
+### Core Features
+- **Actions**: sync, async, promise-based with various input types
+- **Events**: broadcasting to connected clients
+- **State Management**: actor state + per-connection state
+- **Scheduling**: `schedule.at()`, `schedule.after()` with alarm handlers
+- **Force Sleep**: `sleep()` method with configurable sleep timeout
+- **Lifecycle Hooks**: `onWake`, `onSleep`, `onConnect`, `onDisconnect`
+
+### Configuration Options
+- **Transport**: WebSocket vs Server-Sent Events
+- **Encoding**: JSON, CBOR, Bare
+
+### Raw Protocols
+- **Raw HTTP**: Direct HTTP request handling
+- **Raw WebSocket**: Direct WebSocket connection handling
+
+### Connection Patterns
+- **Handle Mode**: Fire-and-forget action calls
+- **Connection Mode**: Persistent connection with real-time events
+
+### Actor Management
+- **Create**: `client.actor.create(key, opts)`
+- **Get**: `client.actor.get(key, opts)`
+- **Get or Create**: `client.actor.getOrCreate(key, opts)`
+- **Get by ID**: `client.actor.getForId(actorId, opts)`
+- **Dispose**: `client.dispose()` - disconnect all connections

--- a/examples/kitchen-sink-vercel/api/index.ts
+++ b/examples/kitchen-sink-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/kitchen-sink-vercel/frontend/App.tsx
+++ b/examples/kitchen-sink-vercel/frontend/App.tsx
@@ -1,0 +1,115 @@
+import { createClient } from "@rivetkit/react";
+import { useState, useMemo, useEffect } from "react";
+import type { Registry } from "../src/actors.ts";
+import ConnectionScreen from "./components/ConnectionScreen.tsx";
+import InteractionScreen from "./components/InteractionScreen.tsx";
+
+export interface AppState {
+  // Configuration
+  encoding: "json" | "cbor" | "bare";
+  connectionMode: "handle" | "connection";
+
+  // Actor management
+  actorMethod: "get" | "getOrCreate" | "getForId" | "create";
+  actorName: string;
+  actorKey: string;
+  actorId: string;
+  actorRegion: string;
+  createInput: string;
+
+  // Connection state
+  isConnected: boolean;
+  connectionError?: string;
+}
+
+function App() {
+  const [state, setState] = useState<AppState | null>(null);
+
+  const handleConnect = (config: AppState) => {
+    setState(config);
+  };
+
+  const handleDisconnect = () => {
+    setState(null);
+  };
+
+  const updateState = (updates: Partial<AppState>) => {
+    setState(prev => prev ? { ...prev, ...updates } : null);
+  };
+
+  // Create client with user-selected encoding
+  const client = useMemo(() => {
+    if (!state) return null;
+
+    return createClient<Registry>({
+      endpoint: `${window.location.origin}/api/rivet`,
+      encoding: state.encoding,
+    });
+  }, [state?.encoding]);
+
+  // Create the connection/handle once based on state
+  const [actorHandle, setActorHandle] = useState<any>(null);
+
+  useEffect(() => {
+    if (!state || !client) {
+      setActorHandle(null);
+      return;
+    }
+
+    const accessor = (client as any)[state.actorName];
+    const key = state.actorKey ? [state.actorKey] : [];
+
+    const initHandle = async () => {
+      let baseHandle: any;
+      switch (state.actorMethod) {
+        case "get":
+          baseHandle = accessor.get(key);
+          break;
+        case "getOrCreate": {
+          const createInput = state.createInput ? JSON.parse(state.createInput) : undefined;
+          baseHandle = accessor.getOrCreate(key, { createWithInput: createInput });
+          break;
+        }
+        case "getForId":
+          if (!state.actorId) {
+            throw new Error("Actor ID is required for getForId method");
+          }
+          baseHandle = accessor.getForId(state.actorId);
+          break;
+        case "create": {
+          const createInput = state.createInput ? JSON.parse(state.createInput) : undefined;
+          baseHandle = await accessor.create(key, { input: createInput });
+          break;
+        }
+        default:
+          throw new Error(`Unknown actor method: ${state.actorMethod}`);
+      }
+
+      // Apply connection mode
+      const handle = state.connectionMode === "connection"
+        ? baseHandle.connect()
+        : baseHandle;
+
+      setActorHandle(handle);
+    };
+
+    initHandle();
+  }, [state, client]);
+
+  return (
+    <div className="app">
+      <ConnectionScreen onConnect={handleConnect} />
+      {state && actorHandle && (
+        <InteractionScreen
+          state={state}
+          updateState={updateState}
+          client={client}
+          actorHandle={actorHandle}
+          onDisconnect={handleDisconnect}
+        />
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/examples/kitchen-sink-vercel/frontend/components/ConnectionScreen.tsx
+++ b/examples/kitchen-sink-vercel/frontend/components/ConnectionScreen.tsx
@@ -1,0 +1,203 @@
+import { useState } from "react";
+import type { AppState } from "../App.tsx";
+
+interface ConnectionScreenProps {
+  onConnect: (config: AppState) => void;
+}
+
+type ActorMethod = "get" | "getOrCreate" | "getForId" | "create";
+
+export default function ConnectionScreen({ onConnect }: ConnectionScreenProps) {
+  const [actorMethod, setActorMethod] = useState<ActorMethod>("getOrCreate");
+  const [actorName, setActorName] = useState("demo");
+  const [actorKey, setActorKey] = useState("");
+  const [actorId, setActorId] = useState("");
+  const [actorRegion, setActorRegion] = useState("");
+  const [createInput, setCreateInput] = useState("");
+  const [encoding, setEncoding] = useState<"json" | "cbor" | "bare">("bare");
+  const [connectionMode, setConnectionMode] = useState<"connection" | "handle">("handle");
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  const handleConnect = async () => {
+    setIsConnecting(true);
+
+    const config: AppState = {
+      actorMethod,
+      actorName,
+      actorKey,
+      actorId,
+      actorRegion,
+      createInput,
+      encoding,
+      connectionMode,
+      isConnected: true,
+    };
+
+    onConnect(config);
+    setIsConnecting(false);
+  };
+
+  return (
+    <div className="connection-screen">
+      <div className="connection-modal">
+        <div className="modal-header">
+          <h1>Connect to Actor</h1>
+          <p>Configure your RivetKit connection</p>
+        </div>
+
+        <div className="modal-content">
+          <div className="form-section">
+            <h3>Actor Configuration</h3>
+            <div className="form-group">
+              <label>Method</label>
+              <div className="toggle-group method-toggle">
+                <button
+                  className={`toggle-button ${actorMethod === "get" ? "active" : ""}`}
+                  onClick={() => setActorMethod("get")}
+                >
+                  Get
+                </button>
+                <button
+                  className={`toggle-button ${actorMethod === "getOrCreate" ? "active" : ""}`}
+                  onClick={() => setActorMethod("getOrCreate")}
+                >
+                  Get or Create
+                </button>
+                <button
+                  className={`toggle-button ${actorMethod === "getForId" ? "active" : ""}`}
+                  onClick={() => setActorMethod("getForId")}
+                >
+                  Get for ID
+                </button>
+                <button
+                  className={`toggle-button ${actorMethod === "create" ? "active" : ""}`}
+                  onClick={() => setActorMethod("create")}
+                >
+                  Create
+                </button>
+              </div>
+            </div>
+
+            <div className="form-group">
+              <label>Actor Name</label>
+              <select
+                className="form-control"
+                value={actorName}
+                onChange={(e) => setActorName(e.target.value)}
+              >
+                <option value="demo">Demo Actor</option>
+              </select>
+            </div>
+
+            {actorMethod === "getForId" ? (
+              <div className="form-group">
+                <label>Actor ID</label>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={actorId}
+                  onChange={(e) => setActorId(e.target.value)}
+                  placeholder="Actor ID"
+                  required
+                />
+              </div>
+            ) : (
+              <div className="form-group">
+                <label>Key</label>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={actorKey}
+                  onChange={(e) => setActorKey(e.target.value)}
+                  placeholder="Optional key for actor instance"
+                />
+              </div>
+            )}
+
+            {(actorMethod === "create" || actorMethod === "getOrCreate") && (
+              <>
+                <div className="form-group">
+                  <label>Region</label>
+                  <input
+                    className="form-control"
+                    type="text"
+                    value={actorRegion}
+                    onChange={(e) => setActorRegion(e.target.value)}
+                    placeholder="Optional region"
+                  />
+                </div>
+                <div className="form-group">
+                  <label>Input Data</label>
+                  <textarea
+                    className="form-control textarea"
+                    value={createInput}
+                    onChange={(e) => setCreateInput(e.target.value)}
+                    placeholder="Optional JSON input data"
+                    rows={3}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="form-section">
+            <h3>Connection Settings</h3>
+            <div className="form-group">
+              <label>Mode</label>
+              <div className="toggle-group">
+                <button
+                  className={`toggle-button ${connectionMode === "handle" ? "active" : ""}`}
+                  onClick={() => setConnectionMode("handle")}
+                >
+                  Handle
+                </button>
+                <button
+                  className={`toggle-button ${connectionMode === "connection" ? "active" : ""}`}
+                  onClick={() => setConnectionMode("connection")}
+                >
+                  Connection
+                </button>
+              </div>
+            </div>
+
+            <div className="form-group">
+              <label>Encoding</label>
+              <div className="toggle-group">
+                <button
+                  className={`toggle-button ${encoding === "bare" ? "active" : ""}`}
+                  onClick={() => setEncoding("bare")}
+                >
+                  Bare
+                </button>
+                <button
+                  className={`toggle-button ${encoding === "cbor" ? "active" : ""}`}
+                  onClick={() => setEncoding("cbor")}
+                >
+                  CBOR
+                </button>
+                <button
+                  className={`toggle-button ${encoding === "json" ? "active" : ""}`}
+                  onClick={() => setEncoding("json")}
+                >
+                  JSON
+                </button>
+              </div>
+            </div>
+          </div>
+
+
+          <div className="modal-actions">
+            <button
+              className="btn btn-primary connect-button"
+              onClick={handleConnect}
+              disabled={isConnecting}
+              aria-busy={isConnecting ? "true" : "false"}
+            >
+              {isConnecting ? "Connecting..." : "Connect to Actor"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/examples/kitchen-sink-vercel/frontend/components/InteractionScreen.tsx
+++ b/examples/kitchen-sink-vercel/frontend/components/InteractionScreen.tsx
@@ -1,0 +1,173 @@
+import { useState } from "react";
+import type { AppState } from "../App.tsx";
+import ActionsTab from "./tabs/ActionsTab.tsx";
+import EventsTab from "./tabs/EventsTab.tsx";
+import ScheduleTab from "./tabs/ScheduleTab.tsx";
+import SleepTab from "./tabs/SleepTab.tsx";
+import RawHttpTab from "./tabs/RawHttpTab.tsx";
+import RawWebSocketTab from "./tabs/RawWebSocketTab.tsx";
+import MetadataTab from "./tabs/MetadataTab.tsx";
+import ConnectionsTab from "./tabs/ConnectionsTab.tsx";
+
+interface InteractionScreenProps {
+  state: AppState;
+  updateState: (updates: Partial<AppState>) => void;
+  client: any;
+  actorHandle: any;
+  onDisconnect: () => void;
+}
+
+export interface EventSubscription {
+  eventName: string;
+  unsubscribe: () => void;
+}
+
+export interface EventItem {
+  timestamp: number;
+  name: string;
+  data: any;
+  id: string;
+}
+
+type TabType = "actions" | "events" | "connections" | "schedule" | "sleep" | "raw-http" | "raw-websocket" | "metadata";
+
+export default function InteractionScreen({
+  state,
+  updateState,
+  client,
+  actorHandle,
+  onDisconnect
+}: InteractionScreenProps) {
+  const [activeTab, setActiveTab] = useState<TabType>("actions");
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const [eventSubscriptions, setEventSubscriptions] = useState<Map<string, EventSubscription>>(new Map());
+  const [events, setEvents] = useState<EventItem[]>([]);
+
+  // Switch to an enabled tab if current tab becomes disabled
+  const isCurrentTabDisabled = activeTab === "events" && state.connectionMode !== "connection";
+  if (isCurrentTabDisabled) {
+    setActiveTab("actions");
+  }
+
+  const handleDisconnect = async () => {
+    setIsDisconnecting(true);
+
+    onDisconnect();
+    setIsDisconnecting(false);
+  };
+
+  const [isDisposing, setIsDisposing] = useState(false);
+
+  const handleDispose = async () => {
+    setIsDisposing(true);
+
+    try {
+      const actorName = state.actorName as keyof typeof client;
+      const accessor = client[actorName];
+      const key = state.actorKey ? [state.actorKey] : [];
+      await accessor.get(key).dispose();
+
+      // After disposal, go back to connection screen
+      onDisconnect();
+    } catch (error) {
+      console.error("Failed to dispose actor:", error);
+      alert("Failed to dispose actor. See console for details.");
+    } finally {
+      setIsDisposing(false);
+    }
+  };
+
+  const tabs = [
+    { id: "actions" as const, label: "Actions", component: ActionsTab, disabled: false },
+    { id: "events" as const, label: "Events", component: EventsTab, disabled: state.connectionMode !== "connection" },
+    { id: "connections" as const, label: "Connections", component: ConnectionsTab, disabled: false },
+    { id: "schedule" as const, label: "Schedule", component: ScheduleTab, disabled: false },
+    { id: "sleep" as const, label: "Sleep", component: SleepTab, disabled: false },
+    { id: "raw-http" as const, label: "Raw HTTP", component: RawHttpTab, disabled: false },
+    { id: "raw-websocket" as const, label: "Raw WebSocket", component: RawWebSocketTab, disabled: false },
+    { id: "metadata" as const, label: "Metadata", component: MetadataTab, disabled: false },
+  ];
+
+  const ActiveTabComponent = tabs.find(tab => tab.id === activeTab)?.component || ActionsTab;
+
+  return (
+    <div className="interaction-modal-overlay">
+      <div className="interaction-modal">
+        {/* Header with connection info and controls */}
+        <div className="interaction-header">
+          <div className="connection-info">
+            <div className="connection-details">
+              <h2>Connected to Actor</h2>
+              <div className="connection-meta">
+                <span className="actor-name">{state.actorName}</span>
+                {state.actorKey && <span className="actor-key">#{state.actorKey}</span>}
+                <span className="transport-info">{state.encoding.toUpperCase()}</span>
+                <span className={`mode-info ${state.connectionMode}`}>
+                  {state.connectionMode === "connection" ? "🔗 Connected" : "🔧 Handle"}
+                </span>
+              </div>
+            </div>
+
+            <div className="connection-actions">
+              <button
+                className="btn"
+                onClick={handleDispose}
+                disabled={isDisposing}
+                aria-busy={isDisposing ? "true" : "false"}
+              >
+                {isDisposing ? "Disposing..." : "Dispose"}
+              </button>
+              <button
+                className="btn"
+                onClick={handleDisconnect}
+                disabled={isDisconnecting}
+                aria-busy={isDisconnecting ? "true" : "false"}
+              >
+                {isDisconnecting ? "Disconnecting..." : "Disconnect"}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div className="tabs">
+          <div className="tab-list">
+            {tabs.map(tab => (
+              <button
+                key={tab.id}
+                className={`tab-button ${activeTab === tab.id ? "active" : ""}`}
+                onClick={() => setActiveTab(tab.id)}
+                disabled={tab.disabled}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="tab-content">
+            {activeTab === "events" ? (
+              <EventsTab
+                state={state}
+                updateState={updateState}
+                client={client}
+                actorHandle={actorHandle}
+                eventSubscriptions={eventSubscriptions}
+                setEventSubscriptions={setEventSubscriptions}
+                events={events}
+                setEvents={setEvents}
+              />
+            ) : (
+              <ActiveTabComponent
+                state={state}
+                updateState={updateState}
+                client={client}
+                actorHandle={actorHandle}
+                {...({} as any)}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/examples/kitchen-sink-vercel/frontend/components/tabs/ActionsTab.tsx
+++ b/examples/kitchen-sink-vercel/frontend/components/tabs/ActionsTab.tsx
@@ -1,0 +1,291 @@
+import { useState } from "react";
+import type { AppState } from "../../App.tsx";
+
+interface TabProps {
+  state: AppState;
+  updateState: (updates: Partial<AppState>) => void;
+  client: any;
+  actorHandle: any;
+}
+
+interface ActionResponse {
+  [key: string]: string;
+}
+
+export default function ActionsTab({ state, actorHandle }: TabProps) {
+  const [responses, setResponses] = useState<ActionResponse>({});
+  const [loading, setLoading] = useState<{ [key: string]: boolean }>({});
+
+  // Demo actor state
+  const [incrementAmount, setIncrementAmount] = useState("1");
+  const [message, setMessage] = useState("Hello World");
+  const [delayAmount, setDelayAmount] = useState("3");
+  const [delayMs, setDelayMs] = useState("2000");
+  const [eventName, setEventName] = useState("userAction");
+  const [eventData, setEventData] = useState('{"type": "click", "target": "button"}');
+
+  // WebSocket actor state
+  const [messageLimit, setMessageLimit] = useState("10");
+
+  const callAction = async (actionName: string, ...args: any[]) => {
+    setLoading((prev) => ({ ...prev, [actionName]: true }));
+    setResponses((prev) => ({ ...prev, [actionName]: "" }));
+
+    try {
+      const result = await actorHandle[actionName](...args);
+      setResponses((prev) => ({
+        ...prev,
+        [actionName]: JSON.stringify(result, null, 2),
+      }));
+    } catch (error) {
+      setResponses((prev) => ({
+        ...prev,
+        [actionName]: `Error: ${error instanceof Error ? error.message : String(error)}`,
+      }));
+    } finally {
+      setLoading((prev) => ({ ...prev, [actionName]: false }));
+    }
+  };
+
+  const ActionSection = ({
+    title,
+    description,
+    actionName,
+    children,
+    onCall,
+  }: {
+    title: string;
+    description: string;
+    actionName: string;
+    children?: React.ReactNode;
+    onCall: () => void;
+  }) => (
+    <div className="section">
+      <h3>{title}</h3>
+      <p style={{ fontSize: "14px", color: "#666", marginBottom: "10px" }}>
+        {description}
+      </p>
+      {children}
+      <button
+        className="btn btn-primary"
+        onClick={onCall}
+        disabled={loading[actionName]}
+        style={{ marginTop: children ? "10px" : "0" }}
+      >
+        {loading[actionName] ? "Calling..." : `Call ${title}`}
+      </button>
+      {responses[actionName] && (
+        <div className="response" style={{ marginTop: "10px" }}>
+          {responses[actionName]}
+        </div>
+      )}
+    </div>
+  );
+
+  const renderDemoActions = () => (
+    <>
+      <ActionSection
+        title="getCount"
+        description="Get current counter value"
+        actionName="getCount"
+        onCall={() => callAction("getCount")}
+      />
+
+      <ActionSection
+        title="increment"
+        description="Increment counter by amount"
+        actionName="increment"
+        onCall={() => callAction("increment", Number(incrementAmount))}
+      >
+        <div className="form-group">
+          <label>Amount:</label>
+          <input
+            className="form-control"
+            type="number"
+            value={incrementAmount}
+            onChange={(e) => setIncrementAmount(e.target.value)}
+          />
+        </div>
+      </ActionSection>
+
+      <ActionSection
+        title="setMessage"
+        description="Set a message string"
+        actionName="setMessage"
+        onCall={() => callAction("setMessage", message)}
+      >
+        <div className="form-group">
+          <label>Message:</label>
+          <input
+            className="form-control"
+            type="text"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+        </div>
+      </ActionSection>
+
+      <ActionSection
+        title="delayedIncrement"
+        description="Increment after delay"
+        actionName="delayedIncrement"
+        onCall={() => callAction("delayedIncrement", Number(delayAmount), Number(delayMs))}
+      >
+        <div className="form-grid">
+          <div className="form-group">
+            <label>Amount:</label>
+            <input
+              className="form-control"
+              type="number"
+              value={delayAmount}
+              onChange={(e) => setDelayAmount(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <label>Delay (ms):</label>
+            <input
+              className="form-control"
+              type="number"
+              value={delayMs}
+              onChange={(e) => setDelayMs(e.target.value)}
+            />
+          </div>
+        </div>
+      </ActionSection>
+
+      <ActionSection
+        title="promiseAction"
+        description="Returns a resolved promise with timestamp"
+        actionName="promiseAction"
+        onCall={() => callAction("promiseAction")}
+      />
+
+      <ActionSection
+        title="getState"
+        description="Get both actor and connection state"
+        actionName="getState"
+        onCall={() => callAction("getState")}
+      />
+
+      <ActionSection
+        title="getLifecycleInfo"
+        description="Get start/stop counts"
+        actionName="getLifecycleInfo"
+        onCall={() => callAction("getLifecycleInfo")}
+      />
+
+      <ActionSection
+        title="getMetadata"
+        description="Get actor metadata"
+        actionName="getMetadata"
+        onCall={() => callAction("getMetadata")}
+      />
+
+      <ActionSection
+        title="getInput"
+        description="Get input data passed during actor creation"
+        actionName="getInput"
+        onCall={() => callAction("getInput")}
+      />
+
+      <ActionSection
+        title="broadcastCustomEvent"
+        description="Broadcast custom event"
+        actionName="broadcastCustomEvent"
+        onCall={() => {
+          try {
+            const data = JSON.parse(eventData);
+            callAction("broadcastCustomEvent", eventName, data);
+          } catch (error) {
+            setResponses((prev) => ({
+              ...prev,
+              broadcastCustomEvent: `Error: Invalid JSON data`,
+            }));
+          }
+        }}
+      >
+        <div className="form-grid">
+          <div className="form-group">
+            <label>Event Name:</label>
+            <input
+              className="form-control"
+              type="text"
+              value={eventName}
+              onChange={(e) => setEventName(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <label>Data (JSON):</label>
+            <input
+              className="form-control"
+              type="text"
+              value={eventData}
+              onChange={(e) => setEventData(e.target.value)}
+            />
+          </div>
+        </div>
+      </ActionSection>
+    </>
+  );
+
+  const renderHttpActions = () => (
+    <>
+      <ActionSection
+        title="getStats"
+        description="Get HTTP request statistics"
+        actionName="getStats"
+        onCall={() => callAction("getStats")}
+      />
+
+      <ActionSection
+        title="clearHistory"
+        description="Clear request history"
+        actionName="clearHistory"
+        onCall={() => callAction("clearHistory")}
+      />
+    </>
+  );
+
+  const renderWebSocketActions = () => (
+    <>
+      <ActionSection
+        title="getStats"
+        description="Get WebSocket statistics"
+        actionName="getStats"
+        onCall={() => callAction("getStats")}
+      />
+
+      <ActionSection
+        title="clearHistory"
+        description="Clear message history"
+        actionName="clearHistory"
+        onCall={() => callAction("clearHistory")}
+      />
+
+      <ActionSection
+        title="getMessageHistory"
+        description="Get recent WebSocket messages"
+        actionName="getMessageHistory"
+        onCall={() => callAction("getMessageHistory", Number(messageLimit))}
+      >
+        <div className="form-group">
+          <label>Limit:</label>
+          <input
+            className="form-control"
+            type="number"
+            value={messageLimit}
+            onChange={(e) => setMessageLimit(e.target.value)}
+          />
+        </div>
+      </ActionSection>
+    </>
+  );
+
+  return (
+    <div>
+      {state.actorName === "demo" && renderDemoActions()}
+      {state.actorName === "http" && renderHttpActions()}
+      {state.actorName === "websocket" && renderWebSocketActions()}
+    </div>
+  );
+}

--- a/examples/kitchen-sink-vercel/frontend/components/tabs/ConnectionsTab.tsx
+++ b/examples/kitchen-sink-vercel/frontend/components/tabs/ConnectionsTab.tsx
@@ -1,0 +1,160 @@
+import { useState, useEffect } from "react";
+import type { AppState } from "../../App.tsx";
+
+interface TabProps {
+  state: AppState;
+  updateState: (updates: Partial<AppState>) => void;
+  client: any;
+  actorHandle: any;
+}
+
+interface ConnectionInfo {
+  id: string;
+  connectedAt: number;
+}
+
+export default function ConnectionsTab({ state, actorHandle }: TabProps) {
+  const [currentConnectionInfo, setCurrentConnectionInfo] = useState<any>(null);
+  const [allConnections, setAllConnections] = useState<ConnectionInfo[]>([]);
+  const [isLoadingConnections, setIsLoadingConnections] = useState(false);
+
+  // Update current connection info when actor handle changes
+  useEffect(() => {
+    if (actorHandle && state.connectionMode === "connection") {
+      setCurrentConnectionInfo({
+        isConnected: true,
+        connectionId: actorHandle.connectionId || "N/A",
+        encoding: state.encoding,
+        actorName: state.actorName,
+        actorKey: state.actorKey,
+        actorId: state.actorId,
+        lastActivity: Date.now(),
+      });
+    } else {
+      setCurrentConnectionInfo(null);
+    }
+  }, [actorHandle, state]);
+
+  const formatTimestamp = (timestamp: number) => {
+    return new Date(timestamp).toLocaleString();
+  };
+
+  const handleListConnections = async () => {
+    setIsLoadingConnections(true);
+    try {
+      const connections = await actorHandle.listConnections();
+      setAllConnections(connections);
+    } catch (error) {
+      console.error("Failed to list connections:", error);
+      alert(`Failed to list connections: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setIsLoadingConnections(false);
+    }
+  };
+
+  if (state.actorName !== "demo") {
+    return (
+      <div className="section">
+        <h3>Connections</h3>
+        <p>Connection features are only available for the <code>demo</code> actor. Please select the demo actor in the header.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Current Connection Information */}
+      {state.connectionMode === "connection" && (
+        <div className="section">
+          <h3>Current Connection</h3>
+
+          {!currentConnectionInfo ? (
+            <div style={{
+              padding: "20px",
+              textAlign: "center",
+              color: "var(--text-secondary)"
+            }}>
+              No active connection
+            </div>
+          ) : (
+            <div style={{ display: "grid", gridTemplateColumns: "auto 1fr", gap: "10px 20px", alignItems: "center" }}>
+              <strong>Status:</strong>
+              <span>🟢 Connected</span>
+
+              <strong>Connection ID:</strong>
+              <code>
+                {currentConnectionInfo.connectionId}
+              </code>
+
+              <strong>Encoding:</strong>
+              <span>{currentConnectionInfo.encoding.toUpperCase()}</span>
+
+              <strong>Actor Name:</strong>
+              <span>{currentConnectionInfo.actorName}</span>
+
+              <strong>Actor Key:</strong>
+              <span>{currentConnectionInfo.actorKey || "(empty)"}</span>
+
+              {currentConnectionInfo.actorId && (
+                <>
+                  <strong>Actor ID:</strong>
+                  <code>
+                    {currentConnectionInfo.actorId}
+                  </code>
+                </>
+              )}
+
+              <strong>Last Activity:</strong>
+              <span>{formatTimestamp(currentConnectionInfo.lastActivity)}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* All Connections */}
+      <div className="section">
+        <h3>All Connections</h3>
+        <p style={{ marginBottom: "15px" }}>
+          List all active connections to this actor instance.
+        </p>
+
+        <button
+          className="btn btn-primary"
+          onClick={handleListConnections}
+          disabled={isLoadingConnections}
+        >
+          {isLoadingConnections ? "Loading..." : "List All Connections"}
+        </button>
+
+        {allConnections.length > 0 && (
+          <div style={{ marginTop: "15px" }}>
+            <table style={{
+              width: "100%",
+              borderCollapse: "collapse",
+              fontSize: "14px"
+            }}>
+              <thead>
+                <tr style={{ borderBottom: "2px solid #333" }}>
+                  <th style={{ padding: "8px", textAlign: "left" }}>Connection ID</th>
+                  <th style={{ padding: "8px", textAlign: "left" }}>Connected At</th>
+                </tr>
+              </thead>
+              <tbody>
+                {allConnections.map((conn) => (
+                  <tr key={conn.id} style={{ borderBottom: "1px solid #222" }}>
+                    <td style={{ padding: "8px" }}>
+                      <code>{conn.id}</code>
+                    </td>
+                    <td style={{ padding: "8px" }}>
+                      {conn.connectedAt ? formatTimestamp(conn.connectedAt) : "N/A"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/kitchen-sink-vercel/frontend/components/tabs/EventsTab.tsx
+++ b/examples/kitchen-sink-vercel/frontend/components/tabs/EventsTab.tsx
@@ -1,0 +1,229 @@
+import { useState, useRef } from "react";
+import type { AppState } from "../../App.tsx";
+import type { EventSubscription, EventItem } from "../InteractionScreen.tsx";
+
+interface TabProps {
+  state: AppState;
+  updateState: (updates: Partial<AppState>) => void;
+  client: any;
+  actorHandle: any;
+  eventSubscriptions: Map<string, EventSubscription>;
+  setEventSubscriptions: React.Dispatch<React.SetStateAction<Map<string, EventSubscription>>>;
+  events: EventItem[];
+  setEvents: React.Dispatch<React.SetStateAction<EventItem[]>>;
+}
+
+export default function EventsTab({
+  actorHandle,
+  eventSubscriptions,
+  setEventSubscriptions,
+  events,
+  setEvents
+}: TabProps) {
+  const [selectedEventType, setSelectedEventType] = useState("countChanged");
+  const [customEventName, setCustomEventName] = useState("");
+  const eventIdCounter = useRef(0);
+
+  const predefinedEvents = [
+    "countChanged",
+    "messageChanged",
+    "preferenceChanged",
+    "alarmTriggered",
+  ];
+
+  const addEvent = (name: string, data: any) => {
+    const event: EventItem = {
+      timestamp: Date.now(),
+      name,
+      data,
+      id: `event-${++eventIdCounter.current}`,
+    };
+    setEvents(prev => [...prev, event].slice(-100)); // Keep last 100 events
+  };
+
+  const subscribe = (eventName: string) => {
+    if (!actorHandle || eventSubscriptions.has(eventName)) return;
+
+    const unsubscribe = actorHandle.on(eventName, (...args: any[]) => {
+      addEvent(eventName, args.length === 1 ? args[0] : args);
+    });
+
+    setEventSubscriptions(prev => {
+      const next = new Map(prev);
+      next.set(eventName, { eventName, unsubscribe });
+      return next;
+    });
+  };
+
+  const unsubscribe = (eventName: string) => {
+    const subscription = eventSubscriptions.get(eventName);
+    if (!subscription) return;
+
+    subscription.unsubscribe();
+    setEventSubscriptions(prev => {
+      const next = new Map(prev);
+      next.delete(eventName);
+      return next;
+    });
+  };
+
+  const handleSubscribe = () => {
+    const eventName = selectedEventType === "custom" ? customEventName.trim() : selectedEventType;
+    if (!eventName) return;
+
+    subscribe(eventName);
+
+    // Reset custom input if it was used
+    if (selectedEventType === "custom") {
+      setCustomEventName("");
+    }
+  };
+
+  const clearEvents = () => {
+    setEvents([]);
+  };
+
+  const formatTimestamp = (timestamp: number) => {
+    return new Date(timestamp).toLocaleTimeString();
+  };
+
+  const formatData = (data: any) => {
+    if (typeof data === "string") return data;
+    return JSON.stringify(data, null, 2);
+  };
+
+  return (
+    <div>
+      <div className="section">
+        <h3>Subscribe to Events</h3>
+
+        <div style={{ display: "flex", gap: "10px", marginBottom: "15px" }}>
+          <div className="form-group" style={{ flex: 1, marginBottom: 0 }}>
+            <label>Event Name:</label>
+            <select
+              className="form-control"
+              value={selectedEventType}
+              onChange={(e) => setSelectedEventType(e.target.value)}
+            >
+              {predefinedEvents.map(event => (
+                <option key={event} value={event}>{event}</option>
+              ))}
+              <option value="custom">Custom...</option>
+            </select>
+          </div>
+
+          {selectedEventType === "custom" && (
+            <div className="form-group" style={{ flex: 1, marginBottom: 0 }}>
+              <label>Custom Event Name:</label>
+              <input
+                className="form-control"
+                type="text"
+                value={customEventName}
+                onChange={(e) => setCustomEventName(e.target.value)}
+                placeholder="Enter event name..."
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSubscribe();
+                }}
+              />
+            </div>
+          )}
+
+          <div style={{ display: "flex", alignItems: "flex-end" }}>
+            <button
+              className="btn btn-primary"
+              onClick={handleSubscribe}
+              disabled={selectedEventType === "custom" && !customEventName.trim()}
+            >
+              Subscribe
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="section">
+        <h3>Active Subscriptions ({eventSubscriptions.size})</h3>
+
+        {eventSubscriptions.size === 0 ? (
+          <div style={{ textAlign: "center", color: "var(--text-secondary)", padding: "20px" }}>
+            No active subscriptions
+          </div>
+        ) : (
+          <div style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "8px"
+          }}>
+            {Array.from(eventSubscriptions.values()).map(sub => (
+              <div
+                key={sub.eventName}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  background: "var(--bg-tertiary)",
+                  border: "1px solid var(--border-secondary)",
+                  borderRadius: "20px",
+                  padding: "6px 12px",
+                  fontSize: "14px"
+                }}
+              >
+                <span style={{ fontFamily: "monospace" }}>{sub.eventName}</span>
+                <button
+                  onClick={() => unsubscribe(sub.eventName)}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: "var(--danger-color)",
+                    cursor: "pointer",
+                    fontSize: "16px",
+                    padding: 0,
+                    lineHeight: 1,
+                    width: "16px",
+                    height: "16px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center"
+                  }}
+                  title="Unsubscribe"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="section">
+        <h3>Event History ({events.length} events)</h3>
+
+        <div style={{ marginBottom: "15px" }}>
+          <button
+            className="btn"
+            onClick={clearEvents}
+          >
+            Clear ({events.length})
+          </button>
+        </div>
+
+        {events.length === 0 ? (
+          <div style={{ textAlign: "center", color: "var(--text-secondary)", padding: "20px" }}>
+            No events received yet
+          </div>
+        ) : (
+          <div className="event-list">
+            {events.map(event => (
+              <div key={event.id} className="event-item">
+                <span className="timestamp">{formatTimestamp(event.timestamp)}</span>
+                <span className="name">{event.name}</span>
+                <div style={{ marginTop: "5px" }}>
+                  {formatData(event.data)}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/kitchen-sink-vercel/frontend/components/tabs/MetadataTab.tsx
+++ b/examples/kitchen-sink-vercel/frontend/components/tabs/MetadataTab.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import type { AppState } from "../../App.tsx";
+
+interface TabProps {
+  state: AppState;
+  updateState: (updates: Partial<AppState>) => void;
+  client: any;
+  actorHandle: any;
+}
+
+export default function MetadataTab({ state, actorHandle }: TabProps) {
+  const [metadata, setMetadata] = useState<any>(null);
+  const [actorState, setActorState] = useState<any>(null);
+  const [connState, setConnState] = useState<any>(null);
+  const [loadingStates, setLoadingStates] = useState({
+    metadata: false,
+    actorState: false,
+    connState: false
+  });
+
+  const callAction = async (actionName: string, args: any[] = []) => {
+    return await actorHandle[actionName](...args);
+  };
+
+  const handleGetMetadata = async () => {
+    setLoadingStates(prev => ({ ...prev, metadata: true }));
+    setMetadata(null);
+
+    try {
+      const result = await callAction("getMetadata");
+      setMetadata(result);
+    } catch (error) {
+      setMetadata({
+        error: error instanceof Error ? error.message : String(error)
+      });
+    } finally {
+      setLoadingStates(prev => ({ ...prev, metadata: false }));
+    }
+  };
+
+  const handleGetActorState = async () => {
+    setLoadingStates(prev => ({ ...prev, actorState: true }));
+    setActorState(null);
+
+    try {
+      const result = await callAction("getActorState");
+      setActorState(result);
+    } catch (error) {
+      setActorState({
+        error: error instanceof Error ? error.message : String(error)
+      });
+    } finally {
+      setLoadingStates(prev => ({ ...prev, actorState: false }));
+    }
+  };
+
+  const handleGetConnState = async () => {
+    setLoadingStates(prev => ({ ...prev, connState: true }));
+    setConnState(null);
+
+    try {
+      const result = await callAction("getConnState");
+      setConnState(result);
+    } catch (error) {
+      setConnState({
+        error: error instanceof Error ? error.message : String(error)
+      });
+    } finally {
+      setLoadingStates(prev => ({ ...prev, connState: false }));
+    }
+  };
+
+  if (state.actorName !== "demo") {
+    return (
+      <div className="section">
+        <h3>Metadata</h3>
+        <p>Metadata features are only available for the <code>demo</code> actor. Please select the demo actor in the header.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="section">
+        <h3>Actor Metadata</h3>
+        <p style={{ marginBottom: "15px" }}>
+          Actors can access metadata about themselves including their name, tags, and region.
+          This information is useful for logging, monitoring, and conditional behavior.
+        </p>
+
+        <button
+          className="btn btn-primary"
+          onClick={handleGetMetadata}
+          disabled={loadingStates.metadata}
+        >
+          {loadingStates.metadata ? "Loading..." : "Get Metadata"}
+        </button>
+
+        {metadata && (
+          <div className="response">
+            <pre style={{ margin: 0, fontSize: "13px", overflow: "auto" }}>
+              {JSON.stringify(metadata, null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+
+      <div className="section">
+        <h3>Actor State</h3>
+        <p style={{ marginBottom: "15px" }}>
+          Current state of the actor. This state is shared across all connections to the actor.
+        </p>
+
+        <button
+          className="btn btn-primary"
+          onClick={handleGetActorState}
+          disabled={loadingStates.actorState}
+        >
+          {loadingStates.actorState ? "Loading..." : "Get Actor State"}
+        </button>
+
+        {actorState && (
+          <div className="response">
+            <pre style={{ margin: 0, fontSize: "13px", overflow: "auto" }}>
+              {JSON.stringify(actorState, null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+
+      <div className="section">
+        <h3>Connection State</h3>
+        <p style={{ marginBottom: "15px" }}>
+          State specific to the current connection. Each connection has its own isolated state.
+        </p>
+
+        <button
+          className="btn btn-primary"
+          onClick={handleGetConnState}
+          disabled={loadingStates.connState}
+        >
+          {loadingStates.connState ? "Loading..." : "Get Connection State"}
+        </button>
+
+        {connState && (
+          <div className="response">
+            <pre style={{ margin: 0, fontSize: "13px", overflow: "auto" }}>
+              {JSON.stringify(connState, null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/kitchen-sink-vercel/frontend/components/tabs/RawHttpTab.tsx
+++ b/examples/kitchen-sink-vercel/frontend/components/tabs/RawHttpTab.tsx
@@ -1,0 +1,245 @@
+import { useState } from "react";
+import type { AppState } from "../../App.tsx";
+
+interface TabProps {
+  state: AppState;
+  updateState: (updates: Partial<AppState>) => void;
+  client: any;
+  actorHandle: any;
+}
+
+export default function RawHttpTab({ state }: TabProps) {
+  const [method, setMethod] = useState("GET");
+  const [path, setPath] = useState("/api/hello");
+  const [headers, setHeaders] = useState("{}");
+  const [body, setBody] = useState("");
+  const [response, setResponse] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const parseHeaders = (headersString: string) => {
+    try {
+      return JSON.parse(headersString);
+    } catch {
+      return {};
+    }
+  };
+
+  const getActorUrl = () => {
+    const baseUrl = "http://localhost:8080";
+    const actorPath = state.actorKey ?
+      `/actors/${state.actorName}/${encodeURIComponent(state.actorKey)}` :
+      `/actors/${state.actorName}`;
+    return `${baseUrl}${actorPath}`;
+  };
+
+  const handleSendRequest = async () => {
+    setIsLoading(true);
+    setResponse("");
+
+    try {
+      const url = `${getActorUrl()}${path}`;
+      const requestHeaders = parseHeaders(headers);
+
+      const requestOptions: RequestInit = {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          ...requestHeaders,
+        },
+      };
+
+      if (method !== "GET" && method !== "HEAD" && body) {
+        requestOptions.body = body;
+      }
+
+      const startTime = Date.now();
+      const res = await fetch(url, requestOptions);
+      const endTime = Date.now();
+
+      const responseHeaders = Object.fromEntries(res.headers.entries());
+      const responseBody = await res.text();
+
+      const responseData = {
+        status: res.status,
+        statusText: res.statusText,
+        duration: `${endTime - startTime}ms`,
+        headers: responseHeaders,
+        body: responseBody,
+        url: url,
+      };
+
+      setResponse(JSON.stringify(responseData, null, 2));
+    } catch (error) {
+      setResponse(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const predefinedPaths = [
+    "/api/hello",
+    "/api/echo",
+    "/api/stats",
+    "/api/headers",
+    "/api/json",
+    "/api/custom?param=value",
+  ];
+
+  const exampleRequests = [
+    {
+      name: "Get Hello",
+      method: "GET",
+      path: "/api/hello",
+      headers: "{}",
+      body: "",
+    },
+    {
+      name: "Echo POST",
+      method: "POST",
+      path: "/api/echo",
+      headers: '{"Content-Type": "text/plain"}',
+      body: "Hello from client!",
+    },
+    {
+      name: "JSON POST",
+      method: "POST",
+      path: "/api/json",
+      headers: '{"Content-Type": "application/json"}',
+      body: '{"message": "Hello", "timestamp": 1234567890}',
+    },
+    {
+      name: "Get Stats",
+      method: "GET",
+      path: "/api/stats",
+      headers: "{}",
+      body: "",
+    },
+  ];
+
+  const loadExample = (example: typeof exampleRequests[0]) => {
+    setMethod(example.method);
+    setPath(example.path);
+    setHeaders(example.headers);
+    setBody(example.body);
+  };
+
+  return (
+    <div>
+      <div className="section">
+        <h3>Raw HTTP Request Builder</h3>
+
+        <div className="form-grid">
+          <div className="form-group">
+            <label>Method:</label>
+            <select
+              className="form-control"
+              value={method}
+              onChange={(e) => setMethod(e.target.value)}
+            >
+              <option value="GET">GET</option>
+              <option value="POST">POST</option>
+              <option value="PUT">PUT</option>
+              <option value="DELETE">DELETE</option>
+              <option value="PATCH">PATCH</option>
+              <option value="HEAD">HEAD</option>
+            </select>
+          </div>
+
+          <div className="form-group">
+            <label>Path:</label>
+            <select
+              className="form-control"
+              value={path}
+              onChange={(e) => setPath(e.target.value)}
+            >
+              {predefinedPaths.map(p => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="form-group" style={{ marginBottom: "15px" }}>
+          <label>Custom Path:</label>
+          <input
+            className="form-control"
+            type="text"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            placeholder="/api/custom"
+          />
+        </div>
+
+        <div className="form-group" style={{ marginBottom: "15px" }}>
+          <label>Headers (JSON):</label>
+          <textarea
+            className="form-control textarea"
+            value={headers}
+            onChange={(e) => setHeaders(e.target.value)}
+            placeholder='{"Content-Type": "application/json"}'
+            rows={3}
+          />
+        </div>
+
+        {method !== "GET" && method !== "HEAD" && (
+          <div className="form-group" style={{ marginBottom: "15px" }}>
+            <label>Body:</label>
+            <textarea
+              className="form-control textarea"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Request body..."
+              rows={4}
+            />
+          </div>
+        )}
+
+        <div style={{ marginBottom: "15px" }}>
+          <button
+            className="btn btn-primary"
+            onClick={handleSendRequest}
+            disabled={isLoading}
+          >
+            {isLoading ? "Sending..." : "Send Request"}
+          </button>
+        </div>
+
+        <div style={{
+          background: "var(--bg-tertiary)",
+          border: "1px solid var(--border-secondary)",
+          borderRadius: "4px",
+          padding: "10px",
+          marginBottom: "15px",
+          fontSize: "13px"
+        }}>
+          <strong>Target URL:</strong> <code>{getActorUrl()}{path}</code>
+        </div>
+      </div>
+
+      <div className="section">
+        <h3>Example Requests</h3>
+        <div style={{ display: "flex", gap: "10px", flexWrap: "wrap", marginBottom: "15px" }}>
+          {exampleRequests.map(example => (
+            <button
+              key={example.name}
+              className="btn"
+              onClick={() => loadExample(example)}
+              style={{ fontSize: "12px" }}
+            >
+              {example.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {response && (
+        <div className="section">
+          <h3>Response</h3>
+          <div className="response">
+            {response}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/kitchen-sink-vercel/frontend/components/tabs/RawWebSocketTab.tsx
+++ b/examples/kitchen-sink-vercel/frontend/components/tabs/RawWebSocketTab.tsx
@@ -1,0 +1,332 @@
+import { useState, useEffect, useRef } from "react";
+import type { AppState } from "../../App.tsx";
+
+interface TabProps {
+  state: AppState;
+  updateState: (updates: Partial<AppState>) => void;
+  client: any;
+  actorHandle: any;
+}
+
+interface Message {
+  id: string;
+  type: "sent" | "received";
+  data: string;
+  timestamp: number;
+  isBinary: boolean;
+}
+
+export default function RawWebSocketTab({ state }: TabProps) {
+  const [message, setMessage] = useState('{"type": "ping", "timestamp": 0}');
+  const [isBinary, setIsBinary] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const [connectionStatus, setConnectionStatus] = useState("disconnected");
+  const [connectionError, setConnectionError] = useState("");
+
+  const websocketRef = useRef<WebSocket | null>(null);
+  const messageIdCounter = useRef(0);
+
+  const getWebSocketUrl = () => {
+    const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const actorPath = state.actorKey ?
+      `/actors/${state.actorName}/${encodeURIComponent(state.actorKey)}/ws` :
+      `/actors/${state.actorName}/ws`;
+      // FIXME: use clientEndpoint from metadata
+    return `${wsProtocol}//localhost:8080${actorPath}`;
+  };
+
+  const addMessage = (type: "sent" | "received", data: string, isBinary = false) => {
+    const message: Message = {
+      id: `msg-${++messageIdCounter.current}`,
+      type,
+      data,
+      timestamp: Date.now(),
+      isBinary,
+    };
+    setMessages(prev => [...prev, message].slice(-50)); // Keep last 50 messages
+  };
+
+  const connectWebSocket = () => {
+    if (websocketRef.current?.readyState === WebSocket.OPEN) {
+      return;
+    }
+
+    setConnectionStatus("connecting");
+    setConnectionError("");
+
+    try {
+      const ws = new WebSocket(getWebSocketUrl());
+      websocketRef.current = ws;
+
+      ws.onopen = () => {
+        setIsConnected(true);
+        setConnectionStatus("connected");
+        addMessage("received", "WebSocket connected", false);
+      };
+
+      ws.onmessage = (event) => {
+        const data = event.data;
+        const isBinary = data instanceof ArrayBuffer || data instanceof Blob;
+
+        if (isBinary) {
+          // Convert binary data to hex string for display
+          if (data instanceof Blob) {
+            data.arrayBuffer().then(ab => {
+              const bytes = new Uint8Array(ab);
+              const hex = Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(' ');
+              addMessage("received", `[Binary: ${bytes.length} bytes] ${hex}`, true);
+            });
+          } else {
+            const bytes = new Uint8Array(data);
+            const hex = Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(' ');
+            addMessage("received", `[Binary: ${bytes.length} bytes] ${hex}`, true);
+          }
+        } else {
+          addMessage("received", String(data), false);
+        }
+      };
+
+      ws.onclose = (event) => {
+        setIsConnected(false);
+        setConnectionStatus("disconnected");
+        addMessage("received", `WebSocket closed (code: ${event.code}, reason: ${event.reason})`, false);
+      };
+
+      ws.onerror = () => {
+        setConnectionError("WebSocket error occurred");
+        addMessage("received", "WebSocket error", false);
+      };
+    } catch (error) {
+      setConnectionError(error instanceof Error ? error.message : "Connection failed");
+      setConnectionStatus("disconnected");
+    }
+  };
+
+  const disconnectWebSocket = () => {
+    if (websocketRef.current) {
+      websocketRef.current.close();
+      websocketRef.current = null;
+    }
+  };
+
+  const sendMessage = () => {
+    if (!websocketRef.current || websocketRef.current.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    try {
+      if (isBinary) {
+        // Convert hex string to binary data
+        const hexString = message.replace(/\s/g, "");
+        const bytes = new Uint8Array(hexString.length / 2);
+        for (let i = 0; i < hexString.length; i += 2) {
+          bytes[i / 2] = parseInt(hexString.substr(i, 2), 16);
+        }
+        websocketRef.current.send(bytes);
+        addMessage("sent", `[Binary: ${bytes.length} bytes] ${hexString}`, true);
+      } else {
+        websocketRef.current.send(message);
+        addMessage("sent", message, false);
+      }
+    } catch (error) {
+      addMessage("received", `Send error: ${error instanceof Error ? error.message : String(error)}`, false);
+    }
+  };
+
+  const clearMessages = () => {
+    setMessages([]);
+  };
+
+  const formatTimestamp = (timestamp: number) => {
+    return new Date(timestamp).toLocaleTimeString();
+  };
+
+  // Update ping message timestamp
+  const updatePingTimestamp = () => {
+    if (message.includes('"timestamp"')) {
+      try {
+        const parsed = JSON.parse(message);
+        parsed.timestamp = Date.now();
+        setMessage(JSON.stringify(parsed, null, 2));
+      } catch {
+        // Not JSON, ignore
+      }
+    }
+  };
+
+  const exampleMessages = [
+    { name: "Ping", data: '{"type": "ping", "timestamp": 0}', binary: false },
+    { name: "Echo", data: '{"type": "echo", "message": "Hello WebSocket!"}', binary: false },
+    { name: "Get Stats", data: '{"type": "getStats"}', binary: false },
+    { name: "Binary Data", data: "48 65 6c 6c 6f", binary: true },
+  ];
+
+  const loadExample = (example: typeof exampleMessages[0]) => {
+    if (example.name === "Ping") {
+      const pingData = JSON.parse(example.data);
+      pingData.timestamp = Date.now();
+      setMessage(JSON.stringify(pingData, null, 2));
+    } else {
+      setMessage(example.data);
+    }
+    setIsBinary(example.binary);
+  };
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      disconnectWebSocket();
+    };
+  }, []);
+
+  return (
+    <div>
+      <div className="section">
+        <h3>WebSocket Connection</h3>
+
+        <div style={{ marginBottom: "15px" }}>
+          <div style={{
+            padding: "10px",
+            border: "1px solid #ddd",
+            borderRadius: "4px",
+            background: isConnected ? "#d4edda" : "#f8d7da",
+            color: isConnected ? "#155724" : "#721c24",
+            marginBottom: "10px"
+          }}>
+            Status: {connectionStatus === "connecting" ? "🟡 Connecting..." :
+                     isConnected ? "🟢 Connected" : "🔴 Disconnected"}
+            {connectionError && ` - ${connectionError}`}
+          </div>
+
+          <div style={{
+            fontSize: "13px",
+            color: "#666",
+            marginBottom: "10px"
+          }}>
+            Target: <code>{getWebSocketUrl()}</code>
+          </div>
+
+          <div style={{ display: "flex", gap: "10px" }}>
+            <button
+              className="btn btn-primary"
+              onClick={connectWebSocket}
+              disabled={isConnected || connectionStatus === "connecting"}
+            >
+              Connect
+            </button>
+            <button
+              className="btn"
+              onClick={disconnectWebSocket}
+              disabled={!isConnected}
+            >
+              Disconnect
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="section">
+        <h3>Send Message</h3>
+
+        <div className="form-group" style={{ marginBottom: "15px" }}>
+          <label>Message Type:</label>
+          <div className="toggle">
+            <button
+              className={!isBinary ? "active" : ""}
+              onClick={() => setIsBinary(false)}
+            >
+              Text/JSON
+            </button>
+            <button
+              className={isBinary ? "active" : ""}
+              onClick={() => setIsBinary(true)}
+            >
+              Binary (Hex)
+            </button>
+          </div>
+        </div>
+
+        <div className="form-group" style={{ marginBottom: "15px" }}>
+          <label>{isBinary ? "Binary Data (Hex):" : "Message (Text/JSON):"}</label>
+          <textarea
+            className="form-control textarea"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder={isBinary ? "48 65 6c 6c 6f (Hello in hex)" : '{"type": "ping"}'}
+            rows={4}
+          />
+        </div>
+
+        <div style={{ display: "flex", gap: "10px", marginBottom: "15px" }}>
+          <button
+            className="btn btn-primary"
+            onClick={sendMessage}
+            disabled={!isConnected || !message.trim()}
+          >
+            Send
+          </button>
+
+          {!isBinary && message.includes('"timestamp"') && (
+            <button
+              className="btn"
+              onClick={updatePingTimestamp}
+            >
+              Update Timestamp
+            </button>
+          )}
+        </div>
+
+        <div className="section">
+          <h4>Example Messages</h4>
+          <div style={{ display: "flex", gap: "10px", flexWrap: "wrap" }}>
+            {exampleMessages.map(example => (
+              <button
+                key={example.name}
+                className="btn"
+                onClick={() => loadExample(example)}
+                style={{ fontSize: "12px" }}
+              >
+                {example.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="section">
+        <h3>Message History ({messages.length})</h3>
+
+        <div style={{ marginBottom: "15px" }}>
+          <button
+            className="btn"
+            onClick={clearMessages}
+          >
+            Clear History
+          </button>
+        </div>
+
+        {messages.length === 0 ? (
+          <div style={{ textAlign: "center", color: "#666", padding: "20px" }}>
+            No messages yet. Connect and send a message to see the conversation.
+          </div>
+        ) : (
+          <div className="event-list">
+            {messages.map(msg => (
+              <div key={msg.id} className="event-item">
+                <span className="timestamp">{formatTimestamp(msg.timestamp)}</span>
+                <span className={`name ${msg.type === "sent" ? "sent" : "received"}`}>
+                  {msg.type === "sent" ? "→ SENT" : "← RECEIVED"}
+                  {msg.isBinary && " (BINARY)"}
+                </span>
+                <div style={{ marginTop: "5px", color: "#333", fontFamily: "monospace", fontSize: "12px" }}>
+                  {msg.data}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/kitchen-sink-vercel/frontend/components/tabs/ScheduleTab.tsx
+++ b/examples/kitchen-sink-vercel/frontend/components/tabs/ScheduleTab.tsx
@@ -1,0 +1,278 @@
+import { useState } from "react";
+import type { AppState } from "../../App.tsx";
+
+interface TabProps {
+  state: AppState;
+  updateState: (updates: Partial<AppState>) => void;
+  client: any;
+  actorHandle: any;
+}
+
+interface AlarmEntry {
+  id: string;
+  scheduledFor: number;
+  data?: any;
+  status: "scheduled" | "triggered";
+}
+
+export default function ScheduleTab({ state, actorHandle }: TabProps) {
+  const [atTimestamp, setAtTimestamp] = useState("");
+  const [afterDelay, setAfterDelay] = useState("5000");
+  const [alarmData, setAlarmData] = useState("{}");
+  const [response, setResponse] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [alarmHistory, setAlarmHistory] = useState<AlarmEntry[]>([]);
+
+  const getCurrentTimestamp = () => {
+    const now = new Date();
+    const offset = now.getTimezoneOffset() * 60000;
+    const localTime = new Date(now.getTime() - offset);
+    return localTime.toISOString().slice(0, 16);
+  };
+
+  const parseAlarmData = (dataString: string) => {
+    try {
+      return JSON.parse(dataString);
+    } catch {
+      return {};
+    }
+  };
+
+  const callAction = async (actionName: string, args: any[]) => {
+    return await actorHandle[actionName](...args);
+  };
+
+  const handleScheduleAt = async () => {
+    if (!atTimestamp) return;
+
+    setIsLoading(true);
+    setResponse("");
+
+    try {
+      const timestamp = new Date(atTimestamp).getTime();
+      const data = parseAlarmData(alarmData);
+
+      const result = await callAction("scheduleAlarmAt", [timestamp, data]);
+      setResponse(JSON.stringify(result, null, 2));
+
+      // Add to local tracking
+      setAlarmHistory(prev => [...prev, {
+        id: result.id,
+        scheduledFor: result.scheduledFor,
+        data,
+        status: "scheduled",
+      }]);
+    } catch (error) {
+      setResponse(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleScheduleAfter = async () => {
+    const delay = parseInt(afterDelay);
+    if (isNaN(delay) || delay < 0) return;
+
+    setIsLoading(true);
+    setResponse("");
+
+    try {
+      const data = parseAlarmData(alarmData);
+
+      const result = await callAction("scheduleAlarmAfter", [delay, data]);
+      setResponse(JSON.stringify(result, null, 2));
+
+      // Add to local tracking
+      setAlarmHistory(prev => [...prev, {
+        id: result.id,
+        scheduledFor: result.scheduledFor,
+        data,
+        status: "scheduled",
+      }]);
+    } catch (error) {
+      setResponse(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleGetHistory = async () => {
+    setIsLoading(true);
+    setResponse("");
+
+    try {
+      const result = await callAction("getAlarmHistory", []);
+      setResponse(JSON.stringify(result, null, 2));
+
+      // Update status of triggered alarms
+      const triggeredIds = result.map((entry: any) => entry.id);
+      setAlarmHistory(prev => prev.map(alarm => ({
+        ...alarm,
+        status: triggeredIds.includes(alarm.id) ? "triggered" : alarm.status,
+      })));
+    } catch (error) {
+      setResponse(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleClearHistory = async () => {
+    setIsLoading(true);
+    setResponse("");
+
+    try {
+      const result = await callAction("clearAlarmHistory", []);
+      setResponse(JSON.stringify(result, null, 2));
+      setAlarmHistory([]);
+    } catch (error) {
+      setResponse(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const formatTime = (timestamp: number) => {
+    return new Date(timestamp).toLocaleString();
+  };
+
+  if (state.actorName !== "demo") {
+    return (
+      <div className="section">
+        <h3>Scheduling</h3>
+        <p>Scheduling features are only available for the <code>demo</code> actor. Please select the demo actor in the header.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="section">
+        <h3>Schedule Alarm At Specific Time</h3>
+        <div className="form-grid">
+          <div className="form-group">
+            <label>Timestamp:</label>
+            <input
+              className="form-control"
+              type="datetime-local"
+              value={atTimestamp}
+              onChange={(e) => setAtTimestamp(e.target.value)}
+              min={getCurrentTimestamp()}
+            />
+          </div>
+
+          <div className="form-group">
+            <label>Alarm Data (JSON):</label>
+            <input
+              className="form-control"
+              type="text"
+              value={alarmData}
+              onChange={(e) => setAlarmData(e.target.value)}
+              placeholder='{"message": "Hello"}'
+            />
+          </div>
+
+          <button
+            className="btn btn-primary"
+            onClick={handleScheduleAt}
+            disabled={isLoading || !atTimestamp}
+          >
+            schedule.at()
+          </button>
+        </div>
+      </div>
+
+      <div className="section">
+        <h3>Schedule Alarm After Delay</h3>
+        <div className="form-grid">
+          <div className="form-group">
+            <label>Delay (ms):</label>
+            <input
+              className="form-control"
+              type="number"
+              value={afterDelay}
+              onChange={(e) => setAfterDelay(e.target.value)}
+              min="0"
+              step="1000"
+            />
+          </div>
+
+          <div className="form-group">
+            <label>Alarm Data (JSON):</label>
+            <input
+              className="form-control"
+              type="text"
+              value={alarmData}
+              onChange={(e) => setAlarmData(e.target.value)}
+              placeholder='{"message": "Hello"}'
+            />
+          </div>
+
+          <button
+            className="btn btn-primary"
+            onClick={handleScheduleAfter}
+            disabled={isLoading}
+          >
+            schedule.after()
+          </button>
+        </div>
+      </div>
+
+      <div className="section">
+        <h3>Alarm Management</h3>
+        <div style={{ display: "flex", gap: "10px", marginBottom: "15px" }}>
+          <button
+            className="btn"
+            onClick={handleGetHistory}
+            disabled={isLoading}
+          >
+            Get Alarm History
+          </button>
+          <button
+            className="btn"
+            onClick={handleClearHistory}
+            disabled={isLoading}
+          >
+            Clear History
+          </button>
+        </div>
+
+        {alarmHistory.length > 0 && (
+          <div>
+            <h4>Scheduled Alarms</h4>
+            <div style={{ marginBottom: "15px" }}>
+              {alarmHistory.map(alarm => (
+                <div
+                  key={alarm.id}
+                  style={{
+                    padding: "10px",
+                    border: "1px solid #ddd",
+                    borderRadius: "4px",
+                    marginBottom: "5px",
+                    background: alarm.status === "triggered" ? "#d4edda" : "#fff3cd",
+                  }}
+                >
+                  <strong>{alarm.id}</strong> - {alarm.status === "triggered" ? "✅ Triggered" : "⏰ Scheduled"}
+                  <br />
+                  Scheduled for: {formatTime(alarm.scheduledFor)}
+                  {alarm.data && Object.keys(alarm.data).length > 0 && (
+                    <>
+                      <br />
+                      Data: {JSON.stringify(alarm.data)}
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {response && (
+          <div className="response">
+            {response}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/kitchen-sink-vercel/frontend/components/tabs/SleepTab.tsx
+++ b/examples/kitchen-sink-vercel/frontend/components/tabs/SleepTab.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import type { AppState } from "../../App.tsx";
+
+interface TabProps {
+  state: AppState;
+  updateState: (updates: Partial<AppState>) => void;
+  client: any;
+  actorHandle: any;
+}
+
+export default function SleepTab({ state, actorHandle }: TabProps) {
+  const [response, setResponse] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const callAction = async (actionName: string, args: any[] = []) => {
+    return await actorHandle[actionName](...args);
+  };
+
+  const handleTriggerSleep = async () => {
+    setIsLoading(true);
+    setResponse("");
+
+    try {
+      const result = await callAction("triggerSleep");
+      setResponse(JSON.stringify(result, null, 2));
+    } catch (error) {
+      setResponse(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleGetLifecycleInfo = async () => {
+    setIsLoading(true);
+    setResponse("");
+
+    try {
+      const result = await callAction("getLifecycleInfo");
+      setResponse(JSON.stringify(result, null, 2));
+    } catch (error) {
+      setResponse(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (state.actorName !== "demo") {
+    return (
+      <div className="section">
+        <h3>Sleep & Lifecycle</h3>
+        <p>Sleep and lifecycle features are only available for the <code>demo</code> actor. Please select the demo actor in the header.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="section">
+        <h3>Force Sleep</h3>
+        <p style={{ marginBottom: "15px" }}>
+          The <code>sleep()</code> method forces an actor to go dormant immediately.
+          This is useful for testing actor lifecycle and persistence.
+        </p>
+
+        <button
+          className="btn btn-primary"
+          onClick={handleTriggerSleep}
+          disabled={isLoading}
+        >
+          {isLoading ? "Triggering..." : "Trigger Sleep"}
+        </button>
+      </div>
+
+      <div className="section">
+        <h3>Lifecycle Information</h3>
+        <p style={{ marginBottom: "15px" }}>
+          View how many times the actor has been started and stopped.
+          This demonstrates the actor lifecycle across sleep/wake cycles.
+        </p>
+
+        <button
+          className="btn"
+          onClick={handleGetLifecycleInfo}
+          disabled={isLoading}
+        >
+          Get Lifecycle Info
+        </button>
+      </div>
+
+      {response && (
+        <div className="section">
+          <h3>Response</h3>
+          <div className="response">
+            {response}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/kitchen-sink-vercel/frontend/index.css
+++ b/examples/kitchen-sink-vercel/frontend/index.css
@@ -1,0 +1,870 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', Roboto, sans-serif;
+  background: #000000;
+  color: #ffffff;
+  height: 100vh;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --primary-color: #007aff;
+  --primary-hover: #0056cc;
+  --primary-light: rgba(0, 122, 255, 0.1);
+  --success-color: #30d158;
+  --success-light: rgba(48, 209, 88, 0.1);
+  --danger-color: #ff3b30;
+  --danger-light: rgba(255, 59, 48, 0.1);
+  --warning-color: #ff9500;
+  --warning-light: rgba(255, 149, 0, 0.1);
+
+  --bg-primary: #000000;
+  --bg-secondary: #1c1c1e;
+  --bg-tertiary: #2c2c2e;
+  --bg-quaternary: #3a3a3c;
+
+  --text-primary: #ffffff;
+  --text-secondary: #8e8e93;
+  --text-tertiary: #64748b;
+
+  --border-primary: #2c2c2e;
+  --border-secondary: #3a3a3c;
+  --border-tertiary: #48484a;
+
+  --border-radius: 8px;
+  --border-radius-sm: 6px;
+  --border-radius-lg: 12px;
+  --border-radius-xl: 16px;
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.app {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+  background: var(--bg-primary);
+  overflow: hidden;
+}
+
+/* Legacy header styles removed - now using ConnectionScreen and InteractionScreen */
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.form-group label {
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-size: 14px;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.form-control {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--border-radius);
+  font-size: 14px;
+  transition: all 0.2s ease;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.form-control:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px var(--primary-light);
+}
+
+.form-control:hover {
+  border-color: var(--border-tertiary);
+}
+
+.form-control::placeholder {
+  color: var(--text-tertiary);
+  opacity: 0.6;
+}
+
+.toggle {
+  display: flex;
+  background: var(--bg-tertiary);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  border: 1px solid var(--border-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.toggle button {
+  padding: 8px 16px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  color: var(--text-secondary);
+}
+
+.toggle button:hover:not(.active) {
+  background: var(--bg-quaternary);
+  color: var(--text-primary);
+}
+
+.toggle button.active {
+  background: var(--primary-color);
+  color: white;
+}
+
+/* New toggle group styling */
+.toggle-group {
+  display: flex;
+  background: var(--bg-tertiary);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  border: 1px solid var(--border-secondary);
+  padding: 2px;
+  gap: 2px;
+}
+
+.toggle-button {
+  flex: 1;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  color: var(--text-secondary);
+  border-radius: calc(var(--border-radius) - 2px);
+  text-align: center;
+}
+
+.toggle-button:hover:not(.active) {
+  background: var(--bg-quaternary);
+  color: var(--text-primary);
+}
+
+.toggle-button.active {
+  background: var(--primary-color);
+  color: white;
+  box-shadow: 0 1px 3px rgba(0, 122, 255, 0.3);
+}
+
+.btn {
+  padding: 10px 20px;
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--border-radius);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  box-shadow: var(--shadow-sm);
+}
+
+.btn:hover {
+  background: var(--bg-quaternary);
+  border-color: var(--border-tertiary);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+
+.btn-primary {
+  background: var(--primary-color);
+  color: white;
+  border-color: var(--primary-color);
+  font-weight: 500;
+}
+
+.btn-primary:hover {
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
+  transform: translateY(-1px);
+}
+
+.btn-danger {
+  background: var(--danger-color);
+  color: white;
+  border-color: var(--danger-color);
+  font-weight: 500;
+}
+
+.btn-danger:hover {
+  background: #c82333;
+  border-color: #c82333;
+  transform: translateY(-1px);
+}
+
+.btn-secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--border-secondary);
+  font-weight: 500;
+}
+
+.btn-secondary:hover {
+  background: var(--bg-quaternary);
+  border-color: var(--border-tertiary);
+  transform: translateY(-1px);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  background: var(--bg-quaternary);
+  border-color: var(--border-secondary);
+  color: var(--text-secondary);
+}
+
+.status {
+  padding: 10px;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-top: 10px;
+}
+
+.status.connected {
+  background: var(--success-light);
+  color: #155724;
+  border: 1px solid #c3e6cb;
+  border-left: 4px solid var(--success-color);
+}
+
+.status.disconnected {
+  background: var(--danger-light);
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+  border-left: 4px solid var(--danger-color);
+}
+
+.tabs {
+  background: var(--bg-secondary);
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border-primary);
+  overflow: hidden;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.tab-list {
+  display: flex;
+  border-bottom: 1px solid var(--border-primary);
+  overflow-x: auto;
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+
+.tab-button {
+  padding: 16px 24px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  border-bottom: 3px solid transparent;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  color: var(--text-secondary);
+}
+
+.tab-button:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.tab-button.active {
+  border-bottom-color: var(--primary-color);
+  color: var(--primary-color);
+  background: var(--primary-light);
+}
+
+.tab-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tab-content {
+  padding: 20px;
+  background: var(--bg-primary);
+  flex: 1;
+  overflow-y: auto;
+}
+
+.section {
+  margin-bottom: 32px;
+  padding: 20px;
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--border-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.section:last-child {
+  margin-bottom: 0;
+}
+
+.section h3 {
+  margin: -20px -20px 20px -20px;
+  padding: 16px 20px;
+  color: var(--text-primary);
+  font-size: 18px;
+  font-weight: 600;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-primary);
+  border-radius: var(--border-radius) var(--border-radius) 0 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 15px;
+  margin-bottom: 15px;
+}
+
+.textarea {
+  min-height: 80px;
+  resize: vertical;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  line-height: 1.5;
+}
+
+.response {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--border-radius);
+  padding: 16px;
+  margin-top: 16px;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  max-height: 300px;
+  overflow-y: auto;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.4);
+  color: var(--text-primary);
+}
+
+.event-list {
+  max-height: 400px;
+  overflow-y: auto;
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--border-radius);
+  background: var(--bg-tertiary);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+.event-item {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-primary);
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  font-size: 13px;
+  line-height: 1.4;
+  transition: background-color 0.2s ease;
+  color: var(--text-primary);
+}
+
+.event-item:last-child {
+  border-bottom: none;
+}
+
+.event-item:hover {
+  background: var(--bg-secondary);
+}
+
+.event-item .timestamp {
+  color: var(--text-secondary);
+  margin-right: 12px;
+  font-size: 12px;
+}
+
+.event-item .name {
+  color: var(--primary-color);
+  font-weight: 600;
+  margin-right: 12px;
+}
+
+.event-item .name.sent {
+  color: var(--success-color);
+}
+
+.event-item .name.received {
+  color: var(--primary-color);
+}
+
+.disabled-content {
+  opacity: 0.5;
+  pointer-events: none;
+  filter: grayscale(20%);
+}
+
+/* Modern scrollbar styling */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--bg-quaternary);
+  border-radius: 3px;
+  transition: background 0.2s ease;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--border-tertiary);
+}
+
+/* Modern focus ring */
+*:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+/* Mobile responsive adjustments */
+@media (max-width: 768px) {
+  .app {
+    padding: 16px;
+  }
+
+  .form-group {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .form-group label {
+    min-width: auto;
+  }
+
+  .tab-list {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .section {
+    padding: 16px;
+    margin-bottom: 24px;
+  }
+
+  .section h3 {
+    margin: -16px -16px 16px -16px;
+    padding: 12px 16px;
+  }
+}
+
+/* Enhanced form controls and visual elements */
+select.form-control {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e");
+  background-position: right 8px center;
+  background-repeat: no-repeat;
+  background-size: 16px;
+  padding-right: 40px;
+  appearance: none;
+}
+
+/* Card-like sections with better visual hierarchy */
+.section:first-child {
+  margin-top: 0;
+}
+
+/* Enhanced status indicators */
+.status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: var(--border-radius-sm);
+  font-size: 14px;
+  font-weight: 500;
+  margin-top: 12px;
+}
+
+.status.connected::before {
+  content: '🟢';
+  font-size: 12px;
+}
+
+.status.disconnected::before {
+  content: '🔴';
+  font-size: 12px;
+}
+
+/* Modern toggle enhancements */
+.toggle button.active {
+  background: var(--primary-color);
+  color: white;
+  box-shadow: 0 2px 4px rgba(0, 123, 255, 0.3);
+}
+
+.toggle button:hover:not(.active) {
+  background: var(--bg-quaternary);
+  color: var(--text-primary);
+}
+
+/* Enhanced buttons */
+.btn-primary:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 3px rgba(0, 123, 255, 0.3);
+}
+
+.btn-danger:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 3px rgba(220, 53, 69, 0.3);
+}
+
+/* Code and monospace improvements */
+code {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  font-size: 0.9em;
+}
+
+pre {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--border-radius-sm);
+  padding: 16px;
+  overflow-x: auto;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+/* Loading states */
+.btn[aria-busy="true"] {
+  position: relative;
+  color: transparent;
+}
+
+.btn[aria-busy="true"]::after {
+  content: '';
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  top: 50%;
+  left: 50%;
+  margin-left: -8px;
+  margin-top: -8px;
+  border: 2px solid transparent;
+  border-top: 2px solid white;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+/* Form grid improvements */
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+@media (max-width: 768px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+}
+
+/* Connection Screen Styles */
+.connection-screen {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  width: 100%;
+  height: 100%;
+}
+
+.connection-modal {
+  max-width: 500px;
+  width: 100%;
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--border-primary);
+  overflow: hidden;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-header {
+  padding: 24px 24px 0 24px;
+  text-align: center;
+}
+
+.modal-header h1 {
+  margin: 0 0 8px 0;
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.modal-header p {
+  margin: 0 0 24px 0;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.modal-content {
+  padding: 0 24px 24px 24px;
+}
+
+.method-toggle {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.method-toggle .toggle-button {
+  font-size: 13px;
+  padding: 8px 8px;
+  white-space: nowrap;
+}
+
+.form-section {
+  margin-bottom: 24px;
+}
+
+.form-section:last-child {
+  margin-bottom: 0;
+}
+
+.form-section h3 {
+  margin: 0 0 16px 0;
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--border-primary);
+  padding-bottom: 8px;
+}
+
+.modal-actions {
+  text-align: center;
+  padding-top: 24px;
+  border-top: 1px solid var(--border-primary);
+}
+
+.connect-button {
+  font-size: 16px;
+  padding: 12px 32px;
+  font-weight: 600;
+  min-width: 160px;
+}
+
+.actor-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.actor-actions .btn {
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+/* Interaction Modal Styles */
+.interaction-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 2000;
+}
+
+.interaction-modal {
+  display: flex;
+  flex-direction: column;
+  width: 90vw;
+  max-width: 1400px;
+  height: 85vh;
+  background: var(--bg-primary);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--border-primary);
+  overflow: hidden;
+}
+
+.interaction-header {
+  background: var(--bg-secondary);
+  padding: 20px;
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.connection-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+}
+
+.connection-details h2 {
+  margin: 0 0 8px 0;
+  color: var(--text-primary);
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.connection-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.actor-name {
+  background: var(--primary-color);
+  color: white;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-weight: 500;
+  font-size: 14px;
+}
+
+.actor-key {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  padding: 4px 10px;
+  border-radius: 16px;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  font-size: 13px;
+}
+
+.transport-info {
+  background: var(--success-light);
+  color: var(--success-color);
+  padding: 4px 10px;
+  border-radius: 16px;
+  font-weight: 500;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.mode-info {
+  padding: 4px 10px;
+  border-radius: 16px;
+  font-weight: 500;
+  font-size: 13px;
+}
+
+.mode-info.connection {
+  background: var(--primary-light);
+  color: var(--primary-color);
+}
+
+.mode-info.handle {
+  background: var(--warning-light);
+  color: var(--warning-color);
+}
+
+.connection-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+/* Mobile responsive adjustments for new screens */
+@media (max-width: 768px) {
+  .connection-screen {
+    padding: 16px;
+  }
+
+  .connection-modal {
+    max-width: none;
+    width: 100%;
+    max-height: 95vh;
+  }
+
+  .modal-header {
+    padding: 20px 20px 0 20px;
+  }
+
+  .modal-header h1 {
+    font-size: 20px;
+  }
+
+  .modal-content {
+    padding: 0 20px 20px 20px;
+  }
+
+  .form-section {
+    margin-bottom: 20px;
+  }
+
+  .actor-actions {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .method-toggle {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 4px;
+  }
+
+  .method-toggle .toggle-button {
+    font-size: 12px;
+    padding: 8px 6px;
+  }
+
+  .connection-info {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .connection-actions {
+    justify-content: center;
+  }
+
+  .connection-meta {
+    justify-content: center;
+  }
+
+  .interaction-modal-overlay {
+    padding: 16px;
+  }
+
+  .interaction-modal {
+    width: 100%;
+    height: 90vh;
+    max-width: none;
+  }
+}

--- a/examples/kitchen-sink-vercel/frontend/main.tsx
+++ b/examples/kitchen-sink-vercel/frontend/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.tsx'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/examples/kitchen-sink-vercel/index.html
+++ b/examples/kitchen-sink-vercel/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RivetKit Kitchen Sink</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+  </body>
+</html>

--- a/examples/kitchen-sink-vercel/package.json
+++ b/examples/kitchen-sink-vercel/package.json
@@ -1,0 +1,37 @@
+{
+	"name": "example-kitchen-sink-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.7.4",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.66",
+		"@types/react-dom": "^18.2.22",
+		"@vitejs/plugin-react": "^4.2.1",
+		"tsx": "^4.7.1",
+		"typescript": "^5.2.2",
+		"vite": "^5.2.0"
+	},
+	"template": {
+		"technologies": [
+			"typescript"
+		],
+		"tags": [],
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/kitchen-sink-vercel/src/actors.ts
+++ b/examples/kitchen-sink-vercel/src/actors.ts
@@ -1,0 +1,10 @@
+import { setup } from "rivetkit";
+import { demo } from "./actors/demo.ts";
+
+export const registry = setup({
+	use: {
+		demo,
+	},
+});
+
+export type Registry = typeof registry;

--- a/examples/kitchen-sink-vercel/src/actors/demo.ts
+++ b/examples/kitchen-sink-vercel/src/actors/demo.ts
@@ -1,0 +1,162 @@
+import { actor } from "rivetkit";
+import { handleHttpRequest, httpActions } from "./http.ts";
+import { handleWebSocket, websocketActions } from "./websocket.ts";
+
+export const demo = actor({
+	createState: (_c, input) => ({
+		input,
+		count: 0,
+		lastMessage: "",
+		alarmHistory: [] as { id: string; time: number; data?: any }[],
+		startCount: 0,
+		stopCount: 0,
+	}),
+	connState: {
+		connectionTime: 0,
+	},
+	onWake: (c) => {
+		c.state.startCount += 1;
+		c.log.info({
+			msg: "demo actor started",
+			startCount: c.state.startCount,
+		});
+	},
+	onSleep: (c) => {
+		c.state.stopCount += 1;
+		c.log.info({ msg: "demo actor stopped", stopCount: c.state.stopCount });
+	},
+	onConnect: (c, conn) => {
+		conn.state.connectionTime = Date.now();
+		c.log.info({
+			msg: "client connected",
+			connectionTime: conn.state.connectionTime,
+		});
+	},
+	onDisconnect: (c) => {
+		c.log.info("client disconnected");
+	},
+	onRequest: handleHttpRequest,
+	onWebSocket: handleWebSocket,
+	actions: {
+		// Sync actions
+		increment: (c, amount: number = 1) => {
+			c.state.count += amount;
+			c.broadcast("countChanged", { count: c.state.count, amount });
+			return c.state.count;
+		},
+		getCount: (c) => {
+			return c.state.count;
+		},
+		setMessage: (c, message: string) => {
+			c.state.lastMessage = message;
+			c.broadcast("messageChanged", { message });
+			return message;
+		},
+
+		// Async actions
+		delayedIncrement: async (
+			c,
+			amount: number = 1,
+			delayMs: number = 1000,
+		) => {
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+			c.state.count += amount;
+			c.broadcast("countChanged", { count: c.state.count, amount });
+			return c.state.count;
+		},
+
+		// Promise action
+		promiseAction: () => {
+			return Promise.resolve({
+				timestamp: Date.now(),
+				message: "promise resolved",
+			});
+		},
+
+		// State management
+		getState: (c) => {
+			return {
+				actorState: c.state,
+				connectionState: c.conn.state,
+			};
+		},
+
+		// Scheduling
+		scheduleAlarmAt: (c, timestamp: number, data?: any) => {
+			const id = `alarm-${Date.now()}`;
+			c.schedule.at(timestamp, "onAlarm", { id, data });
+			return { id, scheduledFor: timestamp };
+		},
+		scheduleAlarmAfter: (c, delayMs: number, data?: any) => {
+			const id = `alarm-${Date.now()}`;
+			c.schedule.after(delayMs, "onAlarm", { id, data });
+			return { id, scheduledFor: Date.now() + delayMs };
+		},
+		onAlarm: (c, payload: { id: string; data?: any }) => {
+			const alarmEntry = { ...payload, time: Date.now() };
+			c.state.alarmHistory.push(alarmEntry);
+			c.broadcast("alarmTriggered", alarmEntry);
+			c.log.info({ msg: "alarm triggered", ...alarmEntry });
+		},
+		getAlarmHistory: (c) => {
+			return c.state.alarmHistory;
+		},
+		clearAlarmHistory: (c) => {
+			c.state.alarmHistory = [];
+			return true;
+		},
+
+		// Sleep
+		triggerSleep: (c) => {
+			c.sleep();
+			return "sleep triggered";
+		},
+
+		// Lifecycle info
+		getLifecycleInfo: (c) => {
+			return {
+				startCount: c.state.startCount,
+				stopCount: c.state.stopCount,
+			};
+		},
+
+		// Metadata
+		getMetadata: (c) => {
+			return {
+				name: c.name,
+			};
+		},
+		getInput: (c) => {
+			return c.state.input;
+		},
+		getActorState: (c) => {
+			return c.state;
+		},
+		getConnState: (c) => {
+			return c.conn.state;
+		},
+
+		// Events
+		broadcastCustomEvent: (c, eventName: string, data: any) => {
+			c.broadcast(eventName, data);
+			return { eventName, data, timestamp: Date.now() };
+		},
+
+		// Connections
+		listConnections: (c) => {
+			return Array.from(c.conns.values()).map((conn) => ({
+				id: conn.id,
+				connectedAt: conn.state.connectionTime,
+			}));
+		},
+
+		// HTTP actions
+		...httpActions,
+
+		// WebSocket actions
+		...websocketActions,
+	},
+	options: {
+		sleepTimeout: 5_000,
+	},
+});

--- a/examples/kitchen-sink-vercel/src/actors/http.ts
+++ b/examples/kitchen-sink-vercel/src/actors/http.ts
@@ -1,0 +1,149 @@
+import type { ActorContext } from "rivetkit";
+
+export function handleHttpRequest(
+	c: ActorContext<any, any, any, any, any, any>,
+	request: Request,
+) {
+	const url = new URL(request.url);
+	const method = request.method;
+	const path = url.pathname;
+
+	// Track request
+	if (!c.state.requestCount) c.state.requestCount = 0;
+	if (!c.state.requestHistory) c.state.requestHistory = [];
+
+	c.state.requestCount++;
+	c.state.requestHistory.push({
+		method,
+		path,
+		timestamp: Date.now(),
+		headers: Object.fromEntries(request.headers.entries()),
+	});
+
+	c.log.info({
+		msg: "http request received",
+		method,
+		path,
+		fullUrl: request.url,
+		requestCount: c.state.requestCount,
+	});
+
+	// Handle different endpoints
+	if (path === "/api/hello") {
+		return new Response(
+			JSON.stringify({
+				message: "Hello from HTTP actor!",
+				timestamp: Date.now(),
+				requestCount: c.state.requestCount,
+			}),
+			{
+				headers: { "Content-Type": "application/json" },
+			},
+		);
+	}
+
+	if (path === "/api/echo" && method === "POST") {
+		return new Response(request.body, {
+			headers: {
+				"Content-Type":
+					request.headers.get("Content-Type") || "text/plain",
+				"X-Echo-Timestamp": Date.now().toString(),
+			},
+		});
+	}
+
+	if (path === "/api/stats") {
+		return new Response(
+			JSON.stringify({
+				requestCount: c.state.requestCount,
+				requestHistory: c.state.requestHistory.slice(-10), // Last 10 requests
+			}),
+			{
+				headers: { "Content-Type": "application/json" },
+			},
+		);
+	}
+
+	if (path === "/api/headers") {
+		const headers = Object.fromEntries(request.headers.entries());
+		return new Response(
+			JSON.stringify({
+				headers,
+				method,
+				path,
+				timestamp: Date.now(),
+			}),
+			{
+				headers: { "Content-Type": "application/json" },
+			},
+		);
+	}
+
+	if (path === "/api/json" && method === "POST") {
+		return request.json().then((body) => {
+			return new Response(
+				JSON.stringify({
+					received: body,
+					method,
+					timestamp: Date.now(),
+					processed: true,
+				}),
+				{
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		});
+	}
+
+	// Handle custom paths with query parameters
+	if (path.startsWith("/api/custom")) {
+		const searchParams = Object.fromEntries(url.searchParams.entries());
+		return new Response(
+			JSON.stringify({
+				path,
+				method,
+				queryParams: searchParams,
+				timestamp: Date.now(),
+				message: "Custom endpoint response",
+			}),
+			{
+				headers: { "Content-Type": "application/json" },
+			},
+		);
+	}
+
+	// Return 404 for unhandled paths
+	return new Response(
+		JSON.stringify({
+			error: "Not Found",
+			path,
+			method,
+			availableEndpoints: [
+				"/api/hello",
+				"/api/echo",
+				"/api/stats",
+				"/api/headers",
+				"/api/json",
+				"/api/custom/*",
+			],
+		}),
+		{
+			status: 404,
+			headers: { "Content-Type": "application/json" },
+		},
+	);
+}
+
+export const httpActions = {
+	getHttpStats: (c: any) => {
+		return {
+			requestCount: c.state.requestCount || 0,
+			requestHistory: c.state.requestHistory || [],
+		};
+	},
+	clearHttpHistory: (c: any) => {
+		c.state.requestHistory = [];
+		c.state.requestCount = 0;
+		return true;
+	},
+};

--- a/examples/kitchen-sink-vercel/src/actors/websocket.ts
+++ b/examples/kitchen-sink-vercel/src/actors/websocket.ts
@@ -1,0 +1,190 @@
+import type { UniversalWebSocket } from "rivetkit";
+
+export function handleWebSocket(c: any, websocket: UniversalWebSocket) {
+	const connectionId = `conn-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+	// Initialize WebSocket state if not exists
+	if (!c.state.connectionCount) c.state.connectionCount = 0;
+	if (!c.state.messageCount) c.state.messageCount = 0;
+	if (!c.state.messageHistory) c.state.messageHistory = [];
+
+	c.state.connectionCount++;
+	c.log.info("websocket connected", {
+		connectionCount: c.state.connectionCount,
+		connectionId,
+		url: c.request.url,
+	});
+
+	// Send welcome message
+	const welcomeMessage = JSON.stringify({
+		type: "welcome",
+		connectionId,
+		connectionCount: c.state.connectionCount,
+		timestamp: Date.now(),
+	});
+
+	websocket.send(welcomeMessage);
+	c.state.messageHistory.push({
+		type: "sent",
+		data: welcomeMessage,
+		timestamp: Date.now(),
+		connectionId,
+	});
+
+	// Handle incoming messages
+	websocket.addEventListener("message", (event: any) => {
+		c.state.messageCount++;
+		const timestamp = Date.now();
+
+		c.log.info("websocket message received", {
+			messageCount: c.state.messageCount,
+			connectionId,
+			dataType: typeof event.data,
+		});
+
+		// Record received message
+		c.state.messageHistory.push({
+			type: "received",
+			data: event.data,
+			timestamp,
+			connectionId,
+		});
+
+		const data = event.data;
+
+		if (typeof data === "string") {
+			try {
+				const parsed = JSON.parse(data);
+
+				if (parsed.type === "ping") {
+					const pongMessage = JSON.stringify({
+						type: "pong",
+						timestamp,
+						originalTimestamp: parsed.timestamp,
+					});
+					websocket.send(pongMessage);
+					c.state.messageHistory.push({
+						type: "sent",
+						data: pongMessage,
+						timestamp,
+						connectionId,
+					});
+				} else if (parsed.type === "echo") {
+					const echoMessage = JSON.stringify({
+						type: "echo-response",
+						originalMessage: parsed.message,
+						timestamp,
+					});
+					websocket.send(echoMessage);
+					c.state.messageHistory.push({
+						type: "sent",
+						data: echoMessage,
+						timestamp,
+						connectionId,
+					});
+				} else if (parsed.type === "getStats") {
+					const statsMessage = JSON.stringify({
+						type: "stats",
+						connectionCount: c.state.connectionCount,
+						messageCount: c.state.messageCount,
+						timestamp,
+					});
+					websocket.send(statsMessage);
+					c.state.messageHistory.push({
+						type: "sent",
+						data: statsMessage,
+						timestamp,
+						connectionId,
+					});
+				} else if (parsed.type === "broadcast") {
+					// Broadcast to all connections would need additional infrastructure
+					const broadcastResponse = JSON.stringify({
+						type: "broadcast-ack",
+						message: parsed.message,
+						timestamp,
+					});
+					websocket.send(broadcastResponse);
+					c.state.messageHistory.push({
+						type: "sent",
+						data: broadcastResponse,
+						timestamp,
+						connectionId,
+					});
+				} else {
+					// Echo back unknown JSON messages
+					websocket.send(data);
+					c.state.messageHistory.push({
+						type: "sent",
+						data: data,
+						timestamp,
+						connectionId,
+					});
+				}
+			} catch {
+				// If not JSON, just echo it back
+				websocket.send(data);
+				c.state.messageHistory.push({
+					type: "sent",
+					data: data,
+					timestamp,
+					connectionId,
+				});
+			}
+		} else if (data instanceof ArrayBuffer || data instanceof Uint8Array) {
+			// Handle binary data - reverse the bytes
+			const bytes = new Uint8Array(data);
+			const reversed = new Uint8Array(bytes.length);
+			for (let i = 0; i < bytes.length; i++) {
+				reversed[i] = bytes[bytes.length - 1 - i];
+			}
+			websocket.send(reversed);
+			c.state.messageHistory.push({
+				type: "sent",
+				data: `[Binary: ${reversed.length} bytes - reversed]`,
+				timestamp,
+				connectionId,
+			});
+		} else {
+			// Echo other data types
+			websocket.send(data);
+			c.state.messageHistory.push({
+				type: "sent",
+				data: data,
+				timestamp,
+				connectionId,
+			});
+		}
+	});
+
+	// Handle connection close
+	websocket.addEventListener("close", () => {
+		c.state.connectionCount--;
+		c.log.info("websocket disconnected", {
+			connectionCount: c.state.connectionCount,
+			connectionId,
+		});
+	});
+
+	// Handle errors
+	websocket.addEventListener("error", (error: any) => {
+		c.log.error("websocket error", { error: error.message, connectionId });
+	});
+}
+
+export const websocketActions = {
+	getWebSocketStats: (c: any) => {
+		return {
+			connectionCount: c.state.connectionCount || 0,
+			messageCount: c.state.messageCount || 0,
+			messageHistory: (c.state.messageHistory || []).slice(-50), // Last 50 messages
+		};
+	},
+	clearWebSocketHistory: (c: any) => {
+		c.state.messageHistory = [];
+		c.state.messageCount = 0;
+		return true;
+	},
+	getWebSocketMessageHistory: (c: any, limit: number = 20) => {
+		return (c.state.messageHistory || []).slice(-limit);
+	},
+};

--- a/examples/kitchen-sink-vercel/src/server.ts
+++ b/examples/kitchen-sink-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/kitchen-sink-vercel/tsconfig.json
+++ b/examples/kitchen-sink-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/kitchen-sink-vercel/tsconfig.node.json
+++ b/examples/kitchen-sink-vercel/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+	"compilerOptions": {
+		"composite": true,
+		"skipLibCheck": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"allowSyntheticDefaultImports": true
+	},
+	"include": ["vite.config.ts"]
+}

--- a/examples/kitchen-sink-vercel/turbo.json
+++ b/examples/kitchen-sink-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/kitchen-sink-vercel/vercel.json
+++ b/examples/kitchen-sink-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/kitchen-sink-vercel/vite.config.ts
+++ b/examples/kitchen-sink-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/kitchen-sink/vercel.json
+++ b/examples/kitchen-sink/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/multi-region-vercel/.gitignore
+++ b/examples/multi-region-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/multi-region-vercel/README.md
+++ b/examples/multi-region-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [multi-region](../multi-region) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fmulti-region-vercel&project-name=multi-region-vercel)
+
+# Multi-Region
+
+Demonstrates deploying Rivet Actors across multiple geographic regions for low-latency global access.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/multi-region
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Multi-region deployment**: Deploy actors across multiple geographic regions automatically
+- **Low-latency access**: Users connect to the nearest region for optimal performance
+- **Automatic routing**: Requests automatically routed to the appropriate regional deployment
+- **Global state management**: Actor state synchronized across regions as needed
+
+## Implementation
+
+This example demonstrates deploying actors across multiple regions:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/multi-region/src/backend/registry.ts)): Shows configuration for multi-region actor deployment
+
+## Resources
+
+Read more about [actions](/docs/actors/actions), [state](/docs/actors/state), and [setup](/docs/setup).
+
+## License
+
+MIT

--- a/examples/multi-region-vercel/api/index.ts
+++ b/examples/multi-region-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/multi-region-vercel/frontend/App.tsx
+++ b/examples/multi-region-vercel/frontend/App.tsx
@@ -1,0 +1,260 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useEffect, useState } from "react";
+import type { Player, registry } from "../src/actors.ts";
+
+const { useActor } = createRivetKit<typeof registry>(`${window.location.origin}/api/rivet`);
+
+export function App() {
+	const [region, setRegion] = useState("us-east");
+	const [players, setPlayers] = useState<Record<string, Player>>({});
+	const [myPlayerId, setMyPlayerId] = useState<string | null>(null);
+	const [latency, setLatency] = useState<number>(0);
+	const [currentRegion, setCurrentRegion] = useState<string>("");
+
+	// Pass region parameter to useActor - this demonstrates multi-region deployment
+	const actor = useActor({
+		name: "gameRoom",
+		key: ["main"],
+		// createInRegion isolates actor instances by region
+		createInRegion: region,
+		// createWithInput parameter is passed to createState
+		createWithInput: { region },
+	});
+
+	// Track connection and get initial state
+	useEffect(() => {
+		if (!actor.connection) return;
+
+		// Fetch initial game state
+		actor.connection
+			.getGameState()
+			.then((state: { players: Record<string, Player>; region: string }) => {
+				setPlayers(state.players);
+				setCurrentRegion(state.region);
+				// Set my player ID to one of the players (we'll update this when playerJoined event fires)
+				const playerIds = Object.keys(state.players);
+				if (playerIds.length > 0 && !myPlayerId) {
+					setMyPlayerId(playerIds[playerIds.length - 1]);
+				}
+			})
+			.catch((err: unknown) => console.error("Failed to get game state:", err));
+	}, [actor.connection, myPlayerId]);
+
+	// Handle keyboard input for movement
+	useEffect(() => {
+		if (!actor.connection) return;
+
+		const handleKeyDown = (e: KeyboardEvent) => {
+			let dx = 0;
+			let dy = 0;
+
+			switch (e.key) {
+				case "w":
+				case "ArrowUp":
+					dy = -10;
+					break;
+				case "s":
+				case "ArrowDown":
+					dy = 10;
+					break;
+				case "a":
+				case "ArrowLeft":
+					dx = -10;
+					break;
+				case "d":
+				case "ArrowRight":
+					dx = 10;
+					break;
+			}
+
+			if (dx !== 0 || dy !== 0) {
+				const startTime = Date.now();
+				actor.connection
+					?.move(dx, dy)
+					.then(() => {
+						// Calculate round-trip latency
+						setLatency(Date.now() - startTime);
+					})
+					.catch((err: unknown) => console.error("Move failed:", err));
+			}
+		};
+
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [actor.connection]);
+
+	// Listen for player joined event
+	actor.useEvent(
+		"playerJoined",
+		({ playerId, player }: { playerId: string; player: Player }) => {
+			setPlayers((prev) => ({ ...prev, [playerId]: player }));
+			// Set our player ID if we don't have one yet
+			if (!myPlayerId) {
+				setMyPlayerId(playerId);
+			}
+		},
+	);
+
+	// Listen for player left event
+	actor.useEvent("playerLeft", ({ playerId }: { playerId: string }) => {
+		setPlayers((prev) => {
+			const newPlayers = { ...prev };
+			delete newPlayers[playerId];
+			return newPlayers;
+		});
+	});
+
+	// Listen for player movement
+	actor.useEvent(
+		"playerMoved",
+		({ playerId, x, y }: { playerId: string; x: number; y: number }) => {
+			setPlayers((prev) => {
+				const player = prev[playerId];
+				if (!player) return prev;
+				return {
+					...prev,
+					[playerId]: { ...player, x, y, lastUpdate: Date.now() },
+				};
+			});
+		},
+	);
+
+	// Handle region change
+	const handleRegionChange = (newRegion: string) => {
+		setRegion(newRegion);
+		setPlayers({});
+		setMyPlayerId(null);
+	};
+
+	const playerCount = Object.keys(players).length;
+
+	return (
+		<div className="app-container">
+			<div className="connection-status-wrapper">
+				<div
+					className={`connection-status ${actor.connection ? "connected" : "disconnected"}`}
+				>
+					{actor.connection ? "Connected" : "Disconnected"}
+				</div>
+			</div>
+
+			<div className="header">
+				<h1>Quickstart: Multi-Region</h1>
+				<p>Multiplayer game demonstrating multi-region deployment</p>
+			</div>
+
+			<div className="info-box">
+				<h3>Multi-Region Deployment</h3>
+				<p>
+					Select a region below to connect to a game room in that region. Each
+					region has its own isolated set of actors, allowing players to connect
+					to servers closer to them for lower latency.
+				</p>
+			</div>
+
+			<div className="region-selector">
+				<label>
+					<strong>Select Region:</strong>
+				</label>
+				<select value={region} onChange={(e) => handleRegionChange(e.target.value)}>
+					<option value="us-east">US East</option>
+					<option value="eu-west">EU West</option>
+					<option value="ap-south">AP South</option>
+				</select>
+			</div>
+
+			<div className="region-info">
+				<div className="info-card">
+					<strong>Current Region:</strong> {currentRegion || region}
+				</div>
+				<div className="info-card">
+					<strong>Players in Region:</strong> {playerCount}
+				</div>
+				<div className="info-card">
+					<strong>Latency:</strong> {latency}ms
+				</div>
+			</div>
+
+			<div className="game-area">
+				<svg
+					width="600"
+					height="600"
+					className="game-canvas"
+					viewBox="0 0 1000 1000"
+				>
+					{/* Grid background */}
+					<defs>
+						<pattern
+							id="grid"
+							width="100"
+							height="100"
+							patternUnits="userSpaceOnUse"
+						>
+							<path
+								d="M 100 0 L 0 0 0 100"
+								fill="none"
+								stroke="#e0e0e0"
+								strokeWidth="1"
+							/>
+						</pattern>
+					</defs>
+					<rect width="1000" height="1000" fill="url(#grid)" />
+					<rect
+						width="1000"
+						height="1000"
+						fill="none"
+						stroke="#333"
+						strokeWidth="3"
+					/>
+
+					{/* Render all players */}
+					{Object.values(players).map((player) => {
+						const isMe = player.id === myPlayerId;
+						return (
+							<g key={player.id}>
+								{/* Player shadow */}
+								<circle
+									cx={player.x + 2}
+									cy={player.y + 2}
+									r="12"
+									fill="rgba(0,0,0,0.2)"
+								/>
+								{/* Player */}
+								<circle
+									cx={player.x}
+									cy={player.y}
+									r="10"
+									fill={player.color}
+									stroke="#333"
+									strokeWidth="2"
+								/>
+								{/* Player label */}
+								<text
+									x={player.x}
+									y={player.y - 15}
+									textAnchor="middle"
+									fontSize="12"
+									fill="#333"
+									fontWeight={isMe ? "bold" : "normal"}
+								>
+									{isMe ? "YOU" : player.id.substring(0, 8)}
+								</text>
+							</g>
+						);
+					})}
+				</svg>
+			</div>
+
+			<div className="controls">
+				<p>
+					<strong>Controls:</strong>
+				</p>
+				<p>Move: WASD or Arrow Keys</p>
+				<p>
+					Each region has its own isolated game rooms. Players in different
+					regions cannot see each other.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/examples/multi-region-vercel/frontend/main.tsx
+++ b/examples/multi-region-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/multi-region-vercel/index.html
+++ b/examples/multi-region-vercel/index.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quickstart: Multi-Region</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f0f0f0;
+        }
+        .app-container {
+            max-width: 800px;
+            margin: 0 auto;
+            background-color: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .header h1 {
+            color: #333;
+            margin: 0;
+        }
+        .header p {
+            color: #666;
+            margin: 10px 0;
+        }
+        .info-box {
+            background-color: #e8f4f8;
+            border: 1px solid #b8d4da;
+            border-radius: 6px;
+            padding: 15px;
+            margin-bottom: 20px;
+        }
+        .info-box h3 {
+            margin: 0 0 10px 0;
+            color: #2c5aa0;
+        }
+        .info-box p {
+            margin: 0;
+            color: #555;
+            line-height: 1.5;
+        }
+        .region-selector {
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        .region-selector label {
+            margin-right: 10px;
+            color: #333;
+        }
+        .region-selector select {
+            padding: 8px 12px;
+            font-size: 14px;
+            border: 2px solid #4287f5;
+            border-radius: 4px;
+            background-color: white;
+            cursor: pointer;
+        }
+        .region-info {
+            display: flex;
+            justify-content: space-around;
+            gap: 10px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+        .info-card {
+            background-color: #f9f9f9;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            padding: 10px 15px;
+            text-align: center;
+            flex: 1;
+            min-width: 150px;
+        }
+        .info-card strong {
+            color: #333;
+            display: block;
+            margin-bottom: 5px;
+        }
+        .game-area {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .game-canvas {
+            border: 3px solid #333;
+            border-radius: 8px;
+            background-color: #fafafa;
+            max-width: 100%;
+            height: auto;
+        }
+        .controls {
+            margin-top: 20px;
+            text-align: center;
+        }
+        .controls p {
+            margin: 5px 0;
+            font-size: 14px;
+            color: #555;
+        }
+        .connection-status-wrapper {
+            position: relative;
+            height: 0;
+        }
+        .connection-status {
+            position: absolute;
+            top: -10px;
+            right: -10px;
+            padding: 8px 12px;
+            border-radius: 4px;
+            font-size: 14px;
+            font-weight: bold;
+        }
+        .connection-status.connected {
+            background-color: #d4edda;
+            color: #155724;
+        }
+        .connection-status.disconnected {
+            background-color: #f8d7da;
+            color: #721c24;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/multi-region-vercel/package.json
+++ b/examples/multi-region-vercel/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "multi-region-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.7.4",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"typescript"
+		],
+		"tags": [],
+		"priority": 1000,
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/multi-region-vercel/src/actors.ts
+++ b/examples/multi-region-vercel/src/actors.ts
@@ -1,0 +1,116 @@
+import { actor, setup } from "rivetkit";
+import type { Player } from "./types.ts";
+
+export type { Player };
+
+interface State {
+	players: Record<string, Player>;
+	region: string;
+}
+
+const gameRoom = actor({
+	// Create initial state with region parameter
+	createState: (_c, input: { region: string }): State => ({
+		players: {} as Record<string, Player>,
+		region: input.region,
+	}),
+
+	// Connection state - tracks which player belongs to each connection
+	connState: {
+		playerId: null as string | null,
+	},
+
+	// Handle client connections
+	onConnect: (c, conn) => {
+		// Generate a unique player ID
+		const playerId = conn.id;
+
+		// Generate random color for player
+		const colors = [
+			"#FF6B6B",
+			"#4ECDC4",
+			"#45B7D1",
+			"#FFA07A",
+			"#98D8C8",
+			"#F7DC6F",
+			"#BB8FCE",
+			"#85C1E2",
+		];
+		const color = colors[Math.floor(Math.random() * colors.length)];
+
+		// Set connection state
+		conn.state.playerId = playerId;
+
+		// Add player at random position
+		c.state.players[playerId] = {
+			id: playerId,
+			x: Math.floor(Math.random() * 900) + 50,
+			y: Math.floor(Math.random() * 900) + 50,
+			color,
+			lastUpdate: Date.now(),
+		};
+
+		// Broadcast player joined event
+		c.broadcast("playerJoined", {
+			playerId,
+			player: c.state.players[playerId],
+		});
+	},
+
+	onDisconnect: (c, conn) => {
+		const playerId = conn.state.playerId;
+		if (playerId) {
+			delete c.state.players[playerId];
+			c.broadcast("playerLeft", { playerId });
+		}
+	},
+
+	actions: {
+		// Move player by delta
+		move: (c, dx: number, dy: number) => {
+			const playerId = c.conn.state.playerId;
+			if (!playerId) return { x: 0, y: 0 };
+
+			const player = c.state.players[playerId];
+			if (!player) return { x: 0, y: 0 };
+
+			// Update position
+			player.x += dx;
+			player.y += dy;
+
+			// Keep player in bounds (0-1000)
+			player.x = Math.max(0, Math.min(player.x, 1000));
+			player.y = Math.max(0, Math.min(player.y, 1000));
+
+			// Update timestamp
+			player.lastUpdate = Date.now();
+
+			// Broadcast movement
+			c.broadcast("playerMoved", {
+				playerId,
+				x: player.x,
+				y: player.y,
+			});
+
+			return { x: player.x, y: player.y };
+		},
+
+		// Get current game state
+		getGameState: (c) => {
+			return {
+				players: c.state.players,
+				region: c.state.region,
+			};
+		},
+
+		// Get region info
+		getRegion: (c) => {
+			return c.state.region;
+		},
+	},
+});
+
+// Register actors for use
+export const registry = setup({
+	use: { gameRoom },
+});

--- a/examples/multi-region-vercel/src/server.ts
+++ b/examples/multi-region-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/multi-region-vercel/src/types.ts
+++ b/examples/multi-region-vercel/src/types.ts
@@ -1,0 +1,18 @@
+export type Position = { x: number; y: number };
+
+export type Player = {
+	id: string;
+	x: number;
+	y: number;
+	color: string;
+	lastUpdate: number;
+};
+
+export type GameState = {
+	players: Record<string, Player>;
+	region: string;
+};
+
+export type ConnectionState = {
+	playerId: string | null;
+};

--- a/examples/multi-region-vercel/tests/regions.test.ts
+++ b/examples/multi-region-vercel/tests/regions.test.ts
@@ -1,0 +1,181 @@
+import { setupTest } from "rivetkit/test";
+import { describe, expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+describe("multi-region deployment", () => {
+	test("isolates actors by region", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		const usEast = client.gameRoom.getOrCreate(["room1"], {
+			createInRegion: "us-east",
+			createWithInput: { region: "us-east" },
+		});
+
+		const euWest = client.gameRoom.getOrCreate(["room1"], {
+			createInRegion: "eu-west",
+			createWithInput: { region: "eu-west" },
+		});
+
+		const usRegion = await usEast.getRegion();
+		const euRegion = await euWest.getRegion();
+
+		expect(usRegion).toBe("us-east");
+		expect(euRegion).toBe("eu-west");
+
+		// Verify they are different actor instances
+		const usState = await usEast.getGameState();
+		const euState = await euWest.getGameState();
+
+		expect(usState.region).toBe("us-east");
+		expect(euState.region).toBe("eu-west");
+	});
+
+	test("players isolated by region", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create actors in different regions
+		const usEast = client.gameRoom.getOrCreate(["room2"], {
+			createInRegion: "us-east",
+			createWithInput: { region: "us-east" },
+		});
+
+		const euWest = client.gameRoom.getOrCreate(["room2"], {
+			createInRegion: "eu-west",
+			createWithInput: { region: "eu-west" },
+		});
+
+		// Get initial state
+		const usInitialState = await usEast.getGameState();
+		const euInitialState = await euWest.getGameState();
+
+		// Verify rooms maintain separate player lists
+		expect(usInitialState.players).not.toBe(euInitialState.players);
+	});
+
+	test("same room ID, different regions", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create "room1" in different regions
+		const usRoom1 = client.gameRoom.getOrCreate(["room1"], {
+			createInRegion: "us-east",
+			createWithInput: { region: "us-east" },
+		});
+
+		const euRoom1 = client.gameRoom.getOrCreate(["room1"], {
+			createInRegion: "eu-west",
+			createWithInput: { region: "eu-west" },
+		});
+
+		// Verify they are different instances
+		const usState = await usRoom1.getGameState();
+		const euState = await euRoom1.getGameState();
+
+		expect(usState.region).toBe("us-east");
+		expect(euState.region).toBe("eu-west");
+
+		// Verify state is not shared
+		expect(usState).not.toBe(euState);
+	});
+
+	test("movement within region", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		const room = client.gameRoom.getOrCreate(["room3"], {
+			createInRegion: "us-east",
+			createWithInput: { region: "us-east" },
+		});
+
+		// Movement should work within region
+		// Note: move requires connection context, so this tests the action exists
+		expect(room.move).toBeDefined();
+		expect(typeof room.move).toBe("function");
+	});
+
+	test("region parameter validation", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create actor with custom region
+		const customRegion = client.gameRoom.getOrCreate(["room4"], {
+			createInRegion: "custom-region",
+			createWithInput: { region: "custom-region" },
+		});
+
+		const region = await customRegion.getRegion();
+		expect(region).toBe("custom-region");
+	});
+
+	test("region switching creates separate instances", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Connect to us-east
+		const usEast = client.gameRoom.getOrCreate(["room5"], {
+			createInRegion: "us-east",
+			createWithInput: { region: "us-east" },
+		});
+
+		const usState = await usEast.getGameState();
+		expect(usState.region).toBe("us-east");
+
+		// Connect to eu-west with same room ID
+		const euWest = client.gameRoom.getOrCreate(["room5"], {
+			createInRegion: "eu-west",
+			createWithInput: { region: "eu-west" },
+		});
+
+		const euState = await euWest.getGameState();
+		expect(euState.region).toBe("eu-west");
+
+		// Verify they have separate state
+		expect(usState.region).not.toBe(euState.region);
+	});
+
+	test("multiple regions with different room IDs", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create different rooms in different regions
+		const usRoom1 = client.gameRoom.getOrCreate(["lobby"], {
+			createInRegion: "us-east",
+			createWithInput: { region: "us-east" },
+		});
+
+		const usRoom2 = client.gameRoom.getOrCreate(["game"], {
+			createInRegion: "us-east",
+			createWithInput: { region: "us-east" },
+		});
+
+		const euRoom1 = client.gameRoom.getOrCreate(["lobby"], {
+			createInRegion: "eu-west",
+			createWithInput: { region: "eu-west" },
+		});
+
+		// Verify all have correct regions
+		expect(await usRoom1.getRegion()).toBe("us-east");
+		expect(await usRoom2.getRegion()).toBe("us-east");
+		expect(await euRoom1.getRegion()).toBe("eu-west");
+
+		// Verify they are independent
+		const usRoom1State = await usRoom1.getGameState();
+		const usRoom2State = await usRoom2.getGameState();
+		const euRoom1State = await euRoom1.getGameState();
+
+		expect(usRoom1State.players).not.toBe(usRoom2State.players);
+		expect(usRoom1State.players).not.toBe(euRoom1State.players);
+	});
+
+	test("getGameState returns players and region", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		const room = client.gameRoom.getOrCreate(["test-state"], {
+			createInRegion: "ap-south",
+			createWithInput: { region: "ap-south" },
+		});
+
+		const state = await room.getGameState();
+
+		// Verify structure
+		expect(state).toHaveProperty("players");
+		expect(state).toHaveProperty("region");
+		expect(typeof state.players).toBe("object");
+		expect(state.region).toBe("ap-south");
+	});
+});

--- a/examples/multi-region-vercel/tsconfig.json
+++ b/examples/multi-region-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/multi-region-vercel/turbo.json
+++ b/examples/multi-region-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/multi-region-vercel/vercel.json
+++ b/examples/multi-region-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/multi-region-vercel/vite.config.ts
+++ b/examples/multi-region-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/multi-region-vercel/vitest.config.ts
+++ b/examples/multi-region-vercel/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+	},
+});

--- a/examples/multi-region/vercel.json
+++ b/examples/multi-region/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/native-websockets-vercel/.gitignore
+++ b/examples/native-websockets-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/native-websockets-vercel/README.md
+++ b/examples/native-websockets-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [native-websockets](../native-websockets) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fnative-websockets-vercel&project-name=native-websockets-vercel)
+
+# Native WebSockets
+
+Demonstrates native WebSocket integration with Rivet Actors for real-time bidirectional communication.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/native-websockets
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Native WebSocket support**: Use standard WebSocket APIs for real-time communication
+- **Bidirectional messaging**: Send and receive messages between client and actor
+- **Connection management**: Track WebSocket connections with `onConnect` and `onDisconnect` hooks
+- **Event broadcasting**: Push updates to all connected WebSocket clients
+
+## Implementation
+
+This example demonstrates native WebSocket integration with Rivet Actors:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/native-websockets/src/backend/registry.ts)): Shows how to use native WebSocket APIs with actors for real-time communication
+
+## Resources
+
+Read more about [WebSockets](/docs/actors/websockets), [events](/docs/actors/events), and [lifecycle hooks](/docs/actors/lifecycle).
+
+## License
+
+MIT

--- a/examples/native-websockets-vercel/api/index.ts
+++ b/examples/native-websockets-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/native-websockets-vercel/frontend/App.tsx
+++ b/examples/native-websockets-vercel/frontend/App.tsx
@@ -1,0 +1,211 @@
+import { createClient } from "@rivetkit/react";
+import { useEffect, useState } from "react";
+import type { registry } from "../src/actors.ts";
+
+// FIXME: use metadata's clientEndpoint
+const rivetUrl = `${window.location.origin}/api/rivet`;
+
+const client = createClient<typeof registry>(rivetUrl);
+
+// Generate a random user ID
+const generateUserId = () =>
+	`user-${Math.random().toString(36).substring(2, 9)}`;
+
+// Cursor colors for different users
+const CURSOR_COLORS = [
+	"#E63946",
+	"#2A9D8F",
+	"#1B8AAE",
+	"#F77F00",
+	"#06A77D",
+	"#D4A017",
+	"#9B59B6",
+	"#5DADE2",
+];
+
+function getColorForUser(userId: string): string {
+	let hash = 0;
+	for (let i = 0; i < userId.length; i++) {
+		hash = userId.charCodeAt(i) + ((hash << 5) - hash);
+	}
+	return CURSOR_COLORS[Math.abs(hash) % CURSOR_COLORS.length];
+}
+
+interface CursorPosition {
+	userId: string;
+	x: number;
+	y: number;
+	timestamp: number;
+}
+
+export function App() {
+	const [userId] = useState(generateUserId());
+	const [cursors, setCursors] = useState<Record<string, CursorPosition>>({});
+	const [ws, setWs] = useState<WebSocket | null>(null);
+	const [connected, setConnected] = useState(false);
+
+	// Connect to WebSocket
+	useEffect(() => {
+		let websocket: WebSocket | null = null;
+
+		const connect = async () => {
+			try {
+				// Get or create the actor for the room
+				const actorId = await client.cursorRoom.getOrCreate("main").resolve();
+				console.log("found actor", actorId);
+
+				// Build WebSocket URL with userId query parameter
+				const wsOrigin = rivetUrl.replace(/^http/, "ws");
+				const wsUrl = `${wsOrigin}/gateway/${actorId}/raw/websocket?userId=${encodeURIComponent(userId)}`;
+
+				console.log("ws url:", wsUrl);
+
+				// Create WebSocket connection
+				websocket = new WebSocket(wsUrl);
+
+				websocket.onopen = () => {
+					console.log("websocket connected");
+					setConnected(true);
+				};
+
+				websocket.onmessage = (event) => {
+					try {
+						const message = JSON.parse(event.data);
+
+						switch (message.type) {
+							case "init": {
+								// Initial state from server
+								setCursors(message.data.cursors);
+								break;
+							}
+
+							case "cursorUpdate": {
+								// Update cursor position
+								setCursors((prev) => ({
+									...prev,
+									[message.data.userId]: message.data,
+								}));
+								break;
+							}
+
+							case "cursorsState": {
+								// Full cursor state
+								setCursors(message.data.cursors);
+								break;
+							}
+						}
+					} catch (error) {
+						console.error("error parsing websocket message:", error);
+					}
+				};
+
+				websocket.onclose = () => {
+					console.log("websocket disconnected");
+					setConnected(false);
+				};
+
+				websocket.onerror = (error) => {
+					console.error("websocket error:", error);
+				};
+
+				setWs(websocket);
+			} catch (error) {
+				console.error("error connecting:", error);
+			}
+		};
+
+		connect();
+
+		// Cleanup
+		return () => {
+			if (websocket) {
+				websocket.close();
+			}
+		};
+	}, [userId]);
+
+	// Handle mouse movement
+	const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+		if (ws && ws.readyState === WebSocket.OPEN) {
+			const rect = e.currentTarget.getBoundingClientRect();
+			const x = e.clientX - rect.left;
+			const y = e.clientY - rect.top;
+
+			// Send cursor update via WebSocket
+			ws.send(
+				JSON.stringify({
+					type: "updateCursor",
+					data: { x, y },
+				}),
+			);
+		}
+	};
+
+	return (
+		<div className="app-container">
+			<div className="header">
+				<h1>Quickstart: Raw WebSockets</h1>
+				<div className="info">
+					<div className="connection-status">
+						Status: <span className={connected ? "connected" : "disconnected"}>
+							{connected ? "Connected" : "Disconnected"}
+						</span>
+					</div>
+					<div className="user-info">
+						Your ID: <span style={{ color: getColorForUser(userId) }}>{userId}</span>
+					</div>
+				</div>
+			</div>
+
+			<div className="canvas" onMouseMove={handleMouseMove}>
+				{/* Render cursors */}
+				{Object.entries(cursors).map(([id, cursor]) => {
+					const color = getColorForUser(cursor.userId);
+					const isOwnCursor = cursor.userId === userId;
+					return (
+						<div
+							key={id}
+							className="cursor"
+							style={{
+								left: cursor.x,
+								top: cursor.y,
+							}}
+						>
+							<svg
+								width="20"
+								height="24"
+								viewBox="0 0 20 24"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+								className="cursor-svg"
+							>
+								<path
+									d="M10 4 L4 18 L16 18 Z"
+									fill={color}
+									stroke="white"
+									strokeWidth="1.5"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									transform="rotate(-45 10 12)"
+								/>
+							</svg>
+							<div
+								className="cursor-label"
+								style={{
+									backgroundColor: color,
+									borderColor: `${color}40`,
+								}}
+							>
+								{isOwnCursor ? "you" : cursor.userId}
+							</div>
+						</div>
+					);
+				})}
+
+				{!connected && (
+					<div className="loading-overlay">Connecting to room...</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/examples/native-websockets-vercel/frontend/main.tsx
+++ b/examples/native-websockets-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/native-websockets-vercel/index.html
+++ b/examples/native-websockets-vercel/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quickstart: Raw WebSockets</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #0a0a0a;
+            color: #e0e0e0;
+            overflow: hidden;
+            height: 100vh;
+        }
+        .app-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+        .header {
+            background: rgba(26, 26, 26, 0.9);
+            backdrop-filter: blur(10px);
+            padding: 20px;
+            border-bottom: 1px solid #2a2a2a;
+        }
+        .header h1 {
+            margin: 0 0 10px 0;
+            font-size: 24px;
+            color: #4a9eff;
+        }
+        .info {
+            display: flex;
+            gap: 20px;
+            font-size: 14px;
+        }
+        .connection-status, .user-info {
+            color: #a0a0a0;
+        }
+        .connection-status .connected {
+            color: #06A77D;
+            font-weight: 500;
+        }
+        .connection-status .disconnected {
+            color: #E63946;
+            font-weight: 500;
+        }
+        .canvas {
+            position: relative;
+            flex: 1;
+            background: #1a1a1a;
+            cursor: none;
+            overflow: hidden;
+        }
+        .cursor {
+            position: absolute;
+            pointer-events: none;
+            z-index: 100;
+        }
+        .cursor-svg {
+            filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+        }
+        .cursor-label {
+            position: absolute;
+            top: 20px;
+            left: 18px;
+            padding: 4px 8px;
+            border-radius: 8px;
+            color: white;
+            font-size: 12px;
+            white-space: nowrap;
+            border: 1px solid;
+        }
+        .loading-overlay {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            font-size: 18px;
+            color: #808080;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/native-websockets-vercel/package.json
+++ b/examples/native-websockets-vercel/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "native-websockets-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.0.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@types/ws": "^8.5.10",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1",
+		"ws": "^8.16.0"
+	},
+	"template": {
+		"technologies": [
+			"websocket",
+			"typescript"
+		],
+		"tags": [
+			"real-time"
+		],
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/native-websockets-vercel/src/actors.ts
+++ b/examples/native-websockets-vercel/src/actors.ts
@@ -1,0 +1,125 @@
+import { actor, setup, type UniversalWebSocket, type RivetMessageEvent } from "rivetkit";
+
+interface Vars {
+	websockets: Map<string, UniversalWebSocket>;
+}
+
+export const cursorRoom = actor({
+	state: {
+		cursors: {} as Record<
+			string,
+			{
+				userId: string;
+				x: number;
+				y: number;
+				timestamp: number;
+			}
+		>,
+	},
+
+	createVars: (): Vars => {
+		return {
+			websockets: new Map(),
+		};
+	},
+
+	actions: {
+		// Get or create the actor (for frontend to resolve actor ID)
+		getOrCreate: () => {
+			return { status: "ok" };
+		},
+	},
+
+	// Handle WebSocket connections
+	onWebSocket: async (c, websocket: UniversalWebSocket) => {
+		// Extract userId from query parameters
+		if (!c.request) {
+			websocket.close(1008, "Missing request");
+			return;
+		}
+		const url = new URL(c.request.url);
+		const userId = url.searchParams.get("userId");
+
+		// Validate userId exists
+		if (!userId) {
+			websocket.close(1008, "Missing userId query parameter");
+			return;
+		}
+
+		console.log(
+			`websocket connected: userId=${userId}, actorId=${c.actorId}`,
+		);
+
+		// Store websocket in vars (non-persistent)
+		c.vars.websockets.set(userId, websocket);
+
+		// Send initial state to the new connection
+		websocket.send(
+			JSON.stringify({
+				type: "init",
+				data: {
+					cursors: c.state.cursors,
+				},
+			}),
+		);
+
+		// Handle incoming messages
+		websocket.addEventListener("message", (event: RivetMessageEvent) => {
+			try {
+				const message = JSON.parse(event.data as string);
+
+				switch (message.type) {
+					case "updateCursor": {
+						const { x, y } = message.data;
+
+						// Update cursor position in state (persistent)
+						c.state.cursors[userId] = {
+							userId,
+							x,
+							y,
+							timestamp: Date.now(),
+						};
+
+						// Broadcast to all websockets
+						for (const ws of c.vars.websockets.values()) {
+							ws.send(
+								JSON.stringify({
+									type: "cursorUpdate",
+									data: c.state.cursors[userId],
+								}),
+							);
+						}
+						break;
+					}
+
+					case "getCursors": {
+						// Send current cursor state to requesting client
+						websocket.send(
+							JSON.stringify({
+								type: "cursorsState",
+								data: {
+									cursors: c.state.cursors,
+								},
+							}),
+						);
+						break;
+					}
+				}
+			} catch (error) {
+				console.error("error handling websocket message:", error);
+			}
+		});
+
+		// Handle connection close
+		websocket.addEventListener("close", () => {
+			console.log(`websocket disconnected: userId=${userId}`);
+			// Clean up websocket from map
+			c.vars.websockets.delete(userId);
+		});
+	},
+});
+
+// Register actors for use
+export const registry = setup({
+	use: { cursorRoom },
+});

--- a/examples/native-websockets-vercel/src/server.ts
+++ b/examples/native-websockets-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/native-websockets-vercel/tests/websocket.test.ts
+++ b/examples/native-websockets-vercel/tests/websocket.test.ts
@@ -1,0 +1,12 @@
+import { setupTest } from "rivetkit/test";
+import { expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+test("Cursor room can be created and initialized", async (ctx: any) => {
+	const { client } = await setupTest(ctx, registry);
+	const room = client.cursorRoom.getOrCreate(["test-room"]);
+
+	// Test that the getOrCreate action works
+	const result = await room.getOrCreate();
+	expect(result).toEqual({ status: "ok" });
+});

--- a/examples/native-websockets-vercel/tsconfig.json
+++ b/examples/native-websockets-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/native-websockets-vercel/turbo.json
+++ b/examples/native-websockets-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/native-websockets-vercel/vercel.json
+++ b/examples/native-websockets-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/native-websockets-vercel/vite.config.ts
+++ b/examples/native-websockets-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/native-websockets-vercel/vitest.config.ts
+++ b/examples/native-websockets-vercel/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	server: {
+		port: 5173,
+	},
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/raw-fetch-handler-vercel/.gitignore
+++ b/examples/raw-fetch-handler-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/raw-fetch-handler-vercel/README.md
+++ b/examples/raw-fetch-handler-vercel/README.md
@@ -1,0 +1,52 @@
+> **Note:** This is the Vercel-optimized version of the [raw-fetch-handler](../raw-fetch-handler) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fraw-fetch-handler-vercel&project-name=raw-fetch-handler-vercel)
+
+# Raw Fetch Handler Example
+
+Example project demonstrating raw HTTP fetch handling with Hono integration.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/raw-fetch-handler
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Raw fetch handlers**: Use `onRequest` for low-level HTTP request handling with custom routing
+- **Hono integration**: Embed Hono router inside actor fetch handlers using `createVars`
+- **HTTP endpoints**: Define custom HTTP endpoints directly within actors
+- **Proxy routing**: Forward HTTP requests from external endpoints to actor fetch handlers
+- **Multiple actor instances**: Each named counter maintains independent state
+
+## Implementation
+
+The backend defines a counter actor with a Hono router embedded in the `onRequest` handler. Each counter is identified by a unique name, and the frontend can interact with counters through direct actor fetch calls or HTTP requests through a forward endpoint. Multiple counters maintain independent state.
+
+### Key Implementation
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/raw-fetch-handler/src/backend/registry.ts)): Demonstrates `onRequest` handler with Hono router for custom HTTP routing
+
+## Project Structure
+
+```
+raw-fetch-handler/
+├── src/
+│   ├── backend/     # RivetKit server with counter actors
+│   └── frontend/    # React app demonstrating client interactions
+└── tests/           # Vitest test suite
+```
+
+## Resources
+
+Read more about [HTTP request handling](/docs/actors/http), [state](/docs/actors/state), and [actions](/docs/actors/actions).
+
+## License
+
+MIT

--- a/examples/raw-fetch-handler-vercel/api/index.ts
+++ b/examples/raw-fetch-handler-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/raw-fetch-handler-vercel/frontend/App.tsx
+++ b/examples/raw-fetch-handler-vercel/frontend/App.tsx
@@ -1,0 +1,112 @@
+import { useState, useEffect } from "react";
+import { createClient } from "@rivetkit/react";
+import type { registry } from "../src/actors.ts";
+
+// Create a client that connects to the running server
+const client = createClient<typeof registry>(`${window.location.origin}/api/rivet`);
+
+function Counter({ name }: { name: string }) {
+	const [count, setCount] = useState<number | null>(null);
+	const [loading, setLoading] = useState(false);
+
+	const actor = client.counter.getOrCreate([name]);
+
+	const fetchCount = async () => {
+		const response = await actor.fetch("/count");
+		const data = await response.json();
+		setCount(data.count);
+	};
+
+	const handleIncrement = async () => {
+		setLoading(true);
+		try {
+			// Method 1: Using fetch API
+			const response = await actor.fetch("/increment", { method: "POST" });
+			const data = await response.json();
+			setCount(data.count);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleForwardIncrement = async () => {
+		setLoading(true);
+		try {
+			// Method 2: Using the forward endpoint
+			// FIXME: Use metadata's clientEndpoint
+			const response = await fetch(`http://localhost:8080/forward/${name}/increment`, {
+				method: "POST",
+			});
+			const data = await response.json();
+			setCount(data.count);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	useEffect(() => {
+		fetchCount();
+	}, []);
+
+	return (
+		<div>
+			<h2>{name}</h2>
+			<p>Count: {count !== null ? count : "Loading..."}</p>
+			
+			<h3>Via Actor Fetch</h3>
+			<button onClick={handleIncrement} disabled={loading}>
+				Increment
+			</button>
+			
+			<h3>Via Forward Endpoint</h3>
+			<button onClick={handleForwardIncrement} disabled={loading}>
+				Increment
+			</button>
+			
+			<br />
+			<button onClick={fetchCount} disabled={loading}>
+				Refresh
+			</button>
+			<hr />
+		</div>
+	);
+}
+
+function App() {
+	const [counters, setCounters] = useState(["counter-1", "counter-2"]);
+	const [newCounterName, setNewCounterName] = useState("");
+
+	const addCounter = () => {
+		if (newCounterName && !counters.includes(newCounterName)) {
+			setCounters([...counters, newCounterName]);
+			setNewCounterName("");
+		}
+	};
+
+	return (
+		<div>
+			<h1>RivetKit Raw Fetch Handler Example</h1>
+			
+			<div>
+				<input
+					type="text"
+					value={newCounterName}
+					onChange={(e) => setNewCounterName(e.target.value)}
+					placeholder="Counter name"
+					onKeyPress={(e) => e.key === "Enter" && addCounter()}
+				/>
+				<button onClick={addCounter}>Add Counter</button>
+			</div>
+			
+			<hr />
+			
+			<div>
+				{counters.map((name) => (
+					<Counter key={name} name={name} />
+				))}
+			</div>
+		</div>
+	);
+}
+
+export default App;

--- a/examples/raw-fetch-handler-vercel/frontend/main.tsx
+++ b/examples/raw-fetch-handler-vercel/frontend/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/raw-fetch-handler-vercel/index.html
+++ b/examples/raw-fetch-handler-vercel/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RivetKit Fetch Handler Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+  </body>
+</html>

--- a/examples/raw-fetch-handler-vercel/package.json
+++ b/examples/raw-fetch-handler-vercel/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "example-raw-fetch-handler-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.1",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.6.18",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.6",
+		"@types/react": "^18.3.18",
+		"@types/react-dom": "^18.3.5",
+		"@vitejs/plugin-react": "^4.3.4",
+		"tsx": "^4.20.0",
+		"typescript": "^5.7.3",
+		"vite": "^5.4.19",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"typescript"
+		],
+		"tags": [],
+		"priority": 1000,
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/raw-fetch-handler-vercel/src/actors.ts
+++ b/examples/raw-fetch-handler-vercel/src/actors.ts
@@ -1,0 +1,47 @@
+import { Hono } from "hono";
+import { type ActorContextOf, actor, setup } from "rivetkit";
+
+export const counter = actor({
+	state: {
+		count: 0,
+	},
+	createVars: () => {
+		// Setup router
+		return { router: createCounterRouter() };
+	},
+	onRequest: (c, request) => {
+		return c.vars.router.fetch(request, { actor: c });
+	},
+	actions: {
+		// ...actions...
+	},
+});
+
+function createCounterRouter(): Hono<any> {
+	const app = new Hono<{
+		Bindings: { actor: ActorContextOf<typeof counter> };
+	}>();
+
+	app.get("/count", (c) => {
+		const { actor } = c.env;
+
+		return c.json({
+			count: actor.state.count,
+		});
+	});
+
+	app.post("/increment", (c) => {
+		const { actor } = c.env;
+
+		actor.state.count++;
+		return c.json({
+			count: actor.state.count,
+		});
+	});
+
+	return app;
+}
+
+export const registry = setup({
+	use: { counter },
+});

--- a/examples/raw-fetch-handler-vercel/src/server.ts
+++ b/examples/raw-fetch-handler-vercel/src/server.ts
@@ -1,0 +1,41 @@
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { createClient } from "rivetkit/client";
+import { registry } from "./actors.ts";
+
+const client = createClient<typeof registry>();
+
+const app = new Hono();
+
+app.use(
+	cors({
+		origin: "http://localhost:5173",
+		credentials: true,
+	}),
+);
+
+app.get("/", (c) => {
+	return c.json({ message: "Fetch Handler Example Server" });
+});
+
+// Forward requests to actor's fetch handler
+app.all("/forward/:name/*", async (c) => {
+	const name = c.req.param("name");
+
+	// Create new URL with the path truncated
+	const truncatedPath = c.req.path.replace(`/forward/${name}`, "");
+	const url = new URL(truncatedPath, c.req.url);
+	const newRequest = new Request(url, c.req.raw);
+
+	// Forward to actor's fetch handler
+	const actor = client.counter.getOrCreate(name);
+	const response = await actor.fetch(truncatedPath, newRequest);
+
+	return response;
+});
+
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+
+export default app;
+
+export { client };

--- a/examples/raw-fetch-handler-vercel/tests/counter.test.ts
+++ b/examples/raw-fetch-handler-vercel/tests/counter.test.ts
@@ -1,0 +1,27 @@
+import { setupTest } from "rivetkit/test";
+import { describe, expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+describe("Counter Actor", () => {
+	test("fetch handler returns counter state", async (test) => {
+		const { client } = await setupTest(test, registry);
+		const handle = client.counter.getOrCreate("test-fetch");
+
+		// GET current state
+		let response = await handle.fetch("/count");
+		expect(response.status).toBe(200);
+		let data = await response.json();
+		expect(data.count).toBe(0);
+
+		// POST to increment
+		response = await handle.fetch("/increment", { method: "POST" });
+		expect(response.status).toBe(200);
+		data = await response.json();
+		expect(data.count).toBe(1);
+
+		// Verify state persisted with another GET
+		response = await handle.fetch("/count");
+		data = await response.json();
+		expect(data.count).toBe(1);
+	});
+});

--- a/examples/raw-fetch-handler-vercel/tsconfig.json
+++ b/examples/raw-fetch-handler-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/raw-fetch-handler-vercel/turbo.json
+++ b/examples/raw-fetch-handler-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/raw-fetch-handler-vercel/vercel.json
+++ b/examples/raw-fetch-handler-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/raw-fetch-handler-vercel/vite.config.ts
+++ b/examples/raw-fetch-handler-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/raw-fetch-handler-vercel/vitest.config.ts
+++ b/examples/raw-fetch-handler-vercel/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/raw-websocket-handler-proxy-vercel/.gitignore
+++ b/examples/raw-websocket-handler-proxy-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/raw-websocket-handler-proxy-vercel/README.md
+++ b/examples/raw-websocket-handler-proxy-vercel/README.md
@@ -1,0 +1,40 @@
+> **Note:** This is the Vercel-optimized version of the [raw-websocket-handler-proxy](../raw-websocket-handler-proxy) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fraw-websocket-handler-proxy-vercel&project-name=raw-websocket-handler-proxy-vercel)
+
+# Raw WebSocket Handler Proxy
+
+Demonstrates raw WebSocket handling using a proxy endpoint pattern for routing connections to actors.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/raw-websocket-handler-proxy
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Raw WebSocket handlers**: Use `onWebSocket` for low-level WebSocket control and custom protocols
+- **Proxy endpoint pattern**: Route WebSocket connections through a proxy endpoint to actors
+- **Connection management**: Track WebSocket connections with state and broadcasting
+- **Real-time chat**: Message broadcasting with user presence and chat history
+- **Persistent state**: Messages and user data automatically saved in actor state
+
+## Implementation
+
+This example demonstrates routing WebSocket connections through a proxy:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/raw-websocket-handler-proxy/src/backend/registry.ts)): Uses proxy endpoint pattern to route WebSocket connections to actors
+
+## Resources
+
+Read more about [WebSockets](/docs/actors/websockets), [state](/docs/actors/state), and [events](/docs/actors/events).
+
+## License
+
+MIT

--- a/examples/raw-websocket-handler-proxy-vercel/api/index.ts
+++ b/examples/raw-websocket-handler-proxy-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/raw-websocket-handler-proxy-vercel/frontend/App.tsx
+++ b/examples/raw-websocket-handler-proxy-vercel/frontend/App.tsx
@@ -1,0 +1,110 @@
+import React, { useState, useEffect, useRef } from "react";
+
+export default function App() {
+	const [messages, setMessages] = useState<Array<{ id: string; text: string; timestamp: number }>>([]);
+	const [inputText, setInputText] = useState("");
+	const [isConnected, setIsConnected] = useState(false);
+	const wsRef = useRef<WebSocket | null>(null);
+
+	useEffect(() => {
+		// Direct WebSocket connection to actor
+		const protocols = [
+			`query.${encodeURIComponent(JSON.stringify({
+				getOrCreateForKey: { name: "chatRoom", key: "main" }
+			}))}`,
+			`encoding.json`,
+			`conn_params.${encodeURIComponent(JSON.stringify({ apiKey: "your-api-key" }))}`
+		];
+
+		// FIXME: Use metadata's clientEndpoint
+		const ws = new WebSocket("ws://localhost:6420/api/rivet/actors/chatRoom/ws/", protocols);
+		
+		ws.onopen = () => {
+			setIsConnected(true);
+			console.log("Connected via direct access!");
+		};
+
+		ws.onmessage = (event) => {
+			const data = JSON.parse(event.data);
+			
+			if (data.type === "init") {
+				setMessages(data.messages);
+			} else if (data.type === "message") {
+				setMessages(prev => [...prev, {
+					id: data.id,
+					text: data.text,
+					timestamp: data.timestamp
+				}]);
+			}
+		};
+
+		ws.onclose = (event) => {
+			setIsConnected(false);
+			console.log("WebSocket closed:", event.code, event.reason);
+		};
+
+		ws.onerror = (event) => {
+			console.error("WebSocket error:", event);
+		};
+
+		wsRef.current = ws;
+
+		return () => {
+			ws.close();
+		};
+	}, []);
+
+	const sendMessage = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!inputText.trim() || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+
+		wsRef.current.send(JSON.stringify({
+			type: "message",
+			text: inputText.trim()
+		}));
+		setInputText("");
+	};
+
+	return (
+		<div style={{ maxWidth: "800px", margin: "0 auto", padding: "20px" }}>
+			<h1>Raw WebSocket Chat</h1>
+			
+			<div style={{
+				padding: "10px",
+				background: isConnected ? "#4caf50" : "#f44336",
+				color: "white",
+				borderRadius: "4px",
+				marginBottom: "20px"
+			}}>
+				{isConnected ? "Connected" : "Disconnected"}
+			</div>
+
+			<div style={{
+				background: "white",
+				border: "1px solid #ddd",
+				borderRadius: "8px",
+				padding: "10px",
+				height: "400px",
+				overflowY: "auto",
+				marginBottom: "10px"
+			}}>
+				{messages.map((msg) => (
+					<div key={msg.id} style={{ marginBottom: "10px" }}>
+						<strong>{new Date(msg.timestamp).toLocaleTimeString()}:</strong> {msg.text}
+					</div>
+				))}
+			</div>
+
+			<form onSubmit={sendMessage} style={{ display: "flex", gap: "10px" }}>
+				<input
+					type="text"
+					value={inputText}
+					onChange={(e) => setInputText(e.target.value)}
+					placeholder="Type a message..."
+					style={{ flex: 1, padding: "8px", borderRadius: "4px", border: "1px solid #ddd" }}
+				/>
+				<button type="submit">Send</button>
+			</form>
+		</div>
+	);
+}

--- a/examples/raw-websocket-handler-proxy-vercel/frontend/main.tsx
+++ b/examples/raw-websocket-handler-proxy-vercel/frontend/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
+);

--- a/examples/raw-websocket-handler-proxy-vercel/index.html
+++ b/examples/raw-websocket-handler-proxy-vercel/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>RivetKit Raw WebSocket Handler</title>
+		<style>
+			body {
+				font-family: system-ui, -apple-system, sans-serif;
+				background: #f5f5f5;
+				margin: 0;
+				padding: 0;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/frontend/main.tsx"></script>
+	</body>
+</html>

--- a/examples/raw-websocket-handler-proxy-vercel/package.json
+++ b/examples/raw-websocket-handler-proxy-vercel/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "example-raw-websocket-handler-proxy-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.1",
+		"@hono/node-ws": "^1.2.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.7.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"rivetkit": "^2.0.38",
+		"ws": "^8.18.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.2",
+		"@types/react": "^18.3.16",
+		"@types/react-dom": "^18.3.5",
+		"@types/ws": "^8.5.10",
+		"@vitejs/plugin-react": "^4.3.4",
+		"tsx": "^4.19.2",
+		"typescript": "^5.7.2",
+		"vite": "^6.0.5",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"websocket",
+			"typescript"
+		],
+		"tags": [],
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/raw-websocket-handler-proxy-vercel/src/actors.ts
+++ b/examples/raw-websocket-handler-proxy-vercel/src/actors.ts
@@ -1,0 +1,77 @@
+import { actor, setup } from "rivetkit";
+
+export const chatRoom = actor({
+	state: {
+		messages: [] as Array<{
+			id: string;
+			text: string;
+			timestamp: number;
+		}>,
+	},
+	createVars: () => {
+		return {
+			sockets: new Set<any>(),
+		};
+	},
+	onWebSocket(ctx, socket) {
+		// Add socket to the set
+		ctx.vars.sockets.add(socket);
+
+		// Send recent messages to new connection
+		socket.send(
+			JSON.stringify({
+				type: "init",
+				messages: ctx.state.messages,
+			}),
+		);
+
+		// Handle incoming messages
+		socket.addEventListener("message", (event: any) => {
+			try {
+				const data = JSON.parse(event.data);
+
+				if (data.type === "message" && data.text) {
+					const message = {
+						id: crypto.randomUUID(),
+						text: data.text,
+						timestamp: Date.now(),
+					};
+
+					// Add to state
+					ctx.state.messages.push(message);
+					ctx.saveState({});
+
+					// Keep only last 50 messages
+					if (ctx.state.messages.length > 50) {
+						ctx.state.messages.shift();
+					}
+
+					// Broadcast to all connected clients
+					const broadcast = JSON.stringify({
+						type: "message",
+						...message,
+					});
+
+					for (const ws of ctx.vars.sockets) {
+						if (ws.readyState === 1) {
+							// OPEN
+							ws.send(broadcast);
+						}
+					}
+				}
+			} catch (e) {
+				console.error("Failed to process message:", e);
+			}
+		});
+
+		// Remove socket on close
+		socket.addEventListener("close", () => {
+			ctx.vars.sockets.delete(socket);
+		});
+	},
+	actions: {},
+});
+
+export const registry = setup({
+	use: { chatRoom },
+});

--- a/examples/raw-websocket-handler-proxy-vercel/src/server.ts
+++ b/examples/raw-websocket-handler-proxy-vercel/src/server.ts
@@ -1,0 +1,52 @@
+import { createNodeWebSocket } from "@hono/node-ws";
+import type { Context } from "hono";
+import { Hono } from "hono";
+import type { WSContext } from "hono/ws";
+import { createClient } from "rivetkit/client";
+import { registry } from "./actors.ts";
+
+const client = createClient<typeof registry>();
+
+const app = new Hono();
+const { upgradeWebSocket } = createNodeWebSocket({ app });
+
+// Forward WebSocket connections to actor's WebSocket handler
+app.get(
+	"/ws/:name",
+	upgradeWebSocket(async (c: Context) => {
+		const name = c.req.param("name");
+
+		// Connect to actor WebSocket
+		const actor = client.chatRoom.getOrCreate(name);
+		const actorWs = await actor.websocket("/");
+
+		return {
+			onOpen: async (_evt: Event, ws: WSContext) => {
+				// Bridge actor WebSocket to client WebSocket
+				actorWs.addEventListener("message", (event: MessageEvent) => {
+					ws.send(event.data);
+				});
+
+				actorWs.addEventListener("close", () => {
+					ws.close();
+				});
+			},
+			onMessage: (evt: MessageEvent) => {
+				// Forward message to actor WebSocket
+				if (actorWs && typeof evt.data === "string") {
+					actorWs.send(evt.data);
+				}
+			},
+			onClose: () => {
+				// Forward close to actor WebSocket
+				if (actorWs) {
+					actorWs.close();
+				}
+			},
+		};
+	}),
+);
+
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+
+export default app;

--- a/examples/raw-websocket-handler-proxy-vercel/tests/basic.test.ts
+++ b/examples/raw-websocket-handler-proxy-vercel/tests/basic.test.ts
@@ -1,0 +1,52 @@
+import { setupTest } from "rivetkit/test";
+import { describe, expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+describe("basic websocket test", () => {
+	test("should handle basic websocket connection", async (t) => {
+		const { client } = await setupTest(t, registry);
+		const actor = client.chatRoom.getOrCreate("test-room");
+
+		// Connect with simple path
+		const ws = await actor.websocket();
+
+		// Wait for welcome/init message
+		const initMessage = await new Promise<any>((resolve, reject) => {
+			ws.addEventListener(
+				"message",
+				(event: any) => {
+					resolve(JSON.parse(event.data));
+				},
+				{ once: true },
+			);
+			ws.addEventListener("error", reject);
+			ws.addEventListener("close", () =>
+				reject(new Error("Connection closed")),
+			);
+		});
+
+		expect(initMessage.type).toBe("init");
+		expect(initMessage.messages).toEqual([]);
+		expect(initMessage.users).toBeDefined();
+
+		// Send a message
+		ws.send(JSON.stringify({ type: "message", text: "Hello!" }));
+
+		// Receive the broadcast
+		const message = await new Promise<any>((resolve, reject) => {
+			ws.addEventListener(
+				"message",
+				(event: any) => {
+					resolve(JSON.parse(event.data));
+				},
+				{ once: true },
+			);
+			ws.addEventListener("error", reject);
+		});
+
+		expect(message.type).toBe("message");
+		expect(message.text).toBe("Hello!");
+
+		ws.close();
+	}, 10000);
+});

--- a/examples/raw-websocket-handler-proxy-vercel/tests/websocket.test.ts
+++ b/examples/raw-websocket-handler-proxy-vercel/tests/websocket.test.ts
@@ -1,0 +1,124 @@
+import { setupTest } from "rivetkit/test";
+import { describe, expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+describe("websocket chat", () => {
+	test("should connect and receive init message", async (test) => {
+		const { client } = await setupTest(test, registry);
+		const actor = client.chatRoom.getOrCreate("test-room");
+
+		const ws = await actor.websocket();
+
+		// Wait for init message
+		const initMessage = await new Promise<any>((resolve) => {
+			ws.addEventListener(
+				"message",
+				(event: any) => {
+					resolve(JSON.parse(event.data));
+				},
+				{ once: true },
+			);
+		});
+
+		expect(initMessage.type).toBe("init");
+		expect(initMessage.messages).toEqual([]);
+
+		ws.close();
+	});
+
+	test("should broadcast messages", async (test) => {
+		const { client } = await setupTest(test, registry);
+		const actor = client.chatRoom.getOrCreate("test-room-2");
+
+		// Connect two clients
+		const ws1 = await actor.websocket();
+		const ws2 = await actor.websocket();
+
+		// Skip init messages
+		await new Promise((resolve) => {
+			ws1.addEventListener("message", resolve, { once: true });
+		});
+		await new Promise((resolve) => {
+			ws2.addEventListener("message", resolve, { once: true });
+		});
+
+		// Send message from client 1
+		ws1.send(
+			JSON.stringify({
+				type: "message",
+				text: "Hello from client 1",
+			}),
+		);
+
+		// Both clients should receive it
+		const [msg1, msg2] = await Promise.all([
+			new Promise<any>((resolve) => {
+				ws1.addEventListener(
+					"message",
+					(event: any) => {
+						resolve(JSON.parse(event.data));
+					},
+					{ once: true },
+				);
+			}),
+			new Promise<any>((resolve) => {
+				ws2.addEventListener(
+					"message",
+					(event: any) => {
+						resolve(JSON.parse(event.data));
+					},
+					{ once: true },
+				);
+			}),
+		]);
+
+		expect(msg1.type).toBe("message");
+		expect(msg1.text).toBe("Hello from client 1");
+		expect(msg2).toEqual(msg1);
+
+		ws1.close();
+		ws2.close();
+	});
+
+	test("should persist messages", async (test) => {
+		const { client } = await setupTest(test, registry);
+		const actor = client.chatRoom.getOrCreate("test-room-3");
+
+		// First client sends a message
+		const ws1 = await actor.websocket();
+		await new Promise((resolve) => {
+			ws1.addEventListener("message", resolve, { once: true });
+		});
+
+		ws1.send(
+			JSON.stringify({
+				type: "message",
+				text: "Persistent message",
+			}),
+		);
+
+		// Wait for the message to be processed
+		await new Promise((resolve) => {
+			ws1.addEventListener("message", resolve, { once: true });
+		});
+		ws1.close();
+
+		// Second client connects and should see the message
+		const ws2 = await actor.websocket();
+		const initMessage = await new Promise<any>((resolve) => {
+			ws2.addEventListener(
+				"message",
+				(event: any) => {
+					resolve(JSON.parse(event.data));
+				},
+				{ once: true },
+			);
+		});
+
+		expect(initMessage.type).toBe("init");
+		expect(initMessage.messages).toHaveLength(1);
+		expect(initMessage.messages[0].text).toBe("Persistent message");
+
+		ws2.close();
+	});
+});

--- a/examples/raw-websocket-handler-proxy-vercel/tsconfig.json
+++ b/examples/raw-websocket-handler-proxy-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/raw-websocket-handler-proxy-vercel/turbo.json
+++ b/examples/raw-websocket-handler-proxy-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/raw-websocket-handler-proxy-vercel/vercel.json
+++ b/examples/raw-websocket-handler-proxy-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/raw-websocket-handler-proxy-vercel/vite.config.ts
+++ b/examples/raw-websocket-handler-proxy-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/raw-websocket-handler-proxy-vercel/vitest.config.ts
+++ b/examples/raw-websocket-handler-proxy-vercel/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/raw-websocket-handler-proxy/vercel.json
+++ b/examples/raw-websocket-handler-proxy/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/raw-websocket-handler-vercel/.gitignore
+++ b/examples/raw-websocket-handler-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/raw-websocket-handler-vercel/README.md
+++ b/examples/raw-websocket-handler-vercel/README.md
@@ -1,0 +1,40 @@
+> **Note:** This is the Vercel-optimized version of the [raw-websocket-handler](../raw-websocket-handler) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fraw-websocket-handler-vercel&project-name=raw-websocket-handler-vercel)
+
+# Raw WebSocket Handler
+
+Demonstrates raw WebSocket handling with direct actor connections and real-time chat functionality.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/raw-websocket-handler
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Raw WebSocket handlers**: Use `onWebSocket` for low-level WebSocket control and custom protocols
+- **Direct actor connections**: Connect WebSocket clients directly to actor instances
+- **Connection management**: Track WebSocket connections with state and broadcasting
+- **Real-time chat**: Message broadcasting with user presence and chat history
+- **Persistent state**: Messages and user data automatically saved in actor state
+
+## Implementation
+
+This example demonstrates raw WebSocket handling for real-time chat:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/raw-websocket-handler/src/backend/registry.ts)): Uses `onWebSocket` handler for low-level WebSocket protocol control
+
+## Resources
+
+Read more about [WebSockets](/docs/actors/websockets), [state](/docs/actors/state), and [events](/docs/actors/events).
+
+## License
+
+MIT

--- a/examples/raw-websocket-handler-vercel/api/index.ts
+++ b/examples/raw-websocket-handler-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/raw-websocket-handler-vercel/frontend/App.tsx
+++ b/examples/raw-websocket-handler-vercel/frontend/App.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useEffect, useRef } from "react";
+import { createRivetKit } from "@rivetkit/react";
+import type { registry } from "../src/actors.ts";
+
+const { useActor } = createRivetKit<typeof registry>(`${window.location.origin}/api/rivet`);
+
+export default function App() {
+	const [messages, setMessages] = useState<Array<{ id: string; text: string; timestamp: number }>>([]);
+	const [inputText, setInputText] = useState("");
+	const [isConnected, setIsConnected] = useState(false);
+
+	// Connect to the WebSocket actor
+	const chatRoom = useActor({
+		name: "chatRoom",
+		key: ["random"],
+	});
+
+	// Raw WS we created to connect to the actors
+	const wsRef = useRef<WebSocket | null>(null);
+
+	useEffect(() => {
+		(async () => {
+			const ws = await chatRoom.handle?.websocket();
+
+			if (!ws) return;
+
+			ws.onopen = () => {
+				setIsConnected(true);
+				console.log("Connected via direct access!");
+			};
+
+			ws.onmessage = (event) => {
+				const data = JSON.parse(event.data);
+
+				if (data.type === "init") {
+					setMessages(data.messages);
+				} else if (data.type === "message") {
+					setMessages(prev => [...prev, {
+						id: data.id,
+						text: data.text,
+						timestamp: data.timestamp
+					}]);
+				}
+			};
+
+			ws.onclose = (event) => {
+				setIsConnected(false);
+				console.log("WebSocket closed:", event.code, event.reason);
+			};
+
+			ws.onerror = (event) => {
+				console.error("WebSocket error:", event);
+			};
+
+			wsRef.current = ws;
+		})();
+
+		return () => {
+			if (wsRef.current) {
+				wsRef.current.close();
+			}
+		};
+	}, [chatRoom.handle]);
+
+	const sendMessage = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!inputText.trim() || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+
+		wsRef.current.send(JSON.stringify({
+			type: "message",
+			text: inputText.trim()
+		}));
+		setInputText("");
+	};
+
+	return (
+		<div style={{ maxWidth: "800px", margin: "0 auto", padding: "20px" }}>
+			<h1>Raw WebSocket Chat</h1>
+
+			<div style={{
+				padding: "10px",
+				background: isConnected ? "#4caf50" : "#f44336",
+				color: "white",
+				borderRadius: "4px",
+				marginBottom: "20px"
+			}}>
+				{isConnected ? "Connected" : "Disconnected"}
+			</div>
+
+			<div style={{
+				background: "white",
+				border: "1px solid #ddd",
+				borderRadius: "8px",
+				padding: "10px",
+				height: "400px",
+				overflowY: "auto",
+				marginBottom: "10px"
+			}}>
+				{messages.map((msg) => (
+					<div key={msg.id} style={{ marginBottom: "10px" }}>
+						<strong>{new Date(msg.timestamp).toLocaleTimeString()}:</strong> {msg.text}
+					</div>
+				))}
+			</div>
+
+			<form onSubmit={sendMessage} style={{ display: "flex", gap: "10px" }}>
+				<input
+					type="text"
+					value={inputText}
+					onChange={(e) => setInputText(e.target.value)}
+					placeholder="Type a message..."
+					style={{ flex: 1, padding: "8px", borderRadius: "4px", border: "1px solid #ddd" }}
+				/>
+				<button type="submit">Send</button>
+			</form>
+		</div>
+	);
+}

--- a/examples/raw-websocket-handler-vercel/frontend/main.tsx
+++ b/examples/raw-websocket-handler-vercel/frontend/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
+);

--- a/examples/raw-websocket-handler-vercel/index.html
+++ b/examples/raw-websocket-handler-vercel/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>RivetKit Raw WebSocket Handler</title>
+		<style>
+			body {
+				font-family: system-ui, -apple-system, sans-serif;
+				background: #f5f5f5;
+				margin: 0;
+				padding: 0;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/frontend/main.tsx"></script>
+	</body>
+</html>

--- a/examples/raw-websocket-handler-vercel/package.json
+++ b/examples/raw-websocket-handler-vercel/package.json
@@ -1,0 +1,42 @@
+{
+	"name": "example-raw-websocket-handler-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.7.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.2",
+		"@types/react": "^18.3.16",
+		"@types/react-dom": "^18.3.5",
+		"@vitejs/plugin-react": "^4.3.4",
+		"tsx": "^4.19.2",
+		"typescript": "^5.7.2",
+		"vite": "^6.0.5",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"websocket",
+			"typescript"
+		],
+		"tags": [
+			"real-time"
+		],
+		"priority": 1000,
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/raw-websocket-handler-vercel/src/actors.ts
+++ b/examples/raw-websocket-handler-vercel/src/actors.ts
@@ -1,0 +1,77 @@
+import { actor, setup } from "rivetkit";
+
+export const chatRoom = actor({
+	state: {
+		messages: [] as Array<{
+			id: string;
+			text: string;
+			timestamp: number;
+		}>,
+	},
+	createVars: () => {
+		return {
+			sockets: new Set<any>(),
+		};
+	},
+	onWebSocket(ctx, socket) {
+		// Add socket to the set
+		ctx.vars.sockets.add(socket);
+
+		// Send recent messages to new connection
+		socket.send(
+			JSON.stringify({
+				type: "init",
+				messages: ctx.state.messages,
+			}),
+		);
+
+		// Handle incoming messages
+		socket.addEventListener("message", (event: any) => {
+			try {
+				const data = JSON.parse(event.data);
+
+				if (data.type === "message" && data.text) {
+					const message = {
+						id: crypto.randomUUID(),
+						text: data.text,
+						timestamp: Date.now(),
+					};
+
+					// Add to state
+					ctx.state.messages.push(message);
+					ctx.saveState({});
+
+					// Keep only last 50 messages
+					if (ctx.state.messages.length > 50) {
+						ctx.state.messages.shift();
+					}
+
+					// Broadcast to all connected clients
+					const broadcast = JSON.stringify({
+						type: "message",
+						...message,
+					});
+
+					for (const ws of ctx.vars.sockets) {
+						if (ws.readyState === 1) {
+							// OPEN
+							ws.send(broadcast);
+						}
+					}
+				}
+			} catch (e) {
+				console.error("Failed to process message:", e);
+			}
+		});
+
+		// Remove socket on close
+		socket.addEventListener("close", () => {
+			ctx.vars.sockets.delete(socket);
+		});
+	},
+	actions: {},
+});
+
+export const registry = setup({
+	use: { chatRoom },
+});

--- a/examples/raw-websocket-handler-vercel/src/server.ts
+++ b/examples/raw-websocket-handler-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/raw-websocket-handler-vercel/tsconfig.json
+++ b/examples/raw-websocket-handler-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/raw-websocket-handler-vercel/turbo.json
+++ b/examples/raw-websocket-handler-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/raw-websocket-handler-vercel/vercel.json
+++ b/examples/raw-websocket-handler-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/raw-websocket-handler-vercel/vite.config.ts
+++ b/examples/raw-websocket-handler-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/raw-websocket-handler-vercel/vitest.config.ts
+++ b/examples/raw-websocket-handler-vercel/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/raw-websocket-handler/vercel.json
+++ b/examples/raw-websocket-handler/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/react-vercel/.gitignore
+++ b/examples/react-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/react-vercel/README.md
+++ b/examples/react-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [react](../react) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Freact-vercel&project-name=react-vercel)
+
+# React Integration
+
+Demonstrates React frontend integration with Rivet Actors.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/react
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **React frontend**: Build interactive UIs with React that connect to Rivet Actors
+- **Type-safe client**: Use `@rivetkit/react` hooks for type-safe actor communication
+- **Real-time updates**: Subscribe to actor events for live UI updates
+- **Actor state management**: Actors handle backend logic while React manages UI state
+
+## Implementation
+
+This example demonstrates React frontend integration with Rivet Actors:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/react/src/backend/registry.ts)): Backend actors with React frontend integration using type-safe hooks
+
+## Resources
+
+Read more about [React integration](/docs/platforms/react), [actions](/docs/actors/actions), [state](/docs/actors/state), and [events](/docs/actors/events).
+
+## License
+
+MIT

--- a/examples/react-vercel/api/index.ts
+++ b/examples/react-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/react-vercel/frontend/App.tsx
+++ b/examples/react-vercel/frontend/App.tsx
@@ -1,0 +1,36 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useState } from "react";
+import type { registry } from "../src/actors.ts";
+
+const { useActor } = createRivetKit<typeof registry>(`${window.location.origin}/api/rivet`);
+
+function App() {
+	const [count, setCount] = useState(0);
+	const [counterName, setCounterName] = useState("test-counter");
+
+	const counter = useActor({
+		name: "counter",
+		key: [counterName],
+	});
+
+	counter.useEvent("newCount", (x: number) => setCount(x));
+
+	const increment = async () => {
+		await counter.connection?.increment(1);
+	};
+
+	return (
+		<div>
+			<h1>Counter: {count}</h1>
+			<input
+				type="text"
+				value={counterName}
+				onChange={(e) => setCounterName(e.target.value)}
+				placeholder="Counter name"
+			/>
+			<button onClick={increment}>Increment</button>
+		</div>
+	);
+}
+
+export default App;

--- a/examples/react-vercel/frontend/main.tsx
+++ b/examples/react-vercel/frontend/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
+);

--- a/examples/react-vercel/index.html
+++ b/examples/react-vercel/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hono React Counter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-vercel/package.json
+++ b/examples/react-vercel/package.json
@@ -1,0 +1,40 @@
+{
+	"name": "example-react-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.7.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"react",
+			"typescript"
+		],
+		"tags": [],
+		"frontendPort": 5173
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/react-vercel/pnpm-lock.yaml
+++ b/examples/react-vercel/pnpm-lock.yaml
@@ -1,0 +1,2961 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: '*'
+        version: 2.0.33(@hono/node-server@1.19.7(hono@4.11.3))(@hono/node-ws@1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3))(@standard-schema/spec@1.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ws@8.19.0)
+      hono:
+        specifier: ^4.7.0
+        version: 4.11.3
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+      rivetkit:
+        specifier: '*'
+        version: 2.0.33(@hono/node-server@1.19.7(hono@4.11.3))(@hono/node-ws@1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3))(@standard-schema/spec@1.0.0)(ws@8.19.0)
+      srvx:
+        specifier: ^0.10.0
+        version: 0.10.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.3
+      '@types/react':
+        specifier: ^18.2.0
+        version: 18.3.27
+      '@types/react-dom':
+        specifier: ^18.2.0
+        version: 18.3.7(@types/react@18.3.27)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.21(@types/node@22.19.3))
+      concurrently:
+        specifier: ^8.2.2
+        version: 8.2.2
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@22.19.3)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/node@22.19.3)
+
+packages:
+
+  '@asteasolutions/zod-to-openapi@8.4.0':
+    resolution: {integrity: sha512-Ckp971tmTw4pnv+o7iK85ldBHBKk6gxMaoNyLn3c2Th/fKoTG8G3jdYuOanpdGqwlDB0z01FOjry2d32lfTqrA==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.28.5':
+    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.28.5':
+    resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.28.5':
+    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.2':
+    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.3':
+    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.27.1':
+    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.28.4':
+    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.5':
+    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.27.2':
+    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.28.5':
+    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.5':
+    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.0':
+    resolution: {integrity: sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.0':
+    resolution: {integrity: sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.0':
+    resolution: {integrity: sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.0':
+    resolution: {integrity: sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==}
+    cpu: [arm]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.0':
+    resolution: {integrity: sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.0':
+    resolution: {integrity: sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hono/node-server@1.19.7':
+    resolution: {integrity: sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@hono/node-ws@1.3.0':
+    resolution: {integrity: sha512-ju25YbbvLuXdqBCmLZLqnNYu1nbHIQjoyUqA8ApZOeL1k4skuiTcw5SW77/5SUYo2Xi2NVBJoVlfQurnKEp03Q==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      '@hono/node-server': ^1.19.2
+      hono: ^4.6.0
+
+  '@hono/standard-validator@0.1.5':
+    resolution: {integrity: sha512-EIyZPPwkyLn6XKwFj5NBEWHXhXbgmnVh2ceIFo5GO7gKI9WmzTjPDKnppQB0KrqKeAkq3kpoW4SIbu5X1dgx3w==}
+    peerDependencies:
+      '@standard-schema/spec': 1.0.0
+      hono: '>=3.9.0'
+
+  '@hono/zod-openapi@1.2.0':
+    resolution: {integrity: sha512-KDfHqv/Wy4elVseZXgokbHxeWuqBL+AZfqsOMpEihBMUsk/fJ+bLIi3Sf70JFVpt1Ihui8RasYrInozt7ZBDIA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.3.6'
+      zod: ^4.0.0
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.25.0 || ^4.0.0
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@rivetkit/bare-ts@0.6.2':
+    resolution: {integrity: sha512-3qndQUQXLdwafMEqfhz24hUtDPcsf1Bu3q52Kb8MqeH8JUh3h6R4HYW3ZJXiQsLcyYyFM68PuIwlLRlg1xDEpg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
+  '@rivetkit/engine-runner-protocol@2.0.33':
+    resolution: {integrity: sha512-VyfjwGy8qxGzwYyk63Hy0Nyl8GffV0KbOouWelrDJqbIG9fnZnUg6ntcwzpWqZQj0nMEfyfak8syjp89q5abSg==}
+
+  '@rivetkit/engine-runner@2.0.33':
+    resolution: {integrity: sha512-pW+icImrxPJ3RGnksQhsOhJ50lcnoKdNZkPeFglPaKaE5L1/rDrrwRx8A7jVmF8NDbWL4fGfvB7tsjoi2vY2Aw==}
+
+  '@rivetkit/fast-json-patch@3.1.2':
+    resolution: {integrity: sha512-CtA50xgsSSzICQduF/NDShPRzvucnNvsW/lQO0WgMTT1XAj9Lfae4pm7r3llFwilgG+9iq76Hv1LUqNy72v6yw==}
+
+  '@rivetkit/framework-base@2.0.33':
+    resolution: {integrity: sha512-kFtW1SucXwLPuJSy9jgf8Ot8fUMRKnEj20GjV6fzGIAOroyJTjH3xlWe0YXx8DtP/I/i+0Fkkml9s8JA+Lye7A==}
+
+  '@rivetkit/on-change@6.0.2-rc.1':
+    resolution: {integrity: sha512-5RC9Ze/wTKqSlJvopdCgr+EfyV93+iiH8Thog0QXrl8PT1unuBNw/jadXNMtwgAxrIaCJL+JLaHQH9w7rqpMDw==}
+    engines: {node: '>=20'}
+
+  '@rivetkit/react@2.0.33':
+    resolution: {integrity: sha512-egqlLMf7ECooxXOauRv3tZMLHe133Dq0K8HY+xklWY4YN1gP5MN73OGaUqN2l+92d8F7T8Wn0k/uLjsZmC5/HA==}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.55.1':
+    resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.55.1':
+    resolution: {integrity: sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.55.1':
+    resolution: {integrity: sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.55.1':
+    resolution: {integrity: sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.55.1':
+    resolution: {integrity: sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.55.1':
+    resolution: {integrity: sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
+    resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.55.1':
+    resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.55.1':
+    resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.55.1':
+    resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.55.1':
+    resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.55.1':
+    resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.55.1':
+    resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.55.1':
+    resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.55.1':
+    resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.55.1':
+    resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.55.1':
+    resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.55.1':
+    resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.55.1':
+    resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.55.1':
+    resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.55.1':
+    resolution: {integrity: sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.55.1':
+    resolution: {integrity: sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.55.1':
+    resolution: {integrity: sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.55.1':
+    resolution: {integrity: sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.55.1':
+    resolution: {integrity: sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@tanstack/react-store@0.7.7':
+    resolution: {integrity: sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/store@0.7.7':
+    resolution: {integrity: sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.3':
+    resolution: {integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.27':
+    resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
+
+  '@types/retry@0.12.2':
+    resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  baseline-browser-mapping@2.9.13:
+    resolution: {integrity: sha512-WhtvB2NG2wjr04+h77sg3klAIwrgOqnjS49GGudnUPGFFgg7G17y7Qecqp+2Dr5kUDxNRBca0SK7cG8JwzkWDQ==}
+    hasBin: true
+
+  browserslist@4.28.1:
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  caniuse-lite@1.0.30001763:
+    resolution: {integrity: sha512-mh/dGtq56uN98LlNX9qdbKnzINhX0QzhiWBFEkFfsFO4QyCvL8YegrJAazCwXIeqkIob8BlZPGM3xdnY+sgmvQ==}
+
+  cbor-extract@2.2.0:
+    resolution: {integrity: sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==}
+    hasBin: true
+
+  cbor-x@1.6.0:
+    resolution: {integrity: sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  concurrently@8.2.2:
+    resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
+    engines: {node: ^14.13.0 || >=16.0.0}
+    hasBin: true
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  electron-to-chromium@1.5.267:
+    resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-tsconfig@4.13.0:
+    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  hono@4.11.3:
+    resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
+    engines: {node: '>=16.9.0'}
+
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-network-error@1.3.0:
+    resolution: {integrity: sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==}
+    engines: {node: '>=16'}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoevents@9.1.0:
+    resolution: {integrity: sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-gyp-build-optional-packages@5.1.1:
+    resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
+    hasBin: true
+
+  node-releases@2.0.27:
+    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
+  p-retry@6.2.1:
+    resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
+    engines: {node: '>=16.17'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.0.0:
+    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  rivetkit@2.0.33:
+    resolution: {integrity: sha512-gTVuZ7cLlGeol8pfJRdrdo1DEhXu1iYvEENPY6uoYi5fDAbsL9uZtcCsQI6xT3Fi6Md7l4xgiuO3bNTHXiqJ6A==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@hono/node-server': ^1.14.0
+      '@hono/node-ws': ^1.1.1
+      eventsource: ^4.0.0
+      ws: ^8.0.0
+    peerDependenciesMeta:
+      '@hono/node-server':
+        optional: true
+      '@hono/node-ws':
+        optional: true
+      eventsource:
+        optional: true
+      ws:
+        optional: true
+
+  rollup@4.55.1:
+    resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sonic-boom@4.2.0:
+    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  spawn-command@0.0.2:
+    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  srvx@0.10.0:
+    resolution: {integrity: sha512-NqIsR+wQCfkvvwczBh8J8uM4wTZx41K2lLSEp/3oMp917ODVVMtW5Me4epCmQ3gH8D+0b+/t4xxkUKutyhimTA==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@3.14.0:
+    resolution: {integrity: sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.2:
+    resolution: {integrity: sha512-heMioaxBcG9+Znsda5Q8sQbWnLJSl98AFDXTO80wELWEzX3hordXsTdxrIfMQoO9IY1MEnoGoPjpoKpMj+Yx0Q==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  uuid@12.0.0:
+    resolution: {integrity: sha512-USe1zesMYh4fjCA8ZH5+X5WIVD0J4V1Jksm1bFTVBX2F/cwSXt0RO5w/3UXbdLKmZX65MiWV+hwhSS8p6oBTGA==}
+    hasBin: true
+
+  vbare@0.0.4:
+    resolution: {integrity: sha512-QsxSVw76NqYUWYPVcQmOnQPX8buIVjgn+yqldTHlWISulBTB9TJ9rnzZceDu+GZmycOtzsmuPbPN1YNxvK12fg==}
+    engines: {node: '>=18.0.0'}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  zod@4.3.5:
+    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
+
+snapshots:
+
+  '@asteasolutions/zod-to-openapi@8.4.0(zod@4.3.5)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 4.3.5
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.28.5': {}
+
+  '@babel/core@7.28.5':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helpers': 7.28.4
+      '@babel/parser': 7.28.5
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.28.5':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.27.2':
+    dependencies:
+      '@babel/compat-data': 7.28.5
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.27.1': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.28.4':
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.5
+
+  '@babel/parser@7.28.5':
+    dependencies:
+      '@babel/types': 7.28.5
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/runtime@7.28.4': {}
+
+  '@babel/template@7.27.2':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+
+  '@babel/traverse@7.28.5':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.5
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.5
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.5
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.0':
+    optional: true
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.0':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.0':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.0':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.0':
+    optional: true
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.0':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@hono/node-server@1.19.7(hono@4.11.3)':
+    dependencies:
+      hono: 4.11.3
+
+  '@hono/node-ws@1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)':
+    dependencies:
+      '@hono/node-server': 1.19.7(hono@4.11.3)
+      hono: 4.11.3
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@hono/standard-validator@0.1.5(@standard-schema/spec@1.0.0)(hono@4.11.3)':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      hono: 4.11.3
+
+  '@hono/zod-openapi@1.2.0(hono@4.11.3)(zod@4.3.5)':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 8.4.0(zod@4.3.5)
+      '@hono/zod-validator': 0.7.6(hono@4.11.3)(zod@4.3.5)
+      hono: 4.11.3
+      openapi3-ts: 4.5.0
+      zod: 4.3.5
+
+  '@hono/zod-validator@0.7.6(hono@4.11.3)(zod@4.3.5)':
+    dependencies:
+      hono: 4.11.3
+      zod: 4.3.5
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@pinojs/redact@0.4.0': {}
+
+  '@rivetkit/bare-ts@0.6.2': {}
+
+  '@rivetkit/engine-runner-protocol@2.0.33':
+    dependencies:
+      '@rivetkit/bare-ts': 0.6.2
+
+  '@rivetkit/engine-runner@2.0.33':
+    dependencies:
+      '@rivetkit/engine-runner-protocol': 2.0.33
+      pino: 9.14.0
+      uuid: 12.0.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@rivetkit/fast-json-patch@3.1.2': {}
+
+  '@rivetkit/framework-base@2.0.33(@hono/node-server@1.19.7(hono@4.11.3))(@hono/node-ws@1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3))(@standard-schema/spec@1.0.0)(ws@8.19.0)':
+    dependencies:
+      '@tanstack/store': 0.7.7
+      fast-deep-equal: 3.1.3
+      rivetkit: 2.0.33(@hono/node-server@1.19.7(hono@4.11.3))(@hono/node-ws@1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3))(@standard-schema/spec@1.0.0)(ws@8.19.0)
+    transitivePeerDependencies:
+      - '@hono/node-server'
+      - '@hono/node-ws'
+      - '@standard-schema/spec'
+      - bufferutil
+      - eventsource
+      - utf-8-validate
+      - ws
+
+  '@rivetkit/on-change@6.0.2-rc.1': {}
+
+  '@rivetkit/react@2.0.33(@hono/node-server@1.19.7(hono@4.11.3))(@hono/node-ws@1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3))(@standard-schema/spec@1.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ws@8.19.0)':
+    dependencies:
+      '@rivetkit/framework-base': 2.0.33(@hono/node-server@1.19.7(hono@4.11.3))(@hono/node-ws@1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3))(@standard-schema/spec@1.0.0)(ws@8.19.0)
+      '@tanstack/react-store': 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      rivetkit: 2.0.33(@hono/node-server@1.19.7(hono@4.11.3))(@hono/node-ws@1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3))(@standard-schema/spec@1.0.0)(ws@8.19.0)
+    transitivePeerDependencies:
+      - '@hono/node-server'
+      - '@hono/node-ws'
+      - '@standard-schema/spec'
+      - bufferutil
+      - eventsource
+      - utf-8-validate
+      - ws
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.55.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.55.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.55.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.55.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.55.1':
+    optional: true
+
+  '@standard-schema/spec@1.0.0': {}
+
+  '@tanstack/react-store@0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/store': 0.7.7
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  '@tanstack/store@0.7.7': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.28.5
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.5
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.3':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.27)':
+    dependencies:
+      '@types/react': 18.3.27
+
+  '@types/react@18.3.27':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@types/retry@0.12.2': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.19.3))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.21(@types/node@22.19.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@22.19.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.3)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  acorn@8.15.0: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  any-promise@1.3.0: {}
+
+  assertion-error@2.0.1: {}
+
+  atomic-sleep@1.0.0: {}
+
+  baseline-browser-mapping@2.9.13: {}
+
+  browserslist@4.28.1:
+    dependencies:
+      baseline-browser-mapping: 2.9.13
+      caniuse-lite: 1.0.30001763
+      electron-to-chromium: 1.5.267
+      node-releases: 2.0.27
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-from@1.1.2: {}
+
+  bundle-require@5.1.0(esbuild@0.27.2):
+    dependencies:
+      esbuild: 0.27.2
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  caniuse-lite@1.0.30001763: {}
+
+  cbor-extract@2.2.0:
+    dependencies:
+      node-gyp-build-optional-packages: 5.1.1
+    optionalDependencies:
+      '@cbor-extract/cbor-extract-darwin-arm64': 2.2.0
+      '@cbor-extract/cbor-extract-darwin-x64': 2.2.0
+      '@cbor-extract/cbor-extract-linux-arm': 2.2.0
+      '@cbor-extract/cbor-extract-linux-arm64': 2.2.0
+      '@cbor-extract/cbor-extract-linux-x64': 2.2.0
+      '@cbor-extract/cbor-extract-win32-x64': 2.2.0
+    optional: true
+
+  cbor-x@1.6.0:
+    optionalDependencies:
+      cbor-extract: 2.2.0
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  check-error@2.1.3: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@4.1.1: {}
+
+  concurrently@8.2.2:
+    dependencies:
+      chalk: 4.1.2
+      date-fns: 2.30.0
+      lodash: 4.17.21
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      spawn-command: 0.0.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  date-fns@2.30.0:
+    dependencies:
+      '@babel/runtime': 7.28.4
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  electron-to-chromium@1.5.267: {}
+
+  emoji-regex@8.0.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.27.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
+
+  escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.55.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-tsconfig@4.13.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  has-flag@4.0.0: {}
+
+  hono@4.11.3: {}
+
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-network-error@1.3.0: {}
+
+  joycon@3.1.1: {}
+
+  js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  lodash@4.17.21: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.2
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoevents@9.1.0: {}
+
+  nanoid@3.3.11: {}
+
+  node-gyp-build-optional-packages@5.1.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
+
+  node-releases@2.0.27: {}
+
+  object-assign@4.1.1: {}
+
+  on-exit-leak-free@2.1.2: {}
+
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.2
+
+  p-retry@6.2.1:
+    dependencies:
+      '@types/retry': 0.12.2
+      is-network-error: 1.3.0
+      retry: 0.13.1
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.0.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.0.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.0
+      thread-stream: 3.1.0
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@3.14.0)(yaml@2.8.2):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+      tsx: 3.14.0
+      yaml: 2.8.2
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  process-warning@5.0.0: {}
+
+  quick-format-unescaped@4.0.4: {}
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  readdirp@4.1.2: {}
+
+  real-require@0.2.0: {}
+
+  require-directory@2.1.1: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  retry@0.13.1: {}
+
+  rivetkit@2.0.33(@hono/node-server@1.19.7(hono@4.11.3))(@hono/node-ws@1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3))(@standard-schema/spec@1.0.0)(ws@8.19.0):
+    dependencies:
+      '@hono/standard-validator': 0.1.5(@standard-schema/spec@1.0.0)(hono@4.11.3)
+      '@hono/zod-openapi': 1.2.0(hono@4.11.3)(zod@4.3.5)
+      '@rivetkit/bare-ts': 0.6.2
+      '@rivetkit/engine-runner': 2.0.33
+      '@rivetkit/fast-json-patch': 3.1.2
+      '@rivetkit/on-change': 6.0.2-rc.1
+      cbor-x: 1.6.0
+      hono: 4.11.3
+      invariant: 2.2.4
+      nanoevents: 9.1.0
+      p-retry: 6.2.1
+      pino: 9.14.0
+      uuid: 12.0.0
+      vbare: 0.0.4
+      zod: 4.3.5
+    optionalDependencies:
+      '@hono/node-server': 1.19.7(hono@4.11.3)
+      '@hono/node-ws': 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - '@standard-schema/spec'
+      - bufferutil
+      - utf-8-validate
+
+  rollup@4.55.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.55.1
+      '@rollup/rollup-android-arm64': 4.55.1
+      '@rollup/rollup-darwin-arm64': 4.55.1
+      '@rollup/rollup-darwin-x64': 4.55.1
+      '@rollup/rollup-freebsd-arm64': 4.55.1
+      '@rollup/rollup-freebsd-x64': 4.55.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.55.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.55.1
+      '@rollup/rollup-linux-arm64-gnu': 4.55.1
+      '@rollup/rollup-linux-arm64-musl': 4.55.1
+      '@rollup/rollup-linux-loong64-gnu': 4.55.1
+      '@rollup/rollup-linux-loong64-musl': 4.55.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.55.1
+      '@rollup/rollup-linux-ppc64-musl': 4.55.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.55.1
+      '@rollup/rollup-linux-riscv64-musl': 4.55.1
+      '@rollup/rollup-linux-s390x-gnu': 4.55.1
+      '@rollup/rollup-linux-x64-gnu': 4.55.1
+      '@rollup/rollup-linux-x64-musl': 4.55.1
+      '@rollup/rollup-openbsd-x64': 4.55.1
+      '@rollup/rollup-openharmony-arm64': 4.55.1
+      '@rollup/rollup-win32-arm64-msvc': 4.55.1
+      '@rollup/rollup-win32-ia32-msvc': 4.55.1
+      '@rollup/rollup-win32-x64-gnu': 4.55.1
+      '@rollup/rollup-win32-x64-msvc': 4.55.1
+      fsevents: 2.3.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-stable-stringify@2.5.0: {}
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
+
+  shell-quote@1.8.3: {}
+
+  siginfo@2.0.0: {}
+
+  sonic-boom@4.2.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  source-map@0.7.6: {}
+
+  spawn-command@0.0.2: {}
+
+  split2@4.2.0: {}
+
+  srvx@0.10.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1: {}
+
+  tsup@8.5.1(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.2)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.2
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@3.14.0)(yaml@2.8.2)
+      resolve-from: 5.0.0
+      rollup: 4.55.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@3.14.0:
+    dependencies:
+      esbuild: 0.18.20
+      get-tsconfig: 4.13.0
+      source-map-support: 0.5.21
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.2: {}
+
+  undici-types@6.21.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
+    dependencies:
+      browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  uuid@12.0.0: {}
+
+  vbare@0.0.4: {}
+
+  vite-node@3.2.4(@types/node@22.19.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.21(@types/node@22.19.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.3):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.55.1
+    optionalDependencies:
+      '@types/node': 22.19.3
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.19.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@22.19.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@22.19.3)
+      vite-node: 3.2.4(@types/node@22.19.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  ws@8.19.0: {}
+
+  y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
+
+  yaml@2.8.2: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  zod@4.3.5: {}

--- a/examples/react-vercel/src/actors.ts
+++ b/examples/react-vercel/src/actors.ts
@@ -1,0 +1,16 @@
+import { actor, setup } from "rivetkit";
+
+export const counter = actor({
+	state: { count: 0 },
+	actions: {
+		increment: (c, x: number) => {
+			c.state.count += x;
+			c.broadcast("newCount", c.state.count);
+			return c.state.count;
+		},
+	},
+});
+
+export const registry = setup({
+	use: { counter },
+});

--- a/examples/react-vercel/src/server.ts
+++ b/examples/react-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/react-vercel/tsconfig.json
+++ b/examples/react-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/react-vercel/turbo.json
+++ b/examples/react-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/react-vercel/vercel.json
+++ b/examples/react-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/react-vercel/vite.config.ts
+++ b/examples/react-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/react/vercel.json
+++ b/examples/react/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/scheduling-vercel/.gitignore
+++ b/examples/scheduling-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/scheduling-vercel/README.md
+++ b/examples/scheduling-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [scheduling](../scheduling) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fscheduling-vercel&project-name=scheduling-vercel)
+
+# Scheduling
+
+Demonstrates how to schedule tasks and execute code at specific times or intervals using Rivet Actors.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/scheduling
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Task scheduling**: Schedule actor actions to run at specific times with `schedule.at()`
+- **Delayed execution**: Schedule tasks to run after a delay with `schedule.after()`
+- **Persistent schedules**: Scheduled tasks survive actor restarts
+- **Action callbacks**: Scheduled tasks invoke actor actions with custom payloads
+
+## Implementation
+
+This example demonstrates time-based task scheduling in Rivet Actors:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/scheduling/src/backend/registry.ts)): Shows how to use `schedule.at()` and `schedule.after()` to schedule future actions with persistent state
+
+## Resources
+
+Read more about [scheduling](/docs/actors/scheduling), [actions](/docs/actors/actions), and [state](/docs/actors/state).
+
+## License
+
+MIT

--- a/examples/scheduling-vercel/api/index.ts
+++ b/examples/scheduling-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/scheduling-vercel/frontend/App.tsx
+++ b/examples/scheduling-vercel/frontend/App.tsx
@@ -1,0 +1,268 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useEffect, useState } from "react";
+import type { Reminder, Registry } from "../src/actors.ts";
+
+const { useActor } = createRivetKit<Registry>(`${window.location.origin}/api/rivet`);
+
+export function App() {
+	const [reminders, setReminders] = useState<Reminder[]>([]);
+	const [message, setMessage] = useState("");
+	const [delay, setDelay] = useState(5);
+	const [timestamp, setTimestamp] = useState("");
+	const [triggeredReminders, setTriggeredReminders] = useState<Reminder[]>([]);
+	const [stats, setStats] = useState({ total: 0, completed: 0, pending: 0 });
+
+	const reminderActor = useActor({
+		name: "reminderActor",
+		key: ["main"],
+	});
+
+	// Load initial state
+	useEffect(() => {
+		if (reminderActor.connection) {
+			reminderActor.connection.getReminders().then((initialReminders) => {
+				setReminders(initialReminders);
+			}).catch((error) => {
+				console.error("error loading reminders", error);
+			});
+
+			reminderActor.connection.getStats().then((initialStats) => {
+				setStats(initialStats);
+			}).catch((error) => {
+				console.error("error loading stats", error);
+			});
+		}
+	}, [reminderActor.connection]);
+
+	// Listen for reminder triggered events
+	reminderActor.useEvent("reminderTriggered", (reminder: Reminder) => {
+		// Update the reminders list
+		setReminders((prev) =>
+			prev.map((r) => (r.id === reminder.id ? reminder : r))
+		);
+
+		// Add to triggered notifications
+		setTriggeredReminders((prev) => [reminder, ...prev].slice(0, 5));
+
+		// Update stats
+		if (reminderActor.connection) {
+			reminderActor.connection.getStats().then(setStats).catch((error) => {
+				console.error("error loading stats", error);
+			});
+		}
+	});
+
+	// Schedule a reminder with delay
+	const handleScheduleReminder = async () => {
+		if (!reminderActor.connection || !message.trim()) return;
+
+		const delayMs = delay * 1000;
+		const reminder = await reminderActor.connection.scheduleReminder(message, delayMs);
+		setReminders((prev) => [...prev, reminder]);
+		setMessage("");
+
+		// Update stats
+		const newStats = await reminderActor.connection.getStats();
+		setStats(newStats);
+	};
+
+	// Schedule a reminder at a specific time
+	const handleScheduleAt = async () => {
+		if (!reminderActor.connection || !message.trim() || !timestamp) return;
+
+		const timestampMs = new Date(timestamp).getTime();
+		const reminder = await reminderActor.connection.scheduleReminderAt(message, timestampMs);
+		setReminders((prev) => [...prev, reminder]);
+		setMessage("");
+		setTimestamp("");
+
+		// Update stats
+		const newStats = await reminderActor.connection.getStats();
+		setStats(newStats);
+	};
+
+	// Cancel a reminder
+	const handleCancelReminder = async (reminderId: string) => {
+		if (!reminderActor.connection) return;
+
+		await reminderActor.connection.cancelReminder(reminderId);
+		setReminders((prev) => prev.filter((r) => r.id !== reminderId));
+
+		// Update stats
+		const newStats = await reminderActor.connection.getStats();
+		setStats(newStats);
+	};
+
+	// Calculate time until reminder triggers
+	const getTimeUntil = (scheduledAt: number) => {
+		const now = Date.now();
+		const diff = scheduledAt - now;
+
+		if (diff <= 0) return "now";
+
+		const seconds = Math.floor(diff / 1000);
+		const minutes = Math.floor(seconds / 60);
+		const hours = Math.floor(minutes / 60);
+
+		if (hours > 0) return `in ${hours}h ${minutes % 60}m`;
+		if (minutes > 0) return `in ${minutes}m ${seconds % 60}s`;
+		return `in ${seconds}s`;
+	};
+
+	// Clear triggered notifications
+	const clearTriggered = () => {
+		setTriggeredReminders([]);
+	};
+
+	return (
+		<div className="app">
+			<div className="header">
+				<h1>Quickstart: Scheduling</h1>
+				<p>Demonstrating c.schedule.after() and c.schedule.at()</p>
+			</div>
+
+			<div className="stats-bar">
+				<div className="stat">
+					<span className="stat-label">Total:</span>
+					<span className="stat-value">{stats.total}</span>
+				</div>
+				<div className="stat">
+					<span className="stat-label">Completed:</span>
+					<span className="stat-value">{stats.completed}</span>
+				</div>
+				<div className="stat">
+					<span className="stat-label">Pending:</span>
+					<span className="stat-value">{stats.pending}</span>
+				</div>
+			</div>
+
+			{triggeredReminders.length > 0 && (
+				<div className="notifications">
+					<div className="notifications-header">
+						<h3>Recent Notifications</h3>
+						<button onClick={clearTriggered} className="clear-btn">Clear</button>
+					</div>
+					{triggeredReminders.map((reminder) => (
+						<div key={reminder.id} className="notification">
+							<div className="notification-icon">🔔</div>
+							<div className="notification-content">
+								<div className="notification-message">{reminder.message}</div>
+								<div className="notification-time">
+									Triggered at {new Date(reminder.completedAt!).toLocaleTimeString()}
+								</div>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+
+			<div className="content">
+				<div className="section">
+					<h2>Schedule Reminder</h2>
+
+					<div className="form-group">
+						<label>Message:</label>
+						<input
+							type="text"
+							value={message}
+							onChange={(e) => setMessage(e.currentTarget.value)}
+							placeholder="Enter reminder message"
+							className="input"
+						/>
+					</div>
+
+					<div className="schedule-options">
+						<div className="option">
+							<h3>After Delay</h3>
+							<div className="form-group">
+								<label>Delay (seconds):</label>
+								<input
+									type="number"
+									value={delay}
+									onChange={(e) => setDelay(Number(e.currentTarget.value))}
+									min="1"
+									className="input"
+								/>
+							</div>
+							<button
+								onClick={handleScheduleReminder}
+								disabled={!message.trim()}
+								className="btn btn-primary"
+							>
+								Schedule Reminder
+							</button>
+						</div>
+
+						<div className="option">
+							<h3>At Specific Time</h3>
+							<div className="form-group">
+								<label>Date & Time:</label>
+								<input
+									type="datetime-local"
+									value={timestamp}
+									onChange={(e) => setTimestamp(e.currentTarget.value)}
+									className="input"
+								/>
+							</div>
+							<button
+								onClick={handleScheduleAt}
+								disabled={!message.trim() || !timestamp}
+								className="btn btn-primary"
+							>
+								Schedule at Time
+							</button>
+						</div>
+					</div>
+				</div>
+
+				<div className="section">
+					<h2>Reminders</h2>
+					{reminders.length === 0 ? (
+						<div className="empty-state">No reminders scheduled</div>
+					) : (
+						<div className="reminders-list">
+							{reminders.map((reminder) => (
+								<div
+									key={reminder.id}
+									className={`reminder-item ${reminder.completedAt ? 'completed' : 'pending'}`}
+								>
+									<div className="reminder-content">
+										<div className="reminder-message">{reminder.message}</div>
+										<div className="reminder-meta">
+											{reminder.completedAt ? (
+												<span className="reminder-status completed">
+													✓ Completed at {new Date(reminder.completedAt).toLocaleString()}
+												</span>
+											) : (
+												<>
+													<span className="reminder-status pending">
+														{getTimeUntil(reminder.scheduledAt)}
+													</span>
+													<span className="reminder-scheduled">
+														Scheduled: {new Date(reminder.scheduledAt).toLocaleString()}
+													</span>
+												</>
+											)}
+										</div>
+									</div>
+									{!reminder.completedAt && (
+										<button
+											onClick={() => handleCancelReminder(reminder.id)}
+											className="btn btn-cancel"
+										>
+											Cancel
+										</button>
+									)}
+								</div>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
+
+			{!reminderActor.connection && (
+				<div className="loading-overlay">Connecting to server...</div>
+			)}
+		</div>
+	);
+}

--- a/examples/scheduling-vercel/frontend/main.tsx
+++ b/examples/scheduling-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/scheduling-vercel/index.html
+++ b/examples/scheduling-vercel/index.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quickstart: Scheduling</title>
+    <style>
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 20px;
+        }
+
+        .app {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .header {
+            text-align: center;
+            color: white;
+            margin-bottom: 30px;
+        }
+
+        .header h1 {
+            font-size: 2.5rem;
+            margin-bottom: 10px;
+            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+        }
+
+        .header p {
+            font-size: 1.1rem;
+            opacity: 0.9;
+        }
+
+        .stats-bar {
+            display: flex;
+            gap: 15px;
+            justify-content: center;
+            margin-bottom: 30px;
+            flex-wrap: wrap;
+        }
+
+        .stat {
+            background: rgba(255, 255, 255, 0.95);
+            padding: 15px 25px;
+            border-radius: 12px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 5px;
+        }
+
+        .stat-label {
+            font-size: 0.9rem;
+            color: #666;
+            font-weight: 500;
+        }
+
+        .stat-value {
+            font-size: 1.8rem;
+            font-weight: bold;
+            color: #667eea;
+        }
+
+        .notifications {
+            background: rgba(255, 255, 255, 0.95);
+            border-radius: 12px;
+            padding: 20px;
+            margin-bottom: 30px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
+
+        .notifications-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 15px;
+        }
+
+        .notifications-header h3 {
+            color: #333;
+            font-size: 1.2rem;
+        }
+
+        .clear-btn {
+            background: #f44336;
+            color: white;
+            border: none;
+            padding: 8px 16px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: background 0.2s;
+        }
+
+        .clear-btn:hover {
+            background: #d32f2f;
+        }
+
+        .notification {
+            display: flex;
+            gap: 15px;
+            padding: 15px;
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            border-radius: 8px;
+            margin-bottom: 10px;
+            animation: slideIn 0.3s ease-out;
+        }
+
+        @keyframes slideIn {
+            from {
+                transform: translateX(-20px);
+                opacity: 0;
+            }
+            to {
+                transform: translateX(0);
+                opacity: 1;
+            }
+        }
+
+        .notification-icon {
+            font-size: 1.5rem;
+        }
+
+        .notification-content {
+            flex: 1;
+        }
+
+        .notification-message {
+            font-weight: 600;
+            color: #333;
+            margin-bottom: 5px;
+        }
+
+        .notification-time {
+            font-size: 0.9rem;
+            color: #666;
+        }
+
+        .content {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 30px;
+        }
+
+        @media (max-width: 768px) {
+            .content {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .section {
+            background: rgba(255, 255, 255, 0.95);
+            border-radius: 12px;
+            padding: 25px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
+
+        .section h2 {
+            color: #333;
+            margin-bottom: 20px;
+            font-size: 1.5rem;
+        }
+
+        .section h3 {
+            color: #555;
+            margin-bottom: 15px;
+            font-size: 1.1rem;
+        }
+
+        .form-group {
+            margin-bottom: 15px;
+        }
+
+        .form-group label {
+            display: block;
+            color: #555;
+            margin-bottom: 8px;
+            font-weight: 500;
+        }
+
+        .input {
+            width: 100%;
+            padding: 12px;
+            border: 2px solid #e0e0e0;
+            border-radius: 8px;
+            font-size: 1rem;
+            transition: border-color 0.2s;
+        }
+
+        .input:focus {
+            outline: none;
+            border-color: #667eea;
+        }
+
+        .schedule-options {
+            display: grid;
+            gap: 20px;
+        }
+
+        .option {
+            padding: 20px;
+            background: #f8f9fa;
+            border-radius: 8px;
+        }
+
+        .btn {
+            padding: 12px 24px;
+            border: none;
+            border-radius: 8px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+            width: 100%;
+        }
+
+        .btn-primary {
+            background: #667eea;
+            color: white;
+        }
+
+        .btn-primary:hover:not(:disabled) {
+            background: #5568d3;
+            transform: translateY(-1px);
+            box-shadow: 0 4px 8px rgba(102, 126, 234, 0.3);
+        }
+
+        .btn-primary:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+
+        .btn-cancel {
+            background: #f44336;
+            color: white;
+            padding: 8px 16px;
+            font-size: 0.9rem;
+            width: auto;
+        }
+
+        .btn-cancel:hover {
+            background: #d32f2f;
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 40px;
+            color: #999;
+            font-size: 1.1rem;
+        }
+
+        .reminders-list {
+            display: flex;
+            flex-direction: column;
+            gap: 15px;
+        }
+
+        .reminder-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 15px;
+            border-radius: 8px;
+            transition: all 0.2s;
+        }
+
+        .reminder-item.pending {
+            background: #e3f2fd;
+            border-left: 4px solid #2196f3;
+        }
+
+        .reminder-item.completed {
+            background: #e8f5e9;
+            border-left: 4px solid #4caf50;
+            opacity: 0.8;
+        }
+
+        .reminder-content {
+            flex: 1;
+        }
+
+        .reminder-message {
+            font-weight: 600;
+            color: #333;
+            margin-bottom: 8px;
+            font-size: 1.05rem;
+        }
+
+        .reminder-meta {
+            display: flex;
+            gap: 15px;
+            flex-wrap: wrap;
+            font-size: 0.9rem;
+        }
+
+        .reminder-status {
+            font-weight: 500;
+        }
+
+        .reminder-status.pending {
+            color: #2196f3;
+        }
+
+        .reminder-status.completed {
+            color: #4caf50;
+        }
+
+        .reminder-scheduled {
+            color: #666;
+        }
+
+        .loading-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.8);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 1.5rem;
+            z-index: 1000;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/scheduling-vercel/package.json
+++ b/examples/scheduling-vercel/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "scheduling-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.0.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"typescript"
+		],
+		"tags": [],
+		"priority": 1000,
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/scheduling-vercel/src/actors.ts
+++ b/examples/scheduling-vercel/src/actors.ts
@@ -1,0 +1,109 @@
+import { actor, setup } from "rivetkit";
+
+interface Reminder {
+	id: string;
+	message: string;
+	scheduledAt: number;
+	completedAt?: number;
+}
+
+interface ReminderActorState {
+	reminders: Reminder[];
+	completedCount: number;
+}
+
+const reminderActor = actor({
+	state: {
+		reminders: [] as Reminder[],
+		completedCount: 0,
+	} satisfies ReminderActorState as ReminderActorState,
+
+	actions: {
+		// Schedule a reminder with a delay in milliseconds
+		scheduleReminder: (c, message: string, delayMs: number) => {
+			const reminder: Reminder = {
+				id: `reminder-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+				message,
+				scheduledAt: Date.now() + delayMs,
+			};
+
+			c.state.reminders.push(reminder);
+			c.schedule.after(delayMs, "triggerReminder", reminder.id);
+
+			return reminder;
+		},
+
+		// Schedule a reminder at a specific timestamp
+		scheduleReminderAt: (c, message: string, timestamp: number) => {
+			const reminder: Reminder = {
+				id: `reminder-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+				message,
+				scheduledAt: timestamp,
+			};
+
+			c.state.reminders.push(reminder);
+			c.schedule.at(timestamp, "triggerReminder", reminder.id);
+
+			return reminder;
+		},
+
+		// Trigger a scheduled reminder
+		triggerReminder: (c, reminderId: string) => {
+			const reminder = c.state.reminders.find((r) => r.id === reminderId);
+			if (!reminder) {
+				console.warn(`reminder not found: ${reminderId}`);
+				return;
+			}
+
+			// Mark as completed
+			reminder.completedAt = Date.now();
+			c.state.completedCount++;
+
+			// Broadcast event
+			c.broadcast("reminderTriggered", reminder);
+
+			console.log(`reminder triggered: ${reminder.message}`);
+		},
+
+		// Get all reminders
+		getReminders: (c): Reminder[] => {
+			return c.state.reminders;
+		},
+
+		// Cancel a scheduled reminder
+		// Note: Rivet doesn't currently support canceling scheduled actions
+		// This will only remove the reminder from state
+		cancelReminder: (c, reminderId: string) => {
+			// Remove from state
+			c.state.reminders = c.state.reminders.filter(
+				(r) => r.id !== reminderId,
+			);
+
+			return {
+				success: true,
+				message:
+					"reminder removed from state (note: scheduled action may still fire)",
+			};
+		},
+
+		// Get statistics about reminders
+		getStats: (c) => {
+			const total = c.state.reminders.length;
+			const completed = c.state.completedCount;
+			const pending = total - completed;
+
+			return {
+				total,
+				completed,
+				pending,
+			};
+		},
+	},
+});
+
+export const registry = setup({
+	use: { reminderActor },
+});
+
+export type Registry = typeof registry;
+export type { Reminder };

--- a/examples/scheduling-vercel/src/server.ts
+++ b/examples/scheduling-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/scheduling-vercel/tests/scheduling.test.ts
+++ b/examples/scheduling-vercel/tests/scheduling.test.ts
@@ -1,0 +1,218 @@
+import { setupTest } from "rivetkit/test";
+import { describe, expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+// Helper to wait for a delay
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("reminder scheduling", () => {
+	test("triggers reminder after delay", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+		const reminderClient =
+			client.reminderActor.getOrCreate("test-after-delay");
+		const reminder = await reminderClient.scheduleReminder(
+			"Test reminder",
+			100,
+		);
+
+		// Verify reminder was created
+		expect(reminder.id).toBeDefined();
+		expect(reminder.message).toBe("Test reminder");
+		expect(reminder.completedAt).toBeUndefined();
+
+		// Wait for the scheduled action to execute
+		await wait(150);
+
+		const reminders = await reminderClient.getReminders();
+		const completed = reminders.find((r) => r.id === reminder.id);
+
+		expect(completed?.completedAt).toBeDefined();
+	});
+
+	test("schedules reminder at specific timestamp", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+		const reminderClient =
+			client.reminderActor.getOrCreate("test-at-timestamp");
+		const futureTime = Date.now() + 100;
+		const reminder = await reminderClient.scheduleReminderAt(
+			"Future reminder",
+			futureTime,
+		);
+
+		// Verify reminder was created
+		expect(reminder.scheduledAt).toBe(futureTime);
+		expect(reminder.completedAt).toBeUndefined();
+
+		// Wait for the scheduled time
+		await wait(150);
+
+		const reminders = await reminderClient.getReminders();
+		const completed = reminders.find((r) => r.id === reminder.id);
+
+		expect(completed?.completedAt).toBeDefined();
+	});
+
+	test("passes correct arguments to scheduled actions", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+		const reminderClient =
+			client.reminderActor.getOrCreate("test-arguments");
+
+		// Schedule multiple reminders with different IDs
+		const reminder1 = await reminderClient.scheduleReminder(
+			"First reminder",
+			50,
+		);
+		const reminder2 = await reminderClient.scheduleReminder(
+			"Second reminder",
+			100,
+		);
+		const reminder3 = await reminderClient.scheduleReminder(
+			"Third reminder",
+			150,
+		);
+
+		// Wait for all to trigger
+		await wait(200);
+
+		const reminders = await reminderClient.getReminders();
+
+		// Verify each reminder received the correct ID and was triggered
+		const completed1 = reminders.find((r) => r.id === reminder1.id);
+		const completed2 = reminders.find((r) => r.id === reminder2.id);
+		const completed3 = reminders.find((r) => r.id === reminder3.id);
+
+		expect(completed1?.completedAt).toBeDefined();
+		expect(completed2?.completedAt).toBeDefined();
+		expect(completed3?.completedAt).toBeDefined();
+	});
+
+	test("cancels scheduled reminder", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+		const reminderClient = client.reminderActor.getOrCreate("test-cancel");
+		const reminder = await reminderClient.scheduleReminder(
+			"To be cancelled",
+			100,
+		);
+
+		// Cancel the reminder before it triggers
+		await reminderClient.cancelReminder(reminder.id);
+
+		// Wait past the original trigger time
+		await wait(150);
+
+		const reminders = await reminderClient.getReminders();
+		const found = reminders.find((r) => r.id === reminder.id);
+
+		// Reminder should not exist (was removed from state)
+		expect(found).toBeUndefined();
+	});
+
+	test("triggers multiple reminders in correct order", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+		const reminderClient =
+			client.reminderActor.getOrCreate("test-multiple");
+
+		// Schedule 5 reminders with different delays
+		const reminder1 = await reminderClient.scheduleReminder(
+			"Reminder 1",
+			50,
+		);
+		const reminder2 = await reminderClient.scheduleReminder(
+			"Reminder 2",
+			100,
+		);
+		const reminder3 = await reminderClient.scheduleReminder(
+			"Reminder 3",
+			150,
+		);
+		const reminder4 = await reminderClient.scheduleReminder(
+			"Reminder 4",
+			200,
+		);
+		const reminder5 = await reminderClient.scheduleReminder(
+			"Reminder 5",
+			250,
+		);
+
+		// Wait for all to complete
+		await wait(300);
+
+		const reminders = await reminderClient.getReminders();
+
+		// Verify all are completed
+		expect(
+			reminders.find((r) => r.id === reminder1.id)?.completedAt,
+		).toBeDefined();
+		expect(
+			reminders.find((r) => r.id === reminder2.id)?.completedAt,
+		).toBeDefined();
+		expect(
+			reminders.find((r) => r.id === reminder3.id)?.completedAt,
+		).toBeDefined();
+		expect(
+			reminders.find((r) => r.id === reminder4.id)?.completedAt,
+		).toBeDefined();
+		expect(
+			reminders.find((r) => r.id === reminder5.id)?.completedAt,
+		).toBeDefined();
+
+		const stats = await reminderClient.getStats();
+		expect(stats.completed).toBe(5);
+	});
+
+	// Skipping restart test as direct actor access is not available in setupTest
+	test.skip("scheduled actions persist across actor restarts", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+		const reminderClient = client.reminderActor.getOrCreate("test-restart");
+		const reminder = await reminderClient.scheduleReminder(
+			"Persistent reminder",
+			100,
+		);
+
+		// This test would require direct access to the actor instance to stop it
+		// which is not provided by setupTest
+
+		await wait(150);
+
+		const reminders = await reminderClient.getReminders();
+		const completed = reminders.find((r) => r.id === reminder.id);
+
+		expect(completed?.completedAt).toBeDefined();
+	});
+
+	test("updates stats correctly", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+		const reminderClient = client.reminderActor.getOrCreate("test-stats");
+
+		let stats = await reminderClient.getStats();
+		expect(stats.total).toBe(0);
+		expect(stats.completed).toBe(0);
+		expect(stats.pending).toBe(0);
+
+		// Schedule some reminders
+		await reminderClient.scheduleReminder("Reminder 1", 50);
+		await reminderClient.scheduleReminder("Reminder 2", 100);
+		await reminderClient.scheduleReminder("Reminder 3", 150);
+
+		stats = await reminderClient.getStats();
+		expect(stats.total).toBe(3);
+		expect(stats.pending).toBe(3);
+		expect(stats.completed).toBe(0);
+
+		// Wait for first reminder to trigger
+		await wait(70);
+
+		stats = await reminderClient.getStats();
+		expect(stats.total).toBe(3);
+		expect(stats.pending).toBe(2);
+		expect(stats.completed).toBe(1);
+
+		// Wait for all remaining
+		await wait(100);
+
+		stats = await reminderClient.getStats();
+		expect(stats.total).toBe(3);
+		expect(stats.pending).toBe(0);
+		expect(stats.completed).toBe(3);
+	});
+});

--- a/examples/scheduling-vercel/tsconfig.json
+++ b/examples/scheduling-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/scheduling-vercel/turbo.json
+++ b/examples/scheduling-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/scheduling-vercel/vercel.json
+++ b/examples/scheduling-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/scheduling-vercel/vite.config.ts
+++ b/examples/scheduling-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/scheduling-vercel/vitest.config.ts
+++ b/examples/scheduling-vercel/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/scheduling/vercel.json
+++ b/examples/scheduling/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/state-vercel/.gitignore
+++ b/examples/state-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/state-vercel/README.md
+++ b/examples/state-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [state](../state) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fstate-vercel&project-name=state-vercel)
+
+# State Management
+
+Demonstrates persistent state management in Rivet Actors with automatic state saving and restoration.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/state
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Persistent state**: Actor state automatically saved and restored across restarts
+- **Typed state management**: Full TypeScript type safety for state objects
+- **State initialization**: Define initial state with `createState` or `state` property
+- **Automatic serialization**: State changes automatically persisted without manual saves
+
+## Implementation
+
+This example demonstrates state management in Rivet Actors with a simple counter:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/state/src/backend/registry.ts)): Defines the `counter` actor with a count state that persists across actor restarts
+
+## Resources
+
+Read more about [state management](/docs/actors/state), [actions](/docs/actors/actions), and [lifecycle hooks](/docs/actors/lifecycle).
+
+## License
+
+MIT

--- a/examples/state-vercel/api/index.ts
+++ b/examples/state-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/state-vercel/frontend/App.tsx
+++ b/examples/state-vercel/frontend/App.tsx
@@ -1,0 +1,122 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useEffect, useRef, useState } from "react";
+import type { Message, registry } from "../src/actors.ts";
+
+const { useActor } = createRivetKit<typeof registry>(`${window.location.origin}/api/rivet`);
+
+export function App() {
+	const [username, setUsername] = useState("User");
+	const [messageText, setMessageText] = useState("");
+	const [messages, setMessages] = useState<Message[]>([]);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+
+	const chatRoom = useActor({
+		name: "chatRoom",
+		key: ["lobby"],
+	});
+
+	// Load initial messages when connected
+	useEffect(() => {
+		if (chatRoom.connection) {
+			chatRoom.connection.getMessages().then(setMessages);
+		}
+	}, [chatRoom.connection]);
+
+	// Listen for new messages
+	chatRoom.useEvent("newMessage", (message: Message) => {
+		setMessages((prev) => [...prev, message]);
+	});
+
+	// Listen for messages cleared event
+	chatRoom.useEvent("messagesCleared", () => {
+		setMessages([]);
+	});
+
+	// Auto-scroll to bottom when new messages arrive
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [messages]);
+
+	const sendMessage = async () => {
+		if (chatRoom.connection && messageText.trim()) {
+			await chatRoom.connection.sendMessage(username, messageText);
+			setMessageText("");
+		}
+	};
+
+	const clearMessages = async () => {
+		if (chatRoom.connection) {
+			await chatRoom.connection.clearMessages();
+		}
+	};
+
+	const handleKeyPress = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter") {
+			sendMessage();
+		}
+	};
+
+	return (
+		<div className="chat-container">
+			<div className="header">
+				<h1>Quickstart: State</h1>
+				<p>A simple chat room demonstrating persistent state</p>
+			</div>
+
+			<div className="user-input">
+				<label>Username:</label>
+				<input
+					type="text"
+					value={username}
+					onChange={(e) => setUsername(e.target.value)}
+					placeholder="Enter your username"
+				/>
+			</div>
+
+			<div className="messages">
+				{messages.length === 0 ? (
+					<div className="empty-message">
+						No messages yet. Start the conversation!
+					</div>
+				) : (
+					messages.map((msg) => (
+						<div key={msg.id} className="message">
+							<div className="message-header">
+								<span className="message-sender">{msg.sender}</span>
+								<span className="message-timestamp">
+									{new Date(msg.timestamp).toLocaleTimeString()}
+								</span>
+							</div>
+							<div className="message-text">{msg.text}</div>
+						</div>
+					))
+				)}
+				<div ref={messagesEndRef} />
+			</div>
+
+			<div className="input-area">
+				<input
+					type="text"
+					value={messageText}
+					onChange={(e) => setMessageText(e.target.value)}
+					onKeyPress={handleKeyPress}
+					placeholder="Type a message..."
+					disabled={!chatRoom.connection}
+				/>
+				<button
+					onClick={sendMessage}
+					disabled={!chatRoom.connection || !messageText.trim()}
+				>
+					Send
+				</button>
+				<button
+					onClick={clearMessages}
+					disabled={!chatRoom.connection}
+					className="clear-button"
+				>
+					Clear
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/examples/state-vercel/frontend/main.tsx
+++ b/examples/state-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/state-vercel/index.html
+++ b/examples/state-vercel/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quickstart: State</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .chat-container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        .header {
+            background: #007bff;
+            color: white;
+            padding: 30px;
+            text-align: center;
+        }
+        .header h1 {
+            margin: 0 0 10px 0;
+            font-size: 2em;
+        }
+        .header p {
+            margin: 0;
+            opacity: 0.9;
+        }
+        .user-input {
+            padding: 20px;
+            border-bottom: 1px solid #eee;
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+        .user-input label {
+            font-weight: 500;
+        }
+        .user-input input {
+            flex: 1;
+            padding: 8px 12px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 14px;
+        }
+        .messages {
+            height: 400px;
+            overflow-y: auto;
+            padding: 20px;
+            border-bottom: 1px solid #eee;
+        }
+        .message {
+            margin-bottom: 15px;
+            padding: 12px;
+            background: #f8f9fa;
+            border-radius: 8px;
+            border-left: 4px solid #007bff;
+        }
+        .message-header {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 8px;
+        }
+        .message-sender {
+            font-weight: bold;
+            color: #007bff;
+        }
+        .message-timestamp {
+            font-size: 0.85em;
+            color: #666;
+        }
+        .message-text {
+            color: #333;
+        }
+        .empty-message {
+            text-align: center;
+            color: #666;
+            padding: 40px;
+            font-style: italic;
+        }
+        .input-area {
+            display: flex;
+            padding: 20px;
+            gap: 10px;
+        }
+        .input-area input {
+            flex: 1;
+            padding: 12px;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            font-size: 16px;
+        }
+        .input-area button {
+            padding: 12px 24px;
+            background: #007bff;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 16px;
+            font-weight: 500;
+        }
+        .input-area button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .input-area button:hover:not(:disabled) {
+            background: #0056b3;
+        }
+        .input-area .clear-button {
+            background: #dc3545;
+        }
+        .input-area .clear-button:hover:not(:disabled) {
+            background: #c82333;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/state-vercel/package.json
+++ b/examples/state-vercel/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "state-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.0.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.2.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"typescript"
+		],
+		"tags": [],
+		"priority": 1000,
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/state-vercel/src/actors.ts
+++ b/examples/state-vercel/src/actors.ts
@@ -1,0 +1,47 @@
+import { actor, setup } from "rivetkit";
+
+export type Message = {
+	id: string;
+	sender: string;
+	text: string;
+	timestamp: number;
+};
+
+export const chatRoom = actor({
+	// Persistent state that survives restarts: https://rivet.dev/docs/actors/state
+	state: {
+		messages: [] as Message[],
+	},
+
+	actions: {
+		// Callable functions from clients: https://rivet.dev/docs/actors/actions
+		sendMessage: (c, sender: string, text: string) => {
+			const message: Message = {
+				id: crypto.randomUUID(),
+				sender,
+				text,
+				timestamp: Date.now(),
+			};
+			// State changes are automatically persisted
+			c.state.messages.push(message);
+			// Send events to all connected clients: https://rivet.dev/docs/actors/events
+			c.broadcast("newMessage", message);
+			return message;
+		},
+
+		// Returns all messages for initial state loading
+		getMessages: (c) => c.state.messages,
+
+		// Clears all messages and notifies clients
+		clearMessages: (c) => {
+			c.state.messages = [];
+			c.broadcast("messagesCleared");
+			return { success: true };
+		},
+	},
+});
+
+// Register actors for use: https://rivet.dev/docs/setup
+export const registry = setup({
+	use: { chatRoom },
+});

--- a/examples/state-vercel/src/server.ts
+++ b/examples/state-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/state-vercel/tests/chat.test.ts
+++ b/examples/state-vercel/tests/chat.test.ts
@@ -1,0 +1,131 @@
+import { setupTest } from "rivetkit/test";
+import { describe, expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+describe("chat room state", () => {
+	test("send and receive messages", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create two clients connected to the same room
+		const client1 = client.chatRoom.getOrCreate(["room1"]);
+		const client2 = client.chatRoom.getOrCreate(["room1"]);
+
+		// Client 1 sends a message
+		const sentMessage = await client1.sendMessage("Alice", "Hello!");
+
+		// Verify message structure
+		expect(sentMessage).toMatchObject({
+			id: expect.any(String),
+			sender: "Alice",
+			text: "Hello!",
+			timestamp: expect.any(Number),
+		});
+
+		// Verify getMessages includes the new message
+		const messages = await client2.getMessages();
+		expect(messages).toHaveLength(1);
+		expect(messages[0]).toEqual(sentMessage);
+	});
+
+	test("message persistence", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Send multiple messages
+		const room1 = client.chatRoom.getOrCreate(["persistent-room"]);
+		await room1.sendMessage("Alice", "Message 1");
+		await room1.sendMessage("Bob", "Message 2");
+		await room1.sendMessage("Charlie", "Message 3");
+
+		// Get messages from a different client instance for the same room
+		const room2 = client.chatRoom.getOrCreate(["persistent-room"]);
+		const messages = await room2.getMessages();
+
+		// Verify all previously sent messages are still there
+		expect(messages).toHaveLength(3);
+		expect(messages[0].sender).toBe("Alice");
+		expect(messages[0].text).toBe("Message 1");
+		expect(messages[1].sender).toBe("Bob");
+		expect(messages[1].text).toBe("Message 2");
+		expect(messages[2].sender).toBe("Charlie");
+		expect(messages[2].text).toBe("Message 3");
+	});
+
+	test("message ordering", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+		const room = client.chatRoom.getOrCreate(["ordering-room"]);
+
+		// Send 5 messages in sequence
+		const msg1 = await room.sendMessage("User", "Message 1");
+		const msg2 = await room.sendMessage("User", "Message 2");
+		const msg3 = await room.sendMessage("User", "Message 3");
+		const msg4 = await room.sendMessage("User", "Message 4");
+		const msg5 = await room.sendMessage("User", "Message 5");
+
+		// Verify messages are returned in the correct order
+		const messages = await room.getMessages();
+		expect(messages).toHaveLength(5);
+		expect(messages[0].text).toBe("Message 1");
+		expect(messages[1].text).toBe("Message 2");
+		expect(messages[2].text).toBe("Message 3");
+		expect(messages[3].text).toBe("Message 4");
+		expect(messages[4].text).toBe("Message 5");
+
+		// Verify timestamps are sequential
+		expect(msg2.timestamp).toBeGreaterThanOrEqual(msg1.timestamp);
+		expect(msg3.timestamp).toBeGreaterThanOrEqual(msg2.timestamp);
+		expect(msg4.timestamp).toBeGreaterThanOrEqual(msg3.timestamp);
+		expect(msg5.timestamp).toBeGreaterThanOrEqual(msg4.timestamp);
+	});
+
+	test("clear messages", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Send several messages
+		const room = client.chatRoom.getOrCreate(["clear-room"]);
+		await room.sendMessage("Alice", "Message 1");
+		await room.sendMessage("Bob", "Message 2");
+		await room.sendMessage("Charlie", "Message 3");
+
+		// Verify messages exist
+		let messages = await room.getMessages();
+		expect(messages).toHaveLength(3);
+
+		// Call clearMessages
+		const result = await room.clearMessages();
+		expect(result.success).toBe(true);
+
+		// Verify getMessages returns empty array
+		messages = await room.getMessages();
+		expect(messages).toHaveLength(0);
+	});
+
+	test("multiple rooms", async (ctx) => {
+		const { client } = await setupTest(ctx, registry);
+
+		// Create clients for "room1" and "room2"
+		const room1 = client.chatRoom.getOrCreate(["room1"]);
+		const room2 = client.chatRoom.getOrCreate(["room2"]);
+
+		// Send messages to room1
+		await room1.sendMessage("Alice", "Room 1 message 1");
+		await room1.sendMessage("Bob", "Room 1 message 2");
+
+		// Verify room2 has no messages
+		const room2Messages = await room2.getMessages();
+		expect(room2Messages).toHaveLength(0);
+
+		// Verify room1 has its messages
+		const room1Messages = await room1.getMessages();
+		expect(room1Messages).toHaveLength(2);
+
+		// Send message to room2
+		await room2.sendMessage("Charlie", "Room 2 message");
+
+		// Verify messages are isolated per room
+		const room1Final = await room1.getMessages();
+		const room2Final = await room2.getMessages();
+		expect(room1Final).toHaveLength(2);
+		expect(room2Final).toHaveLength(1);
+		expect(room2Final[0].text).toBe("Room 2 message");
+	});
+});

--- a/examples/state-vercel/tsconfig.json
+++ b/examples/state-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/state-vercel/turbo.json
+++ b/examples/state-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/state-vercel/vercel.json
+++ b/examples/state-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/state-vercel/vite.config.ts
+++ b/examples/state-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/state-vercel/vitest.config.ts
+++ b/examples/state-vercel/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	server: {
+		port: 5173,
+	},
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/examples/state/vercel.json
+++ b/examples/state/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/stream-vercel/.gitignore
+++ b/examples/stream-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/stream-vercel/README.md
+++ b/examples/stream-vercel/README.md
@@ -1,0 +1,41 @@
+> **Note:** This is the Vercel-optimized version of the [stream](../stream) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fstream-vercel&project-name=stream-vercel)
+
+# Stream Processor
+
+Example project demonstrating real-time top-K stream processing.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/stream
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **Top-K Processing**: Maintains the top 3 highest values in real-time
+- **Real-time Updates**: All connected clients see changes immediately
+- **Stream Statistics**: Total count, highest value, and live metrics
+- **Interactive Input**: Add custom values or generate random numbers
+- **Reset Functionality**: Clear the stream and start fresh
+- **Responsive Design**: Clean, modern interface with live statistics
+
+## Implementation
+
+This stream processor uses a Top-K algorithm to efficiently maintain the top 3 values using insertion sort. Updates are instantly sent to all connected clients via event broadcasting. The actor maintains persistent state tracking values and statistics, and multiple users can add values simultaneously.
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/stream/src/backend/registry.ts)): Implements the `streamProcessor` actor with insertion-based Top-K maintenance with O(k) complexity for efficiently maintaining the highest values
+
+## Resources
+
+Read more about [state management](/docs/actors/state), [actions](/docs/actors/actions), and [events](/docs/actors/events).
+
+## License
+
+MIT

--- a/examples/stream-vercel/api/index.ts
+++ b/examples/stream-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/stream-vercel/frontend/App.tsx
+++ b/examples/stream-vercel/frontend/App.tsx
@@ -1,0 +1,181 @@
+import { createRivetKit } from "@rivetkit/react";
+import { useEffect, useState } from "react";
+import type { registry } from "../src/actors.ts";
+
+const { useActor } = createRivetKit<typeof registry>(`${window.location.origin}/api/rivet`);
+
+export function App() {
+	const [topValues, setTopValues] = useState<number[]>([]);
+	const [newValue, setNewValue] = useState<number>(0);
+	const [totalCount, setTotalCount] = useState<number>(0);
+	const [highestValue, setHighestValue] = useState<number | null>(null);
+
+	const streamProcessor = useActor({
+		name: "streamProcessor",
+		key: ["global"],
+	});
+
+	// Load initial stats
+	useEffect(() => {
+		if (streamProcessor.connection) {
+			streamProcessor.connection.getStats().then((stats) => {
+				setTopValues(stats.topValues);
+				setTotalCount(stats.totalCount);
+				setHighestValue(stats.highestValue);
+			});
+		}
+	}, [streamProcessor.connection]);
+
+	// Listen for updates from other clients
+	streamProcessor.useEvent("updated", ({ topValues, totalCount, highestValue }: {
+		topValues: number[];
+		totalCount: number;
+		highestValue: number | null;
+	}) => {
+		setTopValues(topValues);
+		setTotalCount(totalCount);
+		setHighestValue(highestValue);
+	});
+
+	// Add a new value to the stream
+	const handleAddValue = async () => {
+		if (streamProcessor.connection && !isNaN(newValue)) {
+			await streamProcessor.connection.addValue(newValue);
+			setNewValue(0);
+		}
+	};
+
+	// Reset the stream
+	const handleReset = async () => {
+		if (streamProcessor.connection) {
+			const result = await streamProcessor.connection.reset();
+			setTopValues(result.topValues);
+			setTotalCount(result.totalCount);
+			setHighestValue(result.highestValue);
+		}
+	};
+
+	// Handle form submission
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		handleAddValue();
+	};
+
+	// Handle random value generation
+	const handleRandomValue = () => {
+		const randomValue = Math.floor(Math.random() * 1000) + 1;
+		setNewValue(randomValue);
+	};
+
+	return (
+		<div className="app-container">
+			<div className="header">
+				<h1>Stream Processor</h1>
+				<p>Real-time top-3 value tracking with RivetKit</p>
+			</div>
+
+			<div className="info-box">
+				<h3>How it works</h3>
+				<p>
+					This stream processor maintains the top 3 highest values in real-time. 
+					Add numbers and watch as the system automatically keeps track of the highest values. 
+					All connected clients see updates immediately when new values are added.
+				</p>
+			</div>
+
+			<div className="content">
+				<div className="top-values-section">
+					<div className="top-values-list">
+						<h3>🏆 Top 3 Values</h3>
+						{topValues.length === 0 ? (
+							<div className="empty-state">
+								No values added yet.<br />
+								Add some numbers to get started!
+							</div>
+						) : (
+							topValues.map((value, index) => (
+								<div key={`${value}-${index}`} className="value-item">
+									<span className="value-rank">#{index + 1}</span>
+									<span className="value-number">{value.toLocaleString()}</span>
+								</div>
+							))
+						)}
+					</div>
+				</div>
+
+				<div className="input-section">
+					<form onSubmit={handleSubmit} className="input-form">
+						<h3>Add New Value</h3>
+						
+						<div className="input-group">
+							<label htmlFor="value-input">Number:</label>
+							<input
+								id="value-input"
+								type="number"
+								value={newValue || ""}
+								onChange={(e) => setNewValue(Number(e.target.value))}
+								placeholder="Enter any number..."
+								disabled={!streamProcessor.connection}
+							/>
+						</div>
+
+						<button 
+							type="submit" 
+							className="submit-button"
+							disabled={!streamProcessor.connection || isNaN(newValue)}
+						>
+							Add to Stream
+						</button>
+					</form>
+
+					<div style={{ marginTop: "15px", display: "flex", gap: "10px" }}>
+						<button 
+							onClick={handleRandomValue}
+							style={{
+								flex: 1,
+								padding: "8px",
+								backgroundColor: "#28a745",
+								color: "white",
+								border: "none",
+								borderRadius: "4px",
+								cursor: "pointer"
+							}}
+						>
+							Random Value
+						</button>
+						<button 
+							onClick={handleReset}
+							disabled={!streamProcessor.connection}
+							style={{
+								flex: 1,
+								padding: "8px",
+								backgroundColor: "#dc3545",
+								color: "white",
+								border: "none",
+								borderRadius: "4px",
+								cursor: "pointer"
+							}}
+						>
+							Reset Stream
+						</button>
+					</div>
+				</div>
+			</div>
+
+			<div className="stats">
+				<div className="stat-item">
+					<div className="stat-value">{totalCount}</div>
+					<div className="stat-label">Total Values</div>
+				</div>
+				<div className="stat-item">
+					<div className="stat-value">{highestValue?.toLocaleString() || "—"}</div>
+					<div className="stat-label">Highest Value</div>
+				</div>
+				<div className="stat-item">
+					<div className="stat-value">{topValues.length}</div>
+					<div className="stat-label">Top Values Count</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/examples/stream-vercel/frontend/main.tsx
+++ b/examples/stream-vercel/frontend/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+);

--- a/examples/stream-vercel/index.html
+++ b/examples/stream-vercel/index.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stream Processor - RivetKit</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f0f0f0;
+        }
+        .app-container {
+            max-width: 800px;
+            margin: 0 auto;
+            background-color: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .header h1 {
+            color: #333;
+            margin: 0;
+        }
+        .header p {
+            color: #666;
+            margin: 10px 0;
+        }
+        .content {
+            display: flex;
+            gap: 30px;
+        }
+        .top-values-section {
+            flex: 1;
+        }
+        .input-section {
+            flex: 1;
+        }
+        .top-values-list {
+            background-color: #f8f9fa;
+            border: 2px solid #e9ecef;
+            border-radius: 8px;
+            padding: 20px;
+            min-height: 150px;
+        }
+        .top-values-list h3 {
+            margin: 0 0 15px 0;
+            color: #495057;
+            text-align: center;
+        }
+        .value-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 12px 15px;
+            margin: 8px 0;
+            background-color: white;
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .value-rank {
+            font-weight: bold;
+            color: #6c757d;
+            font-size: 14px;
+        }
+        .value-number {
+            font-size: 18px;
+            font-weight: bold;
+            color: #495057;
+        }
+        .empty-state {
+            text-align: center;
+            color: #6c757d;
+            font-style: italic;
+            padding: 40px 20px;
+        }
+        .input-form {
+            background-color: #f8f9fa;
+            border: 2px solid #e9ecef;
+            border-radius: 8px;
+            padding: 20px;
+        }
+        .input-form h3 {
+            margin: 0 0 15px 0;
+            color: #495057;
+            text-align: center;
+        }
+        .input-group {
+            margin-bottom: 15px;
+        }
+        .input-group label {
+            display: block;
+            margin-bottom: 8px;
+            color: #495057;
+            font-weight: bold;
+        }
+        .input-group input {
+            width: 100%;
+            padding: 12px;
+            border: 1px solid #ced4da;
+            border-radius: 4px;
+            font-size: 16px;
+            box-sizing: border-box;
+        }
+        .input-group input:focus {
+            outline: none;
+            border-color: #80bdff;
+            box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25);
+        }
+        .submit-button {
+            width: 100%;
+            padding: 12px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            font-size: 16px;
+            font-weight: bold;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+        .submit-button:hover {
+            background-color: #0056b3;
+        }
+        .submit-button:disabled {
+            background-color: #6c757d;
+            cursor: not-allowed;
+        }
+        .info-box {
+            background-color: #e8f4f8;
+            border: 1px solid #b8d4da;
+            border-radius: 6px;
+            padding: 15px;
+            margin-bottom: 20px;
+        }
+        .info-box h3 {
+            margin: 0 0 10px 0;
+            color: #2c5aa0;
+        }
+        .info-box p {
+            margin: 0;
+            color: #555;
+            line-height: 1.5;
+        }
+        .stats {
+            display: flex;
+            justify-content: space-around;
+            margin-top: 20px;
+            padding: 15px;
+            background-color: #f8f9fa;
+            border-radius: 6px;
+        }
+        .stat-item {
+            text-align: center;
+        }
+        .stat-value {
+            font-size: 24px;
+            font-weight: bold;
+            color: #007bff;
+        }
+        .stat-label {
+            color: #6c757d;
+            font-size: 14px;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/main.tsx"></script>
+</body>
+</html>

--- a/examples/stream-vercel/package.json
+++ b/examples/stream-vercel/package.json
@@ -1,0 +1,40 @@
+{
+	"name": "example-stream-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"build": "vite build",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@rivetkit/react": "^2.0.38",
+		"hono": "^4.11.3",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"rivetkit": "^2.0.38"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
+		"@vitejs/plugin-react": "^4.0.0",
+		"tsx": "^4.0.0",
+		"typescript": "^5.0.0",
+		"vite": "^5.0.0",
+		"vitest": "^3.1.1"
+	},
+	"template": {
+		"technologies": [
+			"typescript"
+		],
+		"tags": [
+			"real-time"
+		],
+		"frontendPort": 5173
+	},
+	"license": "MIT"
+}

--- a/examples/stream-vercel/src/actors.ts
+++ b/examples/stream-vercel/src/actors.ts
@@ -1,0 +1,80 @@
+import { actor, setup } from "rivetkit";
+
+export type StreamState = {
+	topValues: number[];
+};
+
+const streamProcessor = actor({
+	// Persistent state that survives restarts: https://rivet.dev/docs/actors/state
+	state: {
+		topValues: [] as number[],
+		totalValues: 0,
+	},
+
+	actions: {
+		// Callable functions from clients: https://rivet.dev/docs/actors/actions
+		getTopValues: (c) => c.state.topValues,
+
+		getStats: (c) => ({
+			topValues: c.state.topValues,
+			totalCount: c.state.totalValues,
+			highestValue:
+				c.state.topValues.length > 0 ? c.state.topValues[0] : null,
+		}),
+
+		addValue: (c, value: number) => {
+			// State changes are automatically persisted
+			c.state.totalValues++;
+
+			// Insert new value if needed
+			const insertAt = c.state.topValues.findIndex((v) => value > v);
+			if (insertAt === -1 && c.state.topValues.length < 3) {
+				// Add to end if not better than existing values but we have space
+				c.state.topValues.push(value);
+			} else if (insertAt !== -1) {
+				// Insert at the correct position
+				c.state.topValues.splice(insertAt, 0, value);
+			}
+
+			// Keep only top 3
+			if (c.state.topValues.length > 3) {
+				c.state.topValues.length = 3;
+			}
+
+			// Sort descending to ensure correct order
+			c.state.topValues.sort((a, b) => b - a);
+
+			const result = {
+				topValues: c.state.topValues,
+				totalCount: c.state.totalValues,
+				highestValue:
+					c.state.topValues.length > 0 ? c.state.topValues[0] : null,
+			};
+
+			// Send events to all connected clients: https://rivet.dev/docs/actors/events
+			c.broadcast("updated", result);
+
+			return c.state.topValues;
+		},
+
+		reset: (c) => {
+			c.state.topValues = [];
+			c.state.totalValues = 0;
+
+			const result = {
+				topValues: c.state.topValues,
+				totalCount: c.state.totalValues,
+				highestValue: null,
+			};
+
+			c.broadcast("updated", result);
+
+			return result;
+		},
+	},
+});
+
+// Register actors for use: https://rivet.dev/docs/setup
+export const registry = setup({
+	use: { streamProcessor },
+});

--- a/examples/stream-vercel/src/server.ts
+++ b/examples/stream-vercel/src/server.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { registry } from "./actors.ts";
+
+const app = new Hono();
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+export default app;

--- a/examples/stream-vercel/tests/stream.test.ts
+++ b/examples/stream-vercel/tests/stream.test.ts
@@ -1,0 +1,136 @@
+import { setupTest } from "rivetkit/test";
+import { expect, test } from "vitest";
+import { registry } from "../src/actors.ts";
+
+test("Stream processor maintains top 3 values", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const stream = client.streamProcessor.getOrCreate(["test-top3"]);
+
+	// Initial state should be empty
+	const initial = await stream.getTopValues();
+	expect(initial).toEqual([]);
+
+	// Add first value
+	const result1 = await stream.addValue(10);
+	expect(result1).toEqual([10]);
+
+	// Add second value (lower)
+	const result2 = await stream.addValue(5);
+	expect(result2).toEqual([10, 5]);
+
+	// Add third value (higher)
+	const result3 = await stream.addValue(15);
+	expect(result3).toEqual([15, 10, 5]);
+
+	// Add fourth value (should replace lowest)
+	const result4 = await stream.addValue(8);
+	expect(result4).toEqual([15, 10, 8]);
+
+	// Add fifth value (should replace middle)
+	const result5 = await stream.addValue(12);
+	expect(result5).toEqual([15, 12, 10]);
+});
+
+test("Stream processor tracks statistics correctly", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const stream = client.streamProcessor.getOrCreate(["test-stats"]);
+
+	// Initial stats
+	const initialStats = await stream.getStats();
+	expect(initialStats).toEqual({
+		topValues: [],
+		totalCount: 0,
+		highestValue: null,
+	});
+
+	// Add some values
+	await stream.addValue(20);
+	await stream.addValue(30);
+	await stream.addValue(10);
+
+	const stats = await stream.getStats();
+	expect(stats).toEqual({
+		topValues: [30, 20, 10],
+		totalCount: 3,
+		highestValue: 30,
+	});
+
+	// Add more values to test count tracking
+	await stream.addValue(5);
+	await stream.addValue(25);
+
+	const finalStats = await stream.getStats();
+	expect(finalStats.totalCount).toBe(5);
+	expect(finalStats.topValues).toEqual([30, 25, 20]);
+	expect(finalStats.highestValue).toBe(30);
+});
+
+test("Stream processor handles duplicate values", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const stream = client.streamProcessor.getOrCreate(["test-duplicates"]);
+
+	// Add duplicate values
+	await stream.addValue(10);
+	await stream.addValue(10);
+	await stream.addValue(10);
+
+	const result = await stream.getTopValues();
+	expect(result).toEqual([10, 10, 10]);
+
+	const stats = await stream.getStats();
+	expect(stats.totalCount).toBe(3);
+	expect(stats.highestValue).toBe(10);
+});
+
+test("Stream processor reset functionality", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const stream = client.streamProcessor.getOrCreate(["test-reset"]);
+
+	// Add some values
+	await stream.addValue(100);
+	await stream.addValue(200);
+	await stream.addValue(50);
+
+	// Verify state before reset
+	const beforeReset = await stream.getStats();
+	expect(beforeReset.totalCount).toBe(3);
+	expect(beforeReset.topValues).toEqual([200, 100, 50]);
+
+	// Reset the stream
+	const resetResult = await stream.reset();
+	expect(resetResult).toEqual({
+		topValues: [],
+		totalCount: 0,
+		highestValue: null,
+	});
+
+	// Verify state after reset
+	const afterReset = await stream.getStats();
+	expect(afterReset).toEqual({
+		topValues: [],
+		totalCount: 0,
+		highestValue: null,
+	});
+});
+
+test("Stream processor handles edge case values", async (ctx) => {
+	const { client } = await setupTest(ctx, registry);
+	const stream = client.streamProcessor.getOrCreate(["test-edge-cases"]);
+
+	// Test with zero
+	await stream.addValue(0);
+	expect(await stream.getTopValues()).toEqual([0]);
+
+	// Test with negative numbers
+	await stream.addValue(-5);
+	await stream.addValue(-1);
+	expect(await stream.getTopValues()).toEqual([0, -1, -5]);
+
+	// Test with very large numbers
+	await stream.addValue(1000000);
+	expect(await stream.getTopValues()).toEqual([1000000, 0, -1]);
+
+	const stats = await stream.getStats();
+	expect(stats.totalCount).toBe(4);
+	expect(stats.highestValue).toBe(1000000);
+});

--- a/examples/stream-vercel/tsconfig.json
+++ b/examples/stream-vercel/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"jsx": "react-jsx",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node",
+			"vite/client"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*",
+		"frontend/**/*"
+	]
+}

--- a/examples/stream-vercel/turbo.json
+++ b/examples/stream-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/stream-vercel/vercel.json
+++ b/examples/stream-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/api/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/stream-vercel/vite.config.ts
+++ b/examples/stream-vercel/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/examples/stream-vercel/vitest.config.ts
+++ b/examples/stream-vercel/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+	},
+});

--- a/examples/stream/vercel.json
+++ b/examples/stream/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/examples/trpc-vercel/.gitignore
+++ b/examples/trpc-vercel/.gitignore
@@ -1,0 +1,4 @@
+.actorcore
+node_modules
+dist
+.vercel

--- a/examples/trpc-vercel/README.md
+++ b/examples/trpc-vercel/README.md
@@ -1,0 +1,39 @@
+> **Note:** This is the Vercel-optimized version of the [trpc](../trpc) example.
+> It uses the `hono/vercel` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Ftrpc-vercel&project-name=trpc-vercel)
+
+# tRPC Integration
+
+Example project demonstrating tRPC integration.
+
+## Getting Started
+
+```sh
+git clone https://github.com/rivet-dev/rivet.git
+cd rivet/examples/trpc
+npm install
+npm run dev
+```
+
+
+## Features
+
+- **tRPC integration**: Use tRPC for type-safe API endpoints that call Rivet Actors
+- **End-to-end type safety**: Full TypeScript types from frontend to actor actions
+- **React Query integration**: Automatic caching and real-time updates with tRPC React hooks
+- **Actor backend**: Rivet Actors handle business logic while tRPC provides the API layer
+
+## Implementation
+
+This example demonstrates integrating tRPC with Rivet Actors:
+
+- **Actor Definition** ([`src/backend/registry.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/trpc/src/backend/registry.ts)): Shows how to integrate tRPC router with actors for end-to-end type safety
+
+## Resources
+
+Read more about [actions](/docs/actors/actions), [state](/docs/actors/state), and [setup](/docs/setup).
+
+## License
+
+MIT

--- a/examples/trpc-vercel/api/index.ts
+++ b/examples/trpc-vercel/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server.ts";
+
+export default app;

--- a/examples/trpc-vercel/package.json
+++ b/examples/trpc-vercel/package.json
@@ -1,0 +1,36 @@
+{
+	"name": "example-trpc-vercel",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vercel dev",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@hono/node-server": "^1.19.7",
+		"@hono/node-ws": "^1.3.0",
+		"@hono/trpc-server": "^0.3.0",
+		"@trpc/client": "^11.3.1",
+		"@trpc/server": "^11.4.2",
+		"hono": "^4.7.11",
+		"rivetkit": "^2.0.38",
+		"zod": "^3.25.76"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"tsup": "^8.4.0",
+		"tsx": "^3.12.7",
+		"typescript": "^5.5.2"
+	},
+	"template": {
+		"technologies": [
+			"trpc",
+			"typescript"
+		],
+		"tags": [],
+		"noFrontend": true
+	},
+	"stableVersion": "0.8.0",
+	"license": "MIT"
+}

--- a/examples/trpc-vercel/src/actors.ts
+++ b/examples/trpc-vercel/src/actors.ts
@@ -1,0 +1,15 @@
+import { actor, setup } from "rivetkit";
+
+export const counter = actor({
+	state: { count: 0 },
+	actions: {
+		increment: (c, x: number) => {
+			c.state.count += x;
+			return c.state.count;
+		},
+	},
+});
+
+export const registry = setup({
+	use: { counter },
+});

--- a/examples/trpc-vercel/src/server.ts
+++ b/examples/trpc-vercel/src/server.ts
@@ -1,0 +1,34 @@
+import { trpcServer } from "@hono/trpc-server";
+import { initTRPC } from "@trpc/server";
+import { Hono } from "hono";
+import { createClient } from "rivetkit/client";
+import { z } from "zod";
+import { registry } from "./actors.ts";
+
+const client = createClient<typeof registry>();
+
+// Initialize tRPC
+const t = initTRPC.create();
+
+// Create tRPC router with RivetKit integration
+const appRouter = t.router({
+	// Increment a named counter
+	increment: t.procedure
+		.input(z.object({ name: z.string() }))
+		.mutation(async ({ input }) => {
+			const counter = client.counter.getOrCreate(input.name);
+			const newCount = await counter.increment(1);
+			return newCount;
+		}),
+});
+
+// Export type for client
+export type AppRouter = typeof appRouter;
+
+const app = new Hono();
+
+app.use("/trpc/*", trpcServer({ router: appRouter }));
+
+app.all("/api/rivet/*", (c) => registry.handler(c.req.raw));
+
+export default app;

--- a/examples/trpc-vercel/tsconfig.json
+++ b/examples/trpc-vercel/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": [
+			"esnext"
+		],
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": [
+			"node"
+		],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"src/**/*",
+		"api/**/*"
+	]
+}

--- a/examples/trpc-vercel/tsup.config.ts
+++ b/examples/trpc-vercel/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: {
+		server: "src/server.ts",
+	},
+	format: ["esm"],
+	outDir: "dist",
+	bundle: true,
+	splitting: false,
+	shims: true,
+});

--- a/examples/trpc-vercel/turbo.json
+++ b/examples/trpc-vercel/turbo.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": [
+		"//"
+	]
+}

--- a/examples/trpc-vercel/vercel.json
+++ b/examples/trpc-vercel/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/api"
+		}
+	]
+}

--- a/examples/trpc/vercel.json
+++ b/examples/trpc/vercel.json
@@ -1,3 +1,0 @@
-{
-	"framework": "hono"
-}

--- a/frontend/packages/example-registry/src/_gen.ts
+++ b/frontend/packages/example-registry/src/_gen.ts
@@ -9,6 +9,12 @@ export interface Template {
 	tags: string[];
 	noFrontend: boolean;
 	priority?: number;
+  providers: {
+    [key: string]: {
+      name: string;
+      deployUrl: string;
+    };
+  };
 }
 
 export const templates: Template[] = [
@@ -25,7 +31,13 @@ export const templates: Template[] = [
       "real-time"
     ],
     "noFrontend": false,
-    "priority": 100
+    "priority": 100,
+    "providers": {
+      "vercel": {
+        "name": "ai-agent-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fai-agent-vercel&project-name=ai-agent-vercel"
+      }
+    }
   },
   {
     "name": "hello-world",
@@ -40,7 +52,13 @@ export const templates: Template[] = [
       "starter"
     ],
     "noFrontend": false,
-    "priority": 100
+    "priority": 100,
+    "providers": {
+      "vercel": {
+        "name": "hello-world-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fhello-world-vercel&project-name=hello-world-vercel"
+      }
+    }
   },
   {
     "name": "chat-room",
@@ -55,7 +73,13 @@ export const templates: Template[] = [
       "real-time"
     ],
     "noFrontend": false,
-    "priority": 200
+    "priority": 200,
+    "providers": {
+      "vercel": {
+        "name": "chat-room-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fchat-room-vercel&project-name=chat-room-vercel"
+      }
+    }
   },
   {
     "name": "cursors",
@@ -70,7 +94,13 @@ export const templates: Template[] = [
       "real-time"
     ],
     "noFrontend": false,
-    "priority": 300
+    "priority": 300,
+    "providers": {
+      "vercel": {
+        "name": "cursors-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fcursors-vercel&project-name=cursors-vercel"
+      }
+    }
   },
   {
     "name": "ai-and-user-generated-actors-freestyle",
@@ -86,7 +116,8 @@ export const templates: Template[] = [
       "ai"
     ],
     "noFrontend": false,
-    "priority": 400
+    "priority": 400,
+    "providers": {}
   },
   {
     "name": "actor-actions",
@@ -98,7 +129,13 @@ export const templates: Template[] = [
     ],
     "tags": [],
     "noFrontend": false,
-    "priority": 1000
+    "priority": 1000,
+    "providers": {
+      "vercel": {
+        "name": "actor-actions-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Factor-actions-vercel&project-name=actor-actions-vercel"
+      }
+    }
   },
   {
     "name": "cross-actor-actions",
@@ -110,7 +147,13 @@ export const templates: Template[] = [
     ],
     "tags": [],
     "noFrontend": false,
-    "priority": 1000
+    "priority": 1000,
+    "providers": {
+      "vercel": {
+        "name": "cross-actor-actions-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fcross-actor-actions-vercel&project-name=cross-actor-actions-vercel"
+      }
+    }
   },
   {
     "name": "multi-region",
@@ -122,7 +165,13 @@ export const templates: Template[] = [
     ],
     "tags": [],
     "noFrontend": false,
-    "priority": 1000
+    "priority": 1000,
+    "providers": {
+      "vercel": {
+        "name": "multi-region-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fmulti-region-vercel&project-name=multi-region-vercel"
+      }
+    }
   },
   {
     "name": "raw-fetch-handler",
@@ -134,7 +183,13 @@ export const templates: Template[] = [
     ],
     "tags": [],
     "noFrontend": false,
-    "priority": 1000
+    "priority": 1000,
+    "providers": {
+      "vercel": {
+        "name": "raw-fetch-handler-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fraw-fetch-handler-vercel&project-name=raw-fetch-handler-vercel"
+      }
+    }
   },
   {
     "name": "raw-websocket-handler",
@@ -149,7 +204,13 @@ export const templates: Template[] = [
       "real-time"
     ],
     "noFrontend": false,
-    "priority": 1000
+    "priority": 1000,
+    "providers": {
+      "vercel": {
+        "name": "raw-websocket-handler-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fraw-websocket-handler-vercel&project-name=raw-websocket-handler-vercel"
+      }
+    }
   },
   {
     "name": "scheduling",
@@ -161,7 +222,13 @@ export const templates: Template[] = [
     ],
     "tags": [],
     "noFrontend": false,
-    "priority": 1000
+    "priority": 1000,
+    "providers": {
+      "vercel": {
+        "name": "scheduling-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fscheduling-vercel&project-name=scheduling-vercel"
+      }
+    }
   },
   {
     "name": "state",
@@ -173,7 +240,13 @@ export const templates: Template[] = [
     ],
     "tags": [],
     "noFrontend": false,
-    "priority": 1000
+    "priority": 1000,
+    "providers": {
+      "vercel": {
+        "name": "state-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fstate-vercel&project-name=state-vercel"
+      }
+    }
   },
   {
     "name": "cloudflare-workers",
@@ -185,7 +258,8 @@ export const templates: Template[] = [
       "typescript"
     ],
     "tags": [],
-    "noFrontend": true
+    "noFrontend": true,
+    "providers": {}
   },
   {
     "name": "cloudflare-workers-hono",
@@ -198,7 +272,8 @@ export const templates: Template[] = [
       "typescript"
     ],
     "tags": [],
-    "noFrontend": true
+    "noFrontend": true,
+    "providers": {}
   },
   {
     "name": "cursors-raw-websocket",
@@ -212,7 +287,13 @@ export const templates: Template[] = [
     "tags": [
       "real-time"
     ],
-    "noFrontend": false
+    "noFrontend": false,
+    "providers": {
+      "vercel": {
+        "name": "cursors-raw-websocket-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fcursors-raw-websocket-vercel&project-name=cursors-raw-websocket-vercel"
+      }
+    }
   },
   {
     "name": "custom-serverless",
@@ -225,7 +306,13 @@ export const templates: Template[] = [
     "tags": [
       "starter"
     ],
-    "noFrontend": true
+    "noFrontend": true,
+    "providers": {
+      "vercel": {
+        "name": "custom-serverless-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fcustom-serverless-vercel&project-name=custom-serverless-vercel"
+      }
+    }
   },
   {
     "name": "drizzle",
@@ -239,7 +326,13 @@ export const templates: Template[] = [
     "tags": [
       "database"
     ],
-    "noFrontend": true
+    "noFrontend": true,
+    "providers": {
+      "vercel": {
+        "name": "drizzle-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fdrizzle-vercel&project-name=drizzle-vercel"
+      }
+    }
   },
   {
     "name": "elysia",
@@ -251,7 +344,13 @@ export const templates: Template[] = [
       "typescript"
     ],
     "tags": [],
-    "noFrontend": true
+    "noFrontend": true,
+    "providers": {
+      "vercel": {
+        "name": "elysia-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Felysia-vercel&project-name=elysia-vercel"
+      }
+    }
   },
   {
     "name": "experimental-durable-streams-ai-agent",
@@ -267,7 +366,13 @@ export const templates: Template[] = [
       "real-time",
       "experimental"
     ],
-    "noFrontend": false
+    "noFrontend": false,
+    "providers": {
+      "vercel": {
+        "name": "experimental-durable-streams-ai-agent-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fexperimental-durable-streams-ai-agent-vercel&project-name=experimental-durable-streams-ai-agent-vercel"
+      }
+    }
   },
   {
     "name": "hono",
@@ -279,7 +384,13 @@ export const templates: Template[] = [
       "typescript"
     ],
     "tags": [],
-    "noFrontend": true
+    "noFrontend": true,
+    "providers": {
+      "vercel": {
+        "name": "hono-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fhono-vercel&project-name=hono-vercel"
+      }
+    }
   },
   {
     "name": "hono-react",
@@ -294,7 +405,13 @@ export const templates: Template[] = [
     "tags": [
       "starter"
     ],
-    "noFrontend": false
+    "noFrontend": false,
+    "providers": {
+      "vercel": {
+        "name": "hono-react-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fhono-react-vercel&project-name=hono-react-vercel"
+      }
+    }
   },
   {
     "name": "kitchen-sink",
@@ -305,7 +422,13 @@ export const templates: Template[] = [
       "typescript"
     ],
     "tags": [],
-    "noFrontend": false
+    "noFrontend": false,
+    "providers": {
+      "vercel": {
+        "name": "kitchen-sink-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fkitchen-sink-vercel&project-name=kitchen-sink-vercel"
+      }
+    }
   },
   {
     "name": "native-websockets",
@@ -319,7 +442,13 @@ export const templates: Template[] = [
     "tags": [
       "real-time"
     ],
-    "noFrontend": false
+    "noFrontend": false,
+    "providers": {
+      "vercel": {
+        "name": "native-websockets-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fnative-websockets-vercel&project-name=native-websockets-vercel"
+      }
+    }
   },
   {
     "name": "next-js",
@@ -334,7 +463,8 @@ export const templates: Template[] = [
     "tags": [
       "starter"
     ],
-    "noFrontend": false
+    "noFrontend": false,
+    "providers": {}
   },
   {
     "name": "raw-websocket-handler-proxy",
@@ -346,7 +476,13 @@ export const templates: Template[] = [
       "typescript"
     ],
     "tags": [],
-    "noFrontend": false
+    "noFrontend": false,
+    "providers": {
+      "vercel": {
+        "name": "raw-websocket-handler-proxy-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fraw-websocket-handler-proxy-vercel&project-name=raw-websocket-handler-proxy-vercel"
+      }
+    }
   },
   {
     "name": "react",
@@ -358,7 +494,13 @@ export const templates: Template[] = [
       "typescript"
     ],
     "tags": [],
-    "noFrontend": false
+    "noFrontend": false,
+    "providers": {
+      "vercel": {
+        "name": "react-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Freact-vercel&project-name=react-vercel"
+      }
+    }
   },
   {
     "name": "stream",
@@ -371,7 +513,13 @@ export const templates: Template[] = [
     "tags": [
       "real-time"
     ],
-    "noFrontend": false
+    "noFrontend": false,
+    "providers": {
+      "vercel": {
+        "name": "stream-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Fstream-vercel&project-name=stream-vercel"
+      }
+    }
   },
   {
     "name": "trpc",
@@ -383,6 +531,12 @@ export const templates: Template[] = [
       "typescript"
     ],
     "tags": [],
-    "noFrontend": true
+    "noFrontend": true,
+    "providers": {
+      "vercel": {
+        "name": "trpc-vercel",
+        "deployUrl": "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frivet-gg%2Frivet%2Ftree%2Fmain%2Fexamples%2Ftrpc-vercel&project-name=trpc-vercel"
+      }
+    }
   }
 ];

--- a/frontend/src/app/dialogs/connect-manual-serverless-frame.tsx
+++ b/frontend/src/app/dialogs/connect-manual-serverless-frame.tsx
@@ -145,6 +145,17 @@ export const buildServerlessConfig = async (
 	>,
 	{ provider }: { provider?: string } = {},
 ): Promise<Record<string, Rivet.RunnerConfig>> => {
+	const status = await queryClient.ensureQueryData(
+		dataProvider.runnerHealthCheckQueryOptions({
+			runnerUrl: ConnectServerlessForm.endpointSchema.parse(
+				values.endpoint,
+			),
+			headers: Object.fromEntries(values.headers),
+		}),
+	);
+
+	const endpoint = status.url || values.endpoint;
+
 	let existing: Record<string, Rivet.RunnerConfig> = {};
 	try {
 		const runnerConfig = await queryClient.fetchQuery(
@@ -163,7 +174,7 @@ export const buildServerlessConfig = async (
 
 	const config = {
 		serverless: {
-			url: endpointSchema.parse(values.endpoint),
+			url: endpoint,
 			maxRunners: values.maxRunners,
 			slotsPerRunner: values.slotsPerRunner,
 			runnersMargin: values.runnerMargin,

--- a/frontend/src/app/forms/edit-single-runner-config-form.tsx
+++ b/frontend/src/app/forms/edit-single-runner-config-form.tsx
@@ -1,17 +1,27 @@
 import { FieldPath, useFormContext, type UseFormReturn } from "react-hook-form";
 import z from "zod";
-import { Checkbox, createSchemaForm, FormField, FormMessage } from "@/components";
+import {
+	Checkbox,
+	createSchemaForm,
+	FormField,
+	FormMessage,
+} from "@/components";
 import * as SingleRunnerConfigForm from "./edit-shared-runner-config-form";
 
 export const formSchema = z.object({
 	datacenters: z
 		.record(
 			z.string(),
-			SingleRunnerConfigForm.formSchema.omit({ regions: true }).and(z.object({enable: z.boolean().optional()})).optional(),
+			SingleRunnerConfigForm.formSchema
+				.omit({ regions: true })
+				.and(z.object({ enable: z.boolean().optional() }))
+				.optional(),
 		)
 		.optional()
 		.refine((obj) => {
-			return Object.values(obj || {}).some((dcConfig) => dcConfig?.enable);
+			return Object.values(obj || {}).some(
+				(dcConfig) => dcConfig?.enable,
+			);
 		}, "At least one datacenter must be enabled."),
 });
 
@@ -24,32 +34,40 @@ export type SubmitHandler = (
 const { Form, Submit, SetValue } = createSchemaForm(formSchema);
 export { Form, Submit, SetValue };
 
-export const Enable = <TValues extends Record<string, any> = FormValues>({name}: {name: FieldPath<TValues>;}) => {
+export const Enable = <TValues extends Record<string, any> = FormValues>({
+	name,
+}: {
+	name: FieldPath<TValues>;
+}) => {
 	const { control } = useFormContext<FormValues>();
-	return <FormField
-		control={control}
-		name={name as FieldPath<FormValues>}
-		render={({ field }) => (
-			<Checkbox 
-				onClick={(e) => {
-					e.stopPropagation()
-				}}
-				checked={field.value as unknown as boolean ?? false}
-				name={field.name}
-				onCheckedChange={field.onChange}
-			/>
-		)}
-	/>;
-}
+	return (
+		<FormField
+			control={control}
+			name={name as FieldPath<FormValues>}
+			render={({ field }) => (
+				<Checkbox
+					onClick={(e) => {
+						e.stopPropagation();
+					}}
+					checked={(field.value as unknown as boolean) ?? false}
+					name={field.name}
+					onCheckedChange={field.onChange}
+				/>
+			)}
+		/>
+	);
+};
 
 export const Datacenters = () => {
 	const { control } = useFormContext<FormValues>();
-	return <FormField
-		control={control}
-		name="datacenters"
-		render={() => <FormMessage />}
-	/>
-}
+	return (
+		<FormField
+			control={control}
+			name="datacenters"
+			render={() => <FormMessage />}
+		/>
+	);
+};
 
 export const Url = SingleRunnerConfigForm.Url<FormValues>;
 export const MaxRunners = SingleRunnerConfigForm.MaxRunners<FormValues>;

--- a/frontend/src/app/forms/stepper-form.tsx
+++ b/frontend/src/app/forms/stepper-form.tsx
@@ -67,9 +67,8 @@ export type StepperFormValues<Steps extends Step[]> = z.TypeOf<
 	Steps[number]["schema"]
 >;
 
-export type ExtractSteps<T> = T extends StepperFormProps<infer Steps>
-	? Steps
-	: never;
+export type ExtractSteps<T> =
+	T extends StepperFormProps<infer Steps> ? Steps : never;
 
 export function StepperForm<const Steps extends Step[]>({
 	children,

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -205,27 +205,9 @@ export function GettingStarted({
 						onSubmit={() => {}}
 						onPartialSubmit={async ({ stepper, values }) => {
 							if (stepper.current.id === "backend") {
-								const status =
-									await queryClient.ensureQueryData(
-										dataProvider.runnerHealthCheckQueryOptions(
-											{
-												runnerUrl:
-													ConnectServerlessForm.endpointSchema.parse(
-														values.endpoint,
-													),
-												headers: Object.fromEntries(
-													values.headers,
-												),
-											},
-										),
-									);
-
 								const config = await buildServerlessConfig(
 									dataProvider,
-									{
-										...values,
-										endpoint: status.url || values.endpoint,
-									},
+									values,
 									{ provider: values.provider },
 								);
 

--- a/frontend/src/components/actors/actor-status-label.tsx
+++ b/frontend/src/components/actors/actor-status-label.tsx
@@ -156,11 +156,7 @@ export function QueriedActorError({ actorId }: { actorId: ActorId }) {
 	return <ActorError error={error} />;
 }
 
-export function RunnerPoolError({
-	error,
-}: {
-	error: RivetActorError
-}) {
+export function RunnerPoolError({ error }: { error: RivetActorError }) {
 	return match(error)
 		.with(P.nullish, () => null)
 		.with(P.string, (errStr) =>

--- a/frontend/src/components/hooks/use-dialog.tsx
+++ b/frontend/src/components/hooks/use-dialog.tsx
@@ -286,9 +286,13 @@ function DialogErrorFallback({
 				</Title>
 			</Header>
 			<Content>
-				{"statusCode" in error && error.statusCode === 404
-					? "The resource you are looking for does not exist or you do not have access to it."
-					: 'description' in error ? <>{String(error.description)}</> : "An unexpected error occurred. Please try again later."}
+				{"statusCode" in error && error.statusCode === 404 ? (
+					"The resource you are looking for does not exist or you do not have access to it."
+				) : "description" in error ? (
+					<>{String(error.description)}</>
+				) : (
+					"An unexpected error occurred. Please try again later."
+				)}
 			</Content>
 			<Footer>
 				<Button variant="secondary" onClick={resetError}>

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -26,12 +26,11 @@ export const Changelog = z.array(ChangelogItem);
 export type Changelog = z.infer<typeof Changelog>;
 export type ChangelogItem = z.infer<typeof ChangelogItem>;
 
-
-export type RivetActorError = 
-		| string
-		| null
-		| object
-		| { runner_id: string }
-		| { serverless_http_error: unknown }
-		| { serverless_connection_error: unknown }
-		| { serverless_invalid_sse_payload: unknown };
+export type RivetActorError =
+	| string
+	| null
+	| object
+	| { runner_id: string }
+	| { serverless_http_error: unknown }
+	| { serverless_connection_error: unknown }
+	| { serverless_invalid_sse_payload: unknown };

--- a/frontend/src/routes/onboarding/choose-organization.tsx
+++ b/frontend/src/routes/onboarding/choose-organization.tsx
@@ -12,10 +12,14 @@ export const Route = createFileRoute("/onboarding/choose-organization")({
 		// API perspective but no local session), reload to let Clerk sync state.
 		if (!context.clerk.session) {
 			const MAX_RELOADS = 3;
-			const reloadCount = Number(sessionStorage.getItem(RELOAD_KEY) || "0");
+			const reloadCount = Number(
+				sessionStorage.getItem(RELOAD_KEY) || "0",
+			);
 
 			if (reloadCount < MAX_RELOADS) {
-				console.log(`[choose-organization] No session yet, reloading page to sync Clerk state (attempt ${reloadCount + 1}/${MAX_RELOADS})`);
+				console.log(
+					`[choose-organization] No session yet, reloading page to sync Clerk state (attempt ${reloadCount + 1}/${MAX_RELOADS})`,
+				);
 				sessionStorage.setItem(RELOAD_KEY, String(reloadCount + 1));
 				window.location.reload();
 				// Return a never-resolving promise to prevent further execution
@@ -24,8 +28,12 @@ export const Route = createFileRoute("/onboarding/choose-organization")({
 
 			// Max reloads reached, clear counter and show error
 			sessionStorage.removeItem(RELOAD_KEY);
-			console.error("[choose-organization] No session after max reload attempts");
-			throw new Error("Unable to establish session. Please try signing in again.");
+			console.error(
+				"[choose-organization] No session after max reload attempts",
+			);
+			throw new Error(
+				"Unable to establish session. Please try signing in again.",
+			);
 		}
 
 		// Clear reload counter on success

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@bare-ts/tools": "0.15.0",
-		"@biomejs/biome": "^2.2.3",
+		"@biomejs/biome": "^2.3",
 		"commander": "^12.1.0",
 		"lefthook": "^1.12.4",
 		"semver": "^7.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 0.15.0
         version: 0.15.0(@bare-ts/lib@0.6.0)
       '@biomejs/biome':
-        specifier: ^2.2.3
-        version: 2.2.3
+        specifier: ^2.3
+        version: 2.3.11
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -228,8 +228,8 @@ importers:
   engine/tests/load:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.4
-        version: 1.9.4
+        specifier: ^2.3
+        version: 2.3.11
       '@types/k6':
         specifier: ^0.47.3
         version: 0.47.3
@@ -307,6 +307,55 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
+  examples/actor-actions-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.2.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.11.3
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
   examples/ai-agent:
     dependencies:
       '@ai-sdk/openai':
@@ -370,6 +419,64 @@ importers:
       vitest:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/ui@3.1.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/ai-agent-vercel:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^0.0.66
+        version: 0.0.66(zod@3.25.76)
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      ai:
+        specifier: ^4.0.38
+        version: 4.3.19(react@19.1.0)(zod@3.25.76)
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+      zod:
+        specifier: ^3.25.69
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   examples/ai-and-user-generated-actors-freestyle:
     dependencies:
@@ -490,6 +597,55 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/ui@3.1.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
+  examples/chat-room-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.11.3
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
   examples/cloudflare-workers:
     dependencies:
       '@rivetkit/cloudflare-workers':
@@ -597,6 +753,55 @@ importers:
       vitest:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/cross-actor-actions-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   examples/cursors:
     dependencies:
@@ -708,6 +913,104 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/ui@3.1.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
+  examples/cursors-raw-websocket-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/cursors-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
   examples/custom-serverless:
     dependencies:
       '@hono/node-server':
@@ -741,6 +1044,37 @@ importers:
       vitest:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/custom-serverless-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.5))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   examples/drizzle:
     dependencies:
@@ -782,6 +1116,43 @@ importers:
         specifier: ^5.5.2
         version: 5.9.2
 
+  examples/drizzle-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/db':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/db
+      drizzle-kit:
+        specifier: ^0.31.2
+        version: 0.31.5
+      drizzle-orm:
+        specifier: ^0.44.2
+        version: 0.44.6(@cloudflare/workers-types@4.20251014.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@11.10.0)(bun-types@1.3.0(@types/react@19.2.2))(kysely@0.28.8)(pg@8.17.2)
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.5))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+
   examples/elysia:
     dependencies:
       '@hono/node-server':
@@ -809,6 +1180,31 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.9.2
+
+  examples/elysia-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      elysia:
+        specifier: ^1.4.0
+        version: 1.4.12(@sinclair/typebox@0.34.41)(exact-mirror@0.2.2(@sinclair/typebox@0.34.41))(file-type@21.0.0)(openapi-types@12.1.3)(typescript@5.9.3)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
 
   examples/experimental-durable-streams-ai-agent:
     dependencies:
@@ -883,6 +1279,73 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
+  examples/experimental-durable-streams-ai-agent-vercel:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^1.0.0
+        version: 1.2.12(zod@4.1.13)
+      '@durable-streams/client':
+        specifier: https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/client@0323b8b
+        version: https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/client@0323b8b
+      '@durable-streams/server':
+        specifier: https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/server@0323b8b
+        version: https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/server@0323b8b
+      '@durable-streams/writer':
+        specifier: https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/writer@0323b8b
+        version: https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/writer@0323b8b
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      ai:
+        specifier: ^4.0.38
+        version: 4.3.19(react@19.1.0)(zod@4.1.13)
+      hono:
+        specifier: ^4.11.3
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+      zod:
+        specifier: ^4.1.0
+        version: 4.1.13
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
   examples/hello-world:
     dependencies:
       '@hono/node-server':
@@ -937,6 +1400,55 @@ importers:
       vitest:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.3)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/hello-world-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.11.3
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   examples/hono:
     dependencies:
@@ -1021,6 +1533,80 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/ui@3.1.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
+  examples/hono-react-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.1
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.7.0
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/hono-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.1
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      hono:
+        specifier: ^4.7.0
+        version: 4.11.3
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+
   examples/kitchen-sink:
     dependencies:
       '@hono/node-server':
@@ -1072,6 +1658,52 @@ importers:
       vite-plugin-srvx:
         specifier: ^1.0.0
         version: 1.0.0(srvx@0.10.0)(vite@5.4.20(@types/node@22.19.3)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+
+  examples/kitchen-sink-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.7.4
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.1
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^4.7.1
+        version: 4.20.6
+      typescript:
+        specifier: ^5.2.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.2.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   examples/multi-region:
     dependencies:
@@ -1127,6 +1759,55 @@ importers:
       vitest:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/multi-region-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.7.4
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   examples/native-websockets:
     dependencies:
@@ -1188,6 +1869,61 @@ importers:
       ws:
         specifier: ^8.16.0
         version: 8.18.3
+
+  examples/native-websockets-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@types/ws':
+        specifier: ^8.5.10
+        version: 8.18.1
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      ws:
+        specifier: ^8.16.0
+        version: 8.19.0
 
   examples/next-js:
     dependencies:
@@ -1283,6 +2019,55 @@ importers:
       vitest:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/ui@3.1.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/raw-fetch-handler-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.1
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.6.18
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.6
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^4.20.0
+        version: 4.20.6
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.19
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   examples/raw-websocket-handler:
     dependencies:
@@ -1400,6 +2185,110 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/ui@3.1.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
+  examples/raw-websocket-handler-proxy-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.1
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.2.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.7.0
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@types/ws':
+        specifier: ^8.5.10
+        version: 8.18.1
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.5)(jiti@1.21.7)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.6
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.5
+        version: 6.4.1(@types/node@22.19.5)(jiti@1.21.7)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/raw-websocket-handler-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.7.0
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.5)(jiti@1.21.7)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.6
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.5
+        version: 6.4.1(@types/node@22.19.5)(jiti@1.21.7)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
   examples/react:
     dependencies:
       '@hono/node-server':
@@ -1454,6 +2343,55 @@ importers:
       vitest:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/ui@3.1.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/react-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.7.0
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   examples/scheduling:
     dependencies:
@@ -1510,6 +2448,55 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
+  examples/scheduling-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
   examples/state:
     dependencies:
       '@hono/node-server':
@@ -1564,6 +2551,55 @@ importers:
       vitest:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
+  examples/state-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.0.0
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
   examples/stream:
     dependencies:
@@ -1620,6 +2656,55 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.13)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
 
+  examples/stream-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@rivetkit/react':
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/react
+      hono:
+        specifier: ^4.11.3
+        version: 4.11.3
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.13
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.0.0
+        version: 4.7.0(vite@5.4.20(@types/node@20.19.13)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))
+      tsx:
+        specifier: ^4.0.0
+        version: 4.20.6
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.20(@types/node@20.19.13)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.13)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+
   examples/trpc:
     dependencies:
       '@hono/node-server':
@@ -1662,6 +2747,46 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.9.2
+
+  examples/trpc-vercel:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.7
+        version: 1.19.7(hono@4.11.3)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.7(hono@4.11.3))(hono@4.11.3)
+      '@hono/trpc-server':
+        specifier: ^0.3.0
+        version: 0.3.4(@trpc/server@11.6.0(typescript@5.9.3))(hono@4.11.3)
+      '@trpc/client':
+        specifier: ^11.3.1
+        version: 11.6.0(@trpc/server@11.6.0(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/server':
+        specifier: ^11.4.2
+        version: 11.6.0(typescript@5.9.3)
+      hono:
+        specifier: ^4.7.11
+        version: 4.11.3
+      rivetkit:
+        specifier: workspace:*
+        version: link:../../rivetkit-typescript/packages/rivetkit
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.19.5
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.5))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
 
   frontend:
     dependencies:
@@ -2586,8 +3711,8 @@ importers:
         specifier: ^0.13.0
         version: 0.13.0(@bare-ts/lib@0.6.0)
       '@biomejs/biome':
-        specifier: ^2.2.3
-        version: 2.2.3
+        specifier: ^2.3
+        version: 2.3.11
       '@hono/node-server':
         specifier: ^1.18.2
         version: 1.19.1(hono@4.9.8)
@@ -3741,108 +4866,55 @@ packages:
   '@base-org/account@2.0.1':
     resolution: {integrity: sha512-tySVNx+vd6XEynZL0uvB10uKiwnAfThr8AbKTwILVG86mPbLAhEOInQIk+uDnvpTvfdUhC1Bi5T/46JvFoLZQQ==}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.3.11':
+    resolution: {integrity: sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/biome@2.2.3':
-    resolution: {integrity: sha512-9w0uMTvPrIdvUrxazZ42Ib7t8Y2yoGLKLdNne93RLICmaHw7mcLv4PPb5LvZLJF3141gQHiCColOh/v6VWlWmg==}
-    engines: {node: '>=14.21.3'}
-    hasBin: true
-
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.3.11':
+    resolution: {integrity: sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-arm64@2.2.3':
-    resolution: {integrity: sha512-OrqQVBpadB5eqzinXN4+Q6honBz+tTlKVCsbEuEpljK8ASSItzIRZUA02mTikl3H/1nO2BMPFiJ0nkEZNy3B1w==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.3.11':
+    resolution: {integrity: sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.2.3':
-    resolution: {integrity: sha512-OCdBpb1TmyfsTgBAM1kPMXyYKTohQ48WpiN9tkt9xvU6gKVKHY4oVwteBebiOqyfyzCNaSiuKIPjmHjUZ2ZNMg==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.3.11':
+    resolution: {integrity: sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64-musl@2.2.3':
-    resolution: {integrity: sha512-q3w9jJ6JFPZPeqyvwwPeaiS/6NEszZ+pXKF+IczNo8Xj6fsii45a4gEEicKyKIytalV+s829ACZujQlXAiVLBQ==}
+  '@biomejs/cli-linux-arm64@2.3.11':
+    resolution: {integrity: sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@biomejs/cli-linux-arm64@2.2.3':
-    resolution: {integrity: sha512-g/Uta2DqYpECxG+vUmTAmUKlVhnGEcY7DXWgKP8ruLRa8Si1QHsWknPY3B/wCo0KgYiFIOAZ9hjsHfNb9L85+g==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.3.11':
+    resolution: {integrity: sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.2.3':
-    resolution: {integrity: sha512-y76Dn4vkP1sMRGPFlNc+OTETBhGPJ90jY3il6jAfur8XWrYBQV3swZ1Jo0R2g+JpOeeoA0cOwM7mJG6svDz79w==}
+  '@biomejs/cli-linux-x64@2.3.11':
+    resolution: {integrity: sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
-
-  '@biomejs/cli-linux-x64@2.2.3':
-    resolution: {integrity: sha512-LEtyYL1fJsvw35CxrbQ0gZoxOG3oZsAjzfRdvRBRHxOpQ91Q5doRVjvWW/wepgSdgk5hlaNzfeqpyGmfSD0Eyw==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
-
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.3.11':
+    resolution: {integrity: sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-arm64@2.2.3':
-    resolution: {integrity: sha512-Ms9zFYzjcJK7LV+AOMYnjN3pV3xL8Prxf9aWdDVL74onLn5kcvZ1ZMQswE5XHtnd/r/0bnUd928Rpbs14BzVmA==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [win32]
-
-  '@biomejs/cli-win32-x64@2.2.3':
-    resolution: {integrity: sha512-gvCpewE7mBwBIpqk1YrUqNR4mCiyJm6UI3YWQQXkedSSEwzRdodRpaKhbdbHw1/hmTWOVXQ+Eih5Qctf4TCVOQ==}
+  '@biomejs/cli-win32-x64@2.3.11':
+    resolution: {integrity: sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -16545,74 +17617,39 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.3.11':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.3.11
+      '@biomejs/cli-darwin-x64': 2.3.11
+      '@biomejs/cli-linux-arm64': 2.3.11
+      '@biomejs/cli-linux-arm64-musl': 2.3.11
+      '@biomejs/cli-linux-x64': 2.3.11
+      '@biomejs/cli-linux-x64-musl': 2.3.11
+      '@biomejs/cli-win32-arm64': 2.3.11
+      '@biomejs/cli-win32-x64': 2.3.11
 
-  '@biomejs/biome@2.2.3':
-    optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.2.3
-      '@biomejs/cli-darwin-x64': 2.2.3
-      '@biomejs/cli-linux-arm64': 2.2.3
-      '@biomejs/cli-linux-arm64-musl': 2.2.3
-      '@biomejs/cli-linux-x64': 2.2.3
-      '@biomejs/cli-linux-x64-musl': 2.2.3
-      '@biomejs/cli-win32-arm64': 2.2.3
-      '@biomejs/cli-win32-x64': 2.2.3
-
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.3.11':
     optional: true
 
-  '@biomejs/cli-darwin-arm64@2.2.3':
+  '@biomejs/cli-darwin-x64@2.3.11':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.3.11':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.2.3':
+  '@biomejs/cli-linux-arm64@2.3.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.3.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.2.3':
+  '@biomejs/cli-linux-x64@2.3.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.3.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.2.3':
-    optional: true
-
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    optional: true
-
-  '@biomejs/cli-linux-x64-musl@2.2.3':
-    optional: true
-
-  '@biomejs/cli-linux-x64@1.9.4':
-    optional: true
-
-  '@biomejs/cli-linux-x64@2.2.3':
-    optional: true
-
-  '@biomejs/cli-win32-arm64@1.9.4':
-    optional: true
-
-  '@biomejs/cli-win32-arm64@2.2.3':
-    optional: true
-
-  '@biomejs/cli-win32-x64@1.9.4':
-    optional: true
-
-  '@biomejs/cli-win32-x64@2.2.3':
+  '@biomejs/cli-win32-x64@2.3.11':
     optional: true
 
   '@borewit/text-codec@0.2.1': {}
@@ -18139,6 +19176,11 @@ snapshots:
   '@hono/trpc-server@0.3.4(@trpc/server@11.6.0(typescript@5.9.2))(hono@4.11.3)':
     dependencies:
       '@trpc/server': 11.6.0(typescript@5.9.2)
+      hono: 4.11.3
+
+  '@hono/trpc-server@0.3.4(@trpc/server@11.6.0(typescript@5.9.3))(hono@4.11.3)':
+    dependencies:
+      '@trpc/server': 11.6.0(typescript@5.9.3)
       hono: 4.11.3
 
   '@hono/zod-openapi@1.1.5(hono@4.9.8)(zod@4.1.13)':
@@ -20943,9 +21985,18 @@ snapshots:
       '@trpc/server': 11.6.0(typescript@5.9.2)
       typescript: 5.9.2
 
+  '@trpc/client@11.6.0(@trpc/server@11.6.0(typescript@5.9.3))(typescript@5.9.3)':
+    dependencies:
+      '@trpc/server': 11.6.0(typescript@5.9.3)
+      typescript: 5.9.3
+
   '@trpc/server@11.6.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
+
+  '@trpc/server@11.6.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -21444,6 +22495,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@4.7.0(vite@5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1))':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.4)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.20(@types/node@22.19.5)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.4
@@ -21453,6 +22516,18 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 6.4.1(@types/node@22.18.1)(jiti@1.21.7)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.5)(jiti@1.21.7)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.4)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.1(@types/node@22.19.5)(jiti@1.21.7)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -27477,7 +28552,7 @@ snapshots:
       debug: 4.4.3
       devtools-protocol: 0.0.1367902
       typed-query-selector: 2.12.0
-      ws: 8.18.3
+      ws: 8.19.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -29397,6 +30472,35 @@ snapshots:
       - tsx
       - yaml
 
+  tsup@8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.5))(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(typescript@5.9.3)(yaml@2.8.2):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.2)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.2
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@3.14.0)(yaml@2.8.2)
+      resolve-from: 5.0.0
+      rollup: 4.53.3
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.53.2(@types/node@22.19.5)
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   tsup@8.5.1(@microsoft/api-extractor@7.53.2(@types/node@22.19.5))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
@@ -30276,6 +31380,26 @@ snapshots:
       stylus: 0.62.0
       terser: 5.44.1
       tsx: 4.20.5
+      yaml: 2.8.2
+
+  vite@6.4.1(@types/node@22.19.5)(jiti@1.21.7)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.9
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.50.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.5
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      less: 4.4.1
+      lightningcss: 1.30.2
+      sass: 1.93.2
+      stylus: 0.62.0
+      terser: 5.44.1
+      tsx: 4.20.6
       yaml: 2.8.2
 
   vite@6.4.1(@types/node@25.0.7)(jiti@1.21.7)(less@4.4.1)(lightningcss@1.30.2)(sass@1.93.2)(stylus@0.62.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):

--- a/rivetkit-typescript/packages/rivetkit/package.json
+++ b/rivetkit-typescript/packages/rivetkit/package.json
@@ -187,7 +187,7 @@
 	},
 	"devDependencies": {
 		"@bare-ts/tools": "^0.13.0",
-		"@biomejs/biome": "^2.2.3",
+		"@biomejs/biome": "^2.3",
 		"@hono/node-server": "^1.18.2",
 		"@hono/node-ws": "^1.1.1",
 		"@types/invariant": "^2",

--- a/scripts/vercel-examples/generate-vercel-examples.ts
+++ b/scripts/vercel-examples/generate-vercel-examples.ts
@@ -1,0 +1,493 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Generates Vercel-flavored versions of examples.
+ *
+ * This script:
+ * 1. Detects changes in origin examples using git diff
+ * 2. Generates Vercel-compatible versions at examples/{name}-vercel/
+ * 3. Creates api/index.ts that exports the Hono app with handle() adapter
+ * 4. Creates appropriate vercel.json configuration
+ *
+ * Usage:
+ *   npx tsx scripts/vercel-examples/generate-vercel-examples.ts
+ *   npx tsx scripts/vercel-examples/generate-vercel-examples.ts --example hello-world
+ *   npx tsx scripts/vercel-examples/generate-vercel-examples.ts --force
+ *   npx tsx scripts/vercel-examples/generate-vercel-examples.ts --all
+ */
+
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const EXAMPLES_DIR = path.resolve(import.meta.dirname, "../../examples");
+const VERCEL_SUFFIX = "-vercel";
+
+interface ExampleConfig {
+	name: string;
+	dir: string;
+	hasFrontend: boolean;
+	packageJson: PackageJson;
+}
+
+interface PackageJson {
+	name: string;
+	version: string;
+	type?: string;
+	scripts?: Record<string, string>;
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	template?: {
+		technologies?: string[];
+		tags?: string[];
+		noFrontend?: boolean;
+		frontendPort?: number;
+	};
+	[key: string]: unknown;
+}
+
+interface CliArgs {
+	example?: string;
+	force: boolean;
+	all: boolean;
+	dryRun: boolean;
+}
+
+function parseArgs(): CliArgs {
+	const args = process.argv.slice(2);
+	const result: CliArgs = {
+		force: false,
+		all: false,
+		dryRun: false,
+	};
+
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--example" && args[i + 1]) {
+			result.example = args[++i];
+		} else if (args[i] === "--force") {
+			result.force = true;
+		} else if (args[i] === "--all") {
+			result.all = true;
+		} else if (args[i] === "--dry-run") {
+			result.dryRun = true;
+		}
+	}
+
+	return result;
+}
+
+function getExamples(): ExampleConfig[] {
+	const examples: ExampleConfig[] = [];
+	const entries = fs.readdirSync(EXAMPLES_DIR, { withFileTypes: true });
+
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		// Skip vercel examples and special directories
+		if (entry.name.endsWith(VERCEL_SUFFIX)) continue;
+		if (entry.name.startsWith(".")) continue;
+
+		const packageJsonPath = path.join(EXAMPLES_DIR, entry.name, "package.json");
+		if (!fs.existsSync(packageJsonPath)) continue;
+
+		try {
+			const packageJson = JSON.parse(
+				fs.readFileSync(packageJsonPath, "utf-8")
+			) as PackageJson;
+			if (!packageJson.template) continue;
+
+			const hasFrontend = !(packageJson.template.noFrontend ?? false);
+
+			examples.push({
+				name: entry.name,
+				dir: path.join(EXAMPLES_DIR, entry.name),
+				hasFrontend,
+				packageJson,
+			});
+		} catch {
+			// Skip invalid package.json files
+		}
+	}
+
+	return examples;
+}
+
+function getChangedExamples(): Set<string> {
+	const changed = new Set<string>();
+
+	try {
+		// Check for staged changes
+		const stagedOutput = execSync("git diff --cached --name-only", {
+			encoding: "utf-8",
+			cwd: EXAMPLES_DIR,
+		});
+
+		// Check for unstaged changes
+		const unstagedOutput = execSync("git diff --name-only", {
+			encoding: "utf-8",
+			cwd: EXAMPLES_DIR,
+		});
+
+		// Check for untracked files
+		const untrackedOutput = execSync(
+			"git ls-files --others --exclude-standard",
+			{
+				encoding: "utf-8",
+				cwd: EXAMPLES_DIR,
+			}
+		);
+
+		const allChanges = [
+			...stagedOutput.split("\n"),
+			...unstagedOutput.split("\n"),
+			...untrackedOutput.split("\n"),
+		].filter(Boolean);
+
+		for (const file of allChanges) {
+			// Extract example name from path like "examples/hello-world/src/server.ts"
+			const match = file.match(/^examples\/([^/]+)\//);
+			if (match) {
+				const exampleName = match[1];
+				// Skip vercel examples
+				if (!exampleName.endsWith(VERCEL_SUFFIX)) {
+					changed.add(exampleName);
+				}
+			}
+		}
+	} catch {
+		console.warn("Warning: Could not detect git changes, assuming all changed");
+		return new Set(["*"]);
+	}
+
+	return changed;
+}
+
+function shouldSkipExample(example: ExampleConfig): string | null {
+	// Skip next.js examples - they have their own deployment strategy
+	if (example.name.includes("next-js") || example.name.includes("nextjs")) {
+		return "Next.js has its own Vercel integration";
+	}
+
+	// Skip cloudflare examples - different runtime
+	if (example.name.includes("cloudflare")) {
+		return "Cloudflare Workers have different runtime";
+	}
+
+	// Skip deno examples - different runtime
+	if (example.name === "deno") {
+		return "Deno has different runtime";
+	}
+
+	// Check if src/server.ts exists
+	const serverPath = path.join(example.dir, "src", "server.ts");
+	if (!fs.existsSync(serverPath)) {
+		return "No src/server.ts found";
+	}
+
+	return null;
+}
+
+function generateVercelJson(example: ExampleConfig): object {
+	if (example.hasFrontend) {
+		// Frontend + API: Use vite for frontend, api route for backend
+		return {
+			framework: "vite",
+			rewrites: [{ source: "/api/(.*)", destination: "/api" }],
+		};
+	}
+	// API only
+	return {
+		rewrites: [{ source: "/(.*)", destination: "/api" }],
+	};
+}
+
+function generateApiIndexTs(example: ExampleConfig): string {
+	return `import app from "../src/server.ts";
+
+export default app;
+`;
+}
+
+function generateVercelDeployUrl(exampleName: string): string {
+	const repoUrl = encodeURIComponent(
+		`https://github.com/rivet-gg/rivet/tree/main/examples/${exampleName}${VERCEL_SUFFIX}`
+	);
+	const projectName = encodeURIComponent(`${exampleName}${VERCEL_SUFFIX}`);
+	return `https://vercel.com/new/clone?repository-url=${repoUrl}&project-name=${projectName}`;
+}
+
+function generatePackageJson(example: ExampleConfig): PackageJson {
+	const original = example.packageJson;
+	const newPkg: PackageJson = {
+		name: `${original.name}${VERCEL_SUFFIX}`,
+		version: original.version,
+		private: true,
+		type: "module",
+		scripts: {},
+		dependencies: { ...original.dependencies },
+		devDependencies: { ...original.devDependencies },
+		template: original.template,
+		stableVersion: original.stableVersion as string | undefined,
+		license: original.license as string | undefined,
+	};
+
+	// Update scripts for Vercel
+	if (example.hasFrontend) {
+		newPkg.scripts = {
+			dev: "vercel dev",
+			build: "vite build",
+			"check-types": "tsc --noEmit",
+		};
+	} else {
+		newPkg.scripts = {
+			dev: "vercel dev",
+			"check-types": "tsc --noEmit",
+		};
+	}
+
+	// Remove srvx-related dependencies (not needed for Vercel)
+	delete newPkg.dependencies?.["srvx"];
+	delete newPkg.devDependencies?.["vite-plugin-srvx"];
+
+	return newPkg;
+}
+
+function generateViteConfig(): string {
+	return `import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+});
+`;
+}
+
+function generateTsConfig(example: ExampleConfig): object {
+	const includeList = ["src/**/*", "api/**/*"];
+	if (example.hasFrontend) {
+		includeList.push("frontend/**/*");
+	}
+
+	return {
+		compilerOptions: {
+			target: "esnext",
+			lib: example.hasFrontend ? ["esnext", "dom"] : ["esnext"],
+			jsx: example.hasFrontend ? "react-jsx" : undefined,
+			module: "esnext",
+			moduleResolution: "bundler",
+			types: example.hasFrontend ? ["node", "vite/client"] : ["node"],
+			noEmit: true,
+			strict: true,
+			skipLibCheck: true,
+			allowImportingTsExtensions: true,
+			rewriteRelativeImportExtensions: true,
+		},
+		include: includeList,
+	};
+}
+
+function copyDirectory(src: string, dest: string, exclude: string[] = []): void {
+	if (!fs.existsSync(dest)) {
+		fs.mkdirSync(dest, { recursive: true });
+	}
+
+	const entries = fs.readdirSync(src, { withFileTypes: true });
+
+	for (const entry of entries) {
+		if (exclude.includes(entry.name)) continue;
+
+		const srcPath = path.join(src, entry.name);
+		const destPath = path.join(dest, entry.name);
+
+		if (entry.isDirectory()) {
+			copyDirectory(srcPath, destPath, exclude);
+		} else {
+			fs.copyFileSync(srcPath, destPath);
+		}
+	}
+}
+
+function generateVercelExample(
+	example: ExampleConfig,
+	dryRun: boolean
+): void {
+	const vercelDir = path.join(EXAMPLES_DIR, `${example.name}${VERCEL_SUFFIX}`);
+
+	console.log(`  📁 Output: ${vercelDir}`);
+
+	if (dryRun) {
+		console.log(`  🔍 [DRY RUN] Would generate Vercel example`);
+		return;
+	}
+
+	// Remove existing vercel example if it exists
+	if (fs.existsSync(vercelDir)) {
+		fs.rmSync(vercelDir, { recursive: true });
+	}
+
+	// Create the vercel example directory
+	fs.mkdirSync(vercelDir, { recursive: true });
+
+	// Copy source files, excluding certain files/directories
+	const excludeList = [
+		"node_modules",
+		".actorcore",
+		"dist",
+		".turbo",
+		".vercel",
+		"vercel.json",
+		"package.json",
+		"tsconfig.json",
+		"vite.config.ts",
+		"turbo.json",
+	];
+
+	copyDirectory(example.dir, vercelDir, excludeList);
+
+	// Create api/index.ts
+	const apiDir = path.join(vercelDir, "api");
+	fs.mkdirSync(apiDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(apiDir, "index.ts"),
+		generateApiIndexTs(example)
+	);
+
+	// Create vercel.json
+	fs.writeFileSync(
+		path.join(vercelDir, "vercel.json"),
+		JSON.stringify(generateVercelJson(example), null, "\t") + "\n"
+	);
+
+	// Create package.json
+	fs.writeFileSync(
+		path.join(vercelDir, "package.json"),
+		JSON.stringify(generatePackageJson(example), null, "\t") + "\n"
+	);
+
+	// Create tsconfig.json
+	fs.writeFileSync(
+		path.join(vercelDir, "tsconfig.json"),
+		JSON.stringify(generateTsConfig(example), null, "\t") + "\n"
+	);
+
+	// Create vite.config.ts for frontend examples
+	if (example.hasFrontend) {
+		fs.writeFileSync(
+			path.join(vercelDir, "vite.config.ts"),
+			generateViteConfig()
+		);
+	}
+
+	// Create turbo.json
+	fs.writeFileSync(
+		path.join(vercelDir, "turbo.json"),
+		JSON.stringify(
+			{
+				$schema: "https://turbo.build/schema.json",
+				extends: ["//"],
+			},
+			null,
+			"\t"
+		) + "\n"
+	);
+
+	// Create .gitignore
+	fs.writeFileSync(
+		path.join(vercelDir, ".gitignore"),
+		".actorcore\nnode_modules\ndist\n.vercel\n"
+	);
+
+	// Update README if it exists
+	const readmePath = path.join(vercelDir, "README.md");
+	if (fs.existsSync(readmePath)) {
+		let readme = fs.readFileSync(readmePath, "utf-8");
+		// Add Vercel-specific note and deploy button at the top
+		if (!readme.includes("Vercel-optimized")) {
+			const deployUrl = generateVercelDeployUrl(example.name);
+			const vercelNote = `> **Note:** This is the Vercel-optimized version of the [${example.name}](../${example.name}) example.
+> It uses the \`hono/vercel\` adapter and is configured for Vercel deployment.
+
+[![Deploy with Vercel](https://vercel.com/button)](${deployUrl})
+
+`;
+			readme = vercelNote + readme;
+			fs.writeFileSync(readmePath, readme);
+		}
+	}
+
+	console.log(`  ✅ Generated successfully`);
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs();
+	let examples = getExamples();
+
+	console.log(`\n🔍 Found ${examples.length} origin examples\n`);
+
+	// Filter by specific example if provided
+	if (args.example) {
+		examples = examples.filter((e) => e.name === args.example);
+		if (examples.length === 0) {
+			console.error(`❌ Example "${args.example}" not found`);
+			process.exit(1);
+		}
+	}
+
+	// Determine which examples need regeneration
+	let examplesToGenerate: ExampleConfig[] = [];
+
+	if (args.force || args.all) {
+		examplesToGenerate = examples;
+		console.log(`📦 Generating all ${examplesToGenerate.length} examples (--force/--all)\n`);
+	} else {
+		const changedExamples = getChangedExamples();
+
+		if (changedExamples.has("*")) {
+			examplesToGenerate = examples;
+			console.log(`📦 Could not detect changes, generating all examples\n`);
+		} else if (changedExamples.size === 0) {
+			console.log(`✅ No changes detected in origin examples\n`);
+			return;
+		} else {
+			examplesToGenerate = examples.filter((e) => changedExamples.has(e.name));
+			console.log(
+				`📦 Detected changes in ${changedExamples.size} examples: ${[...changedExamples].join(", ")}\n`
+			);
+		}
+	}
+
+	// Generate Vercel examples
+	let generated = 0;
+	let skipped = 0;
+
+	for (const example of examplesToGenerate) {
+		console.log(`\n🔧 Processing: ${example.name}`);
+
+		const skipReason = shouldSkipExample(example);
+		if (skipReason) {
+			console.log(`  ⏭️  Skipping: ${skipReason}`);
+			skipped++;
+			continue;
+		}
+
+		generateVercelExample(example, args.dryRun);
+		generated++;
+	}
+
+	// Print summary
+	console.log("\n" + "=".repeat(60));
+	console.log("📊 SUMMARY");
+	console.log("=".repeat(60));
+	console.log(`\n✅ Generated: ${generated}`);
+	console.log(`⏭️  Skipped: ${skipped}`);
+
+	if (args.dryRun) {
+		console.log(`\n🔍 This was a dry run. No files were modified.`);
+	}
+
+	console.log("\n");
+}
+
+main().catch((err) => {
+	console.error("Fatal error:", err);
+	process.exit(1);
+});

--- a/scripts/vercel-examples/package.json
+++ b/scripts/vercel-examples/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "vercel-examples",
+	"version": "2.0.21",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"start": "tsx generate-vercel-examples.ts",
+		"check-types": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.9",
+		"tsx": "^4.7.1",
+		"typescript": "^5.5.2"
+	}
+}

--- a/scripts/vercel-examples/tsconfig.json
+++ b/scripts/vercel-examples/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": ["esnext"],
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": ["node"],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": ["*.ts"]
+}

--- a/website/src/pages/templates/[slug].astro
+++ b/website/src/pages/templates/[slug].astro
@@ -6,7 +6,7 @@ import { templates, TECHNOLOGIES, TAGS, type Template } from '@/data/templates/s
 import { VanillaMarkdown } from '@/components/VanillaMarkdown';
 import { TemplateCard } from '@/components/templates/TemplateCard';
 import { Code } from '@/components/v2/Code';
-import { Icon, faCloud, faGithub } from '@rivet-gg/icons';
+import { Icon, faCloud, faGithub, faVercel } from '@rivet-gg/icons';
 
 export async function getStaticPaths() {
 	return templates.map((template) => ({
@@ -151,6 +151,18 @@ const description = template.description.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
 									<Icon icon={faCloud} className="text-sm" />
 									Deploy 
 								</a>
+								{template.providers.vercel && (
+									<a
+										href={template.providers.vercel.deployUrl}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="flex items-center gap-2 w-full rounded-md border border-white/10 bg-white/5 px-4 py-2 text-sm text-white hover:border-white/20 transition-colors"
+									>
+										
+										<Icon icon={faVercel} className="text-sm" />
+										Deploy with Vercel
+									</a>
+								)}
 								<a
 									href={githubUrl}
 									target="_blank"


### PR DESCRIPTION
### TL;DR

Added Vercel-compatible versions of examples with a script to generate them automatically.

### What changed?

- Added a script (`scripts/vercel-examples/generate-vercel-examples.ts`) that automatically creates Vercel-compatible versions of examples
- Created Vercel-specific examples for all compatible examples with `-vercel` suffix
- Updated CLAUDE.md with guidance about maintaining parity between local and Vercel examples
- Removed standalone `vercel.json` files from original examples
- Updated website template page to show Vercel deploy buttons when available

### How to test?

1. Run the script to generate or update Vercel examples:
   ```
   npx tsx scripts/vercel-examples/generate-vercel-examples.ts
   ```

2. Test specific examples:
   ```
   npx tsx scripts/vercel-examples/generate-vercel-examples.ts --example hello-world
   ```

3. Force regeneration of all examples:
   ```
   npx tsx scripts/vercel-examples/generate-vercel-examples.ts --force
   ```

### Why make this change?

This change streamlines the process of maintaining Vercel-compatible versions of examples, ensuring parity between local and Vercel deployments. It makes it easier for users to deploy examples directly to Vercel with proper configuration, while keeping the original examples clean and focused on local development.