### PR TITLE
feat(dashboard): add custom plaftorm and improve ai prompt

### DIFF
--- a/frontend/packages/example-registry/src/deploy.ts
+++ b/frontend/packages/example-registry/src/deploy.ts
@@ -5,6 +5,7 @@ import {
     faHetznerH,
     faKubernetes,
     faRailway,
+    faRocket,
     faServer,
     faVercel,
 } from "@rivet-gg/icons";
@@ -94,6 +95,14 @@ export const deployOptions = [
 			"Run on virtual machines or bare metal servers with full control",
 		icon: faServer as any,
 	},
+	{
+		displayName: "Custom Platform",
+		name: "custom-platform" as const,
+		href: "/docs/connect/custom",
+		description:
+			"Integrate RivetKit with any other hosting platform of your choice",
+		icon: faRocket as any,
+	}
 ] satisfies DeployOption[];
 
 

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -159,10 +159,6 @@ export function GettingStarted({
 						to: ".",
 						search: { template, flow },
 					})}
-					startFromScratchLink={{
-						to: ".",
-						search: { noTemplate: true, flow: "manual" },
-					}}
 				/>
 			</Content>
 		);
@@ -417,7 +413,26 @@ function AgentInstructions({
 	const publishableToken = useRivetDsn({ kind: "publishable", endpoint });
 	const secretToken = useRivetDsn({ kind: "secret", endpoint });
 
-	const code = `Integrate Rivet into ${providerDetails?.displayName || provider}, use following\nenvironment variables in your deployment, deploy,\nthen tell me the url to connect to Rivet.\n\nRIVET_PUBLIC_ENDPOINT=${publishableToken}\nRIVET_SECRET_ENDPOINT=${secretToken}${runnerName !== "default" ? `\nRIVET_RUNNER=${runnerName || "default"}` : ""}`;
+	const providerStr = providerDetails
+		? `${providerDetails.displayName}`
+		: provider || "your chosen provider";
+
+	const code = `Load the Rivet skill and then:
+1. Integrate Rivet in to the project
+2. Verify it works on the local machine
+3. Deploy to ${providerStr} and configure
+   the following environment variables:
+
+  RIVET_PUBLIC_ENDPOINT=${publishableToken}
+  RIVET_ENDPOINT=${secretToken}${
+		runnerName !== "default"
+			? `
+  RIVET_RUNNER_NAME=${runnerName}`
+			: ""
+  }
+
+4. Tell the user the URL to past in 
+   to the Rivet dashboard`;
 
 	return (
 		<CodeFrame
@@ -440,7 +455,6 @@ function BackendSetup({ template, flow }: { template?: string; flow?: Flow }) {
 	const templateDetails = templates.find((t) => t.name === template);
 	const providerDetails = deployOptions.find((p) => p.name === provider);
 
-	const id = useId();
 	const endpoint = useEndpoint();
 	const runnerName = useWatch({ name: "runnerName" }) as string;
 
@@ -454,12 +468,9 @@ function BackendSetup({ template, flow }: { template?: string; flow?: Flow }) {
 
 	return (
 		<div className="flex flex-col gap-10">
-			{flow !== "agent" ? (
-				<>
-					<SkillsSetup />
-					<Connector />
-				</>
-			) : null}
+			<SkillsSetup />
+			<Connector />
+
 			{match({ template, provider, flow })
 				.with(
 					{ provider: P.any, template: undefined, flow: "agent" },

--- a/frontend/src/app/serverless-connection-check.tsx
+++ b/frontend/src/app/serverless-connection-check.tsx
@@ -119,6 +119,10 @@ export function ServerlessConnectionCheck({
 								.with("hetzner", () => "Hetzner")
 								.with("kubernetes", () => "Kubernetes")
 								.with("custom", () => "VM & Bare Metal")
+								.with(
+									"custom-platform",
+									() => "Custom Platform",
+								)
 								.exhaustive()}{" "}
 							is running with RivetKit {data.success.version}
 						</>

--- a/frontend/src/app/templates.tsx
+++ b/frontend/src/app/templates.tsx
@@ -1,13 +1,6 @@
 import { faChevronRight, faCode, Icon } from "@rivet-gg/icons";
 import { templates } from "@rivetkit/example-registry";
-import {
-	createLink,
-	Link,
-	type LinkOptions,
-	useSearch,
-} from "@tanstack/react-router";
-import { motion } from "framer-motion";
-import React, { type ComponentProps } from "react";
+import { Link, type LinkOptions, useSearch } from "@tanstack/react-router";
 import {
 	Button,
 	cn,
@@ -20,10 +13,8 @@ import { MotionLink } from "./motion-link";
 
 export function Templates({
 	getTemplateLink,
-	startFromScratchLink,
 }: {
 	getTemplateLink?: (template: string) => LinkOptions;
-	startFromScratchLink?: LinkOptions;
 }) {
 	const showAll = useSearch({ strict: false, select: (s) => s?.showAll });
 	return (
@@ -60,13 +51,6 @@ export function Templates({
 							</Link>
 						</Button>
 					)}
-				</div>
-				<div className="flex gap-4">
-					<Button variant="outline" asChild>
-						<Link {...startFromScratchLink}>
-							Start From Scratch
-						</Link>
-					</Button>
 				</div>
 			</div>
 		</>

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/new/index.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/new/index.tsx
@@ -53,13 +53,6 @@ function RouteComponent() {
 						to: "/orgs/$organization/new/$template",
 						params: { template },
 					})}
-					startFromScratchLink={{
-						to: ".",
-						search: {
-							flow: "manual",
-							noTemplate: true,
-						},
-					}}
 				/>
 			</>
 		);

--- a/website/src/content/docs/connect/custom.mdx
+++ b/website/src/content/docs/connect/custom.mdx
@@ -1,0 +1,65 @@
+---
+title: "Custom Platform"
+description: "Integrate RivetKit with any other hosting platform of your choice."
+skill: false
+---
+
+## Steps
+
+<Steps>
+<Step title="Prerequisites">
+
+- Your RivetKit app
+  - If you don't have one, see the [Quickstart](/docs/actors/quickstart) page or our [Examples](https://github.com/rivet-dev/rivet/tree/main/examples)
+- Access to the [Rivet Cloud](https://dashboard.rivet.dev/) or a [self-hosted Rivet Engine](/docs/general/self-hosting)
+- A hosting platform that supports running Node.js applications with HTTP endpoints
+
+</Step>
+<Step title="Deploy Your App">
+
+Deploy your RivetKit app to your hosting platform of choice. The specific steps will vary depending on your platform, but ensure:
+
+1. Your app is built and deployed
+2. The `/api/rivet` endpoint is publicly accessible
+3. Your app can receive incoming HTTP requests
+
+</Step>
+<Step title="Set Environment Variables">
+
+After creating your project on the Rivet dashboard, select "Custom" as your provider. You'll be provided two environment variables to configure in your hosting platform:
+
+- `RIVET_ENDPOINT` - The endpoint for your app to communicate with Rivet
+- `RIVET_PUBLIC_ENDPOINT` - The public endpoint for clients to connect to actors
+
+Add these environment variables to your hosting platform's configuration.
+
+</Step>
+<Step title="Connect to Rivet">
+
+1. Ensure your app is accessible via a public URL
+2. On the Rivet dashboard, paste your URL with the `/api/rivet` path into the connect form (e.g. `https://my-app.example.com/api/rivet`)
+3. Click "Done"
+
+</Step>
+</Steps>
+
+## Requirements
+
+Your hosting platform must support:
+
+- **HTTP endpoints** - Your app must be reachable via a public URL
+- **Environment variables** - To configure the Rivet connection
+- **Persistent processes or serverless functions** - To handle incoming requests to the `/api/rivet` endpoint
+
+## Troubleshooting
+
+### Connection fails
+
+- Verify your app is publicly accessible
+- Check that the `/api/rivet` endpoint returns a valid response
+- Ensure environment variables are correctly set
+
+### Actors not responding
+
+- Confirm `RIVET_ENDPOINT` and `RIVET_PUBLIC_ENDPOINT` are both configured
+- Check your hosting platform's logs for connection errors


### PR DESCRIPTION
### TL;DR

Added support for custom platforms in RivetKit deployment options and improved the agent instructions flow.

### What changed?

- Added a new "Custom Platform" deployment option with documentation
- Created a new `/docs/connect/custom.mdx` page with detailed steps for integrating RivetKit with any hosting platform
- Improved the agent instructions with clearer formatting and better guidance
- Removed the "Start From Scratch" option from the templates UI
- Enhanced code formatting in the agent instructions for better readability
- Updated provider string handling to be more flexible

### How to test?

1. Verify the new "Custom Platform" option appears in the deployment options list
2. Check that the custom platform documentation is accessible and complete
3. Test the agent instructions flow to ensure the improved formatting works correctly
4. Confirm that removing the "Start From Scratch" option doesn't break the template selection flow

### Why make this change?

This change expands RivetKit's compatibility with various hosting platforms by providing a generic "Custom Platform" option. It also improves the onboarding experience by making agent instructions clearer and more structured, helping users successfully deploy their applications regardless of their chosen platform.