### PR TITLE
feat(dashboard): use vercel-flavored examples when deploying with vercel

### DIFF
--- a/frontend/src/app/dialogs/connect-quick-vercel-frame.tsx
+++ b/frontend/src/app/dialogs/connect-quick-vercel-frame.tsx
@@ -126,8 +126,7 @@ const useVercelTemplateLink = ({ template }: { template?: string }) => {
 	const publicDsn = useRivetDsn({ endpoint, kind: "publishable" });
 
 	return useMemo(() => {
-		// const repositoryUrl = `https://github.com/rivet-dev/rivet/tree/main/examples/${template || "chat-room"}`;
-		const repositoryUrl = "https://github.com/rivet-dev/template-vercel";
+		const repositoryUrl = `https://github.com/rivet-dev/rivet/tree/main/examples/${template || "chat-room"}`;
 		const env = ["RIVET_ENDPOINT", "RIVET_PUBLIC_ENDPOINT"].join(",");
 		const projectName = template ?? "rivetkit-vercel";
 		const envDefaults = {

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -1,5 +1,5 @@
 import { faChevronLeft, faChevronRight, Icon } from "@rivet-gg/icons";
-import { deployOptions } from "@rivetkit/example-registry";
+import { deployOptions, templates } from "@rivetkit/example-registry";
 import {
 	useInfiniteQuery,
 	useMutation,
@@ -13,7 +13,6 @@ import {
 	useSearch,
 } from "@tanstack/react-router";
 import { motion } from "framer-motion";
-import posthog from "posthog-js";
 import { Suspense, useEffect, useMemo } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { match, P } from "ts-pattern";
@@ -357,12 +356,13 @@ function Connector() {
 
 function BackendSetup({ template }: { template?: string }) {
 	const provider = useWatch({ name: "provider" });
+	const templateDetails = templates.find((t) => t.name === template);
 	const options = deployOptions.find((p) => p.name === provider);
 	return (
 		<div className="flex flex-col gap-6">
 			{match({ template, provider })
 				.with({ provider: "vercel", template: P.string }, () => (
-					<DeployToVercelCard template={template} />
+					<DeployToVercelCard template={templateDetails?.providers.vercel.name || template || "chat-room"} />
 				))
 				// .with("railway", () => (
 				// 	<RailwayQuickSetupInfo template={template} />


### PR DESCRIPTION
### TL;DR

Updated the Vercel deployment template link to use the correct repository path and improved template handling for Vercel deployments.

### What changed?

- Replaced the hardcoded Vercel template repository URL (`https://github.com/rivet-dev/template-vercel`) with a dynamic path that points to examples in the main Rivet repository (`https://github.com/rivet-dev/rivet/tree/main/examples/${template || "chat-room"}`)
- Imported the `templates` from `@rivetkit/example-registry` in the getting-started component
- Enhanced the `DeployToVercelCard` component to use template-specific Vercel provider configuration when available, falling back to the template name or "chat-room" as default

### How to test?

1. Navigate to the getting started flow
2. Select Vercel as the deployment provider
3. Verify that the correct template repository URL is being used
4. Test with different templates to ensure the proper Vercel configuration is applied

### Why make this change?

This change ensures that users are directed to the correct template repositories when deploying to Vercel, providing a more consistent experience across different templates. It also improves the flexibility of the deployment system by using template-specific Vercel configurations when available.