### PR TITLE
feat(dashboard): improve data providers stability

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,6 +1,6 @@
 import type { Clerk } from "@clerk/clerk-js";
 import * as Sentry from "@sentry/react";
-import { CancelledError, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { Suspense } from "react";
@@ -12,6 +12,15 @@ import {
 	Toaster,
 	TooltipProvider,
 } from "@/components";
+import {
+	getOrCreateCloudContext,
+	getOrCreateCloudNamespaceContext,
+	getOrCreateEngineContext,
+	getOrCreateEngineNamespaceContext,
+	getOrCreateInspectorContext,
+	getOrCreateOrganizationContext,
+	getOrCreateProjectContext,
+} from "./app/data-providers/cache";
 import { NotFoundCard } from "./app/not-found-card";
 import { RouteLayout } from "./app/route-layout";
 import { clerk } from "./lib/auth";
@@ -41,6 +50,13 @@ export const router = createRouter({
 		clerk:
 			__APP_TYPE__ === "cloud" ? clerk : (undefined as unknown as Clerk),
 		queryClient: queryClient,
+		getOrCreateCloudContext,
+		getOrCreateEngineContext,
+		getOrCreateInspectorContext,
+		getOrCreateOrganizationContext,
+		getOrCreateProjectContext,
+		getOrCreateCloudNamespaceContext,
+		getOrCreateEngineNamespaceContext,
 	},
 	defaultPreloadStaleTime: 0,
 	defaultGcTime: 0,

--- a/frontend/src/app/data-providers/cache.ts
+++ b/frontend/src/app/data-providers/cache.ts
@@ -1,0 +1,144 @@
+import type { Clerk } from "@clerk/clerk-js";
+import {
+	createNamespaceContext as createCloudNamespaceContext,
+	createGlobalContext as createGlobalCloudContext,
+	createOrganizationContext,
+	createProjectContext,
+} from "@/app/data-providers/cloud-data-provider";
+import {
+	createNamespaceContext as createEngineNamespaceContext,
+	createGlobalContext as createGlobalEngineContext,
+} from "@/app/data-providers/engine-data-provider";
+import { createGlobalContext as createGlobalInspectorContext } from "@/app/data-providers/inspector-data-provider";
+
+// Cache factories for data providers to maintain stable references across navigation
+export type CloudContext = ReturnType<typeof createGlobalCloudContext>;
+export type CloudNamespaceContext = ReturnType<
+	typeof createCloudNamespaceContext
+>;
+export type EngineContext = ReturnType<typeof createGlobalEngineContext>;
+export type EngineNamespaceContext = ReturnType<
+	typeof createEngineNamespaceContext
+>;
+export type InspectorContext = ReturnType<typeof createGlobalInspectorContext>;
+export type OrganizationContext = ReturnType<typeof createOrganizationContext>;
+export type ProjectContext = ReturnType<typeof createProjectContext>;
+
+let cloudContextCache: CloudContext | null = null;
+const cloudNamespaceContextCache = new Map<string, CloudNamespaceContext>();
+const engineContextCache = new Map<string, EngineContext>();
+const engineNamespaceContextCache = new Map<string, EngineNamespaceContext>();
+const inspectorContextCache = new Map<string, InspectorContext>();
+const organizationContextCache = new Map<string, OrganizationContext>();
+const projectContextCache = new Map<string, ProjectContext>();
+
+export function getOrCreateCloudContext(clerk: Clerk): CloudContext {
+	if (!cloudContextCache) {
+		cloudContextCache = createGlobalCloudContext({ clerk });
+	}
+	return cloudContextCache;
+}
+
+export function getOrCreateEngineContext(
+	engineToken: (() => string) | string | (() => Promise<string>),
+): EngineContext {
+	const key =
+		typeof engineToken === "function"
+			? engineToken.toString()
+			: engineToken;
+	const cached = engineContextCache.get(key);
+	if (cached) {
+		return cached;
+	}
+	const context = createGlobalEngineContext({ engineToken });
+	engineContextCache.set(key, context);
+	return context;
+}
+
+export function getOrCreateInspectorContext(opts: {
+	url?: string;
+	token?: string;
+}): InspectorContext {
+	const key = `${opts.url ?? ""}:${opts.token ?? ""}`;
+	const cached = inspectorContextCache.get(key);
+	if (cached) {
+		return cached;
+	}
+	const context = createGlobalInspectorContext(opts);
+	inspectorContextCache.set(key, context);
+	return context;
+}
+
+export function getOrCreateOrganizationContext(
+	parent: CloudContext,
+	organization: string,
+): OrganizationContext {
+	const key = organization;
+	const cached = organizationContextCache.get(key);
+	if (cached) {
+		return cached;
+	}
+	const context = createOrganizationContext({
+		...parent,
+		organization,
+	});
+	organizationContextCache.set(key, context);
+	return context;
+}
+
+export function getOrCreateProjectContext(
+	parent: CloudContext & OrganizationContext,
+	organization: string,
+	project: string,
+): ProjectContext {
+	const key = `${organization}:${project}`;
+	const cached = projectContextCache.get(key);
+	if (cached) {
+		return cached;
+	}
+	const context = createProjectContext({
+		...parent,
+		organization,
+		project,
+	});
+	projectContextCache.set(key, context);
+	return context;
+}
+
+export function getOrCreateCloudNamespaceContext(
+	parent: CloudContext & OrganizationContext & ProjectContext,
+	namespace: string,
+	engineNamespaceName: string,
+	engineNamespaceId: string,
+): CloudNamespaceContext {
+	const key = `${parent.organization}:${parent.project}:${namespace}`;
+	const cached = cloudNamespaceContextCache.get(key);
+	if (cached) {
+		return cached;
+	}
+	const context = createCloudNamespaceContext({
+		...parent,
+		namespace,
+		engineNamespaceName,
+		engineNamespaceId,
+	});
+	cloudNamespaceContextCache.set(key, context);
+	return context;
+}
+
+export function getOrCreateEngineNamespaceContext(
+	parent: EngineContext,
+	namespace: string,
+): EngineNamespaceContext {
+	const key = `${parent.engineToken}:${namespace}`;
+	const cached = engineNamespaceContextCache.get(key);
+	if (cached) {
+		return cached;
+	}
+	const context = createEngineNamespaceContext({
+		...parent,
+		namespace,
+	});
+	engineNamespaceContextCache.set(key, context);
+	return context;
+}

--- a/frontend/src/app/data-providers/cloud-data-provider.tsx
+++ b/frontend/src/app/data-providers/cloud-data-provider.tsx
@@ -77,6 +77,7 @@ export const createGlobalContext = ({ clerk }: { clerk: Clerk }) => {
 export const createOrganizationContext = ({
 	client,
 	organization,
+	...parent
 }: {
 	organization: string;
 } & ReturnType<typeof createGlobalContext>) => {
@@ -212,6 +213,8 @@ export const createOrganizationContext = ({
 		});
 
 	return {
+		...parent,
+		client,
 		organization,
 		organizationsQueryOptions,
 		orgProjectNamespacesQueryOptions,
@@ -269,6 +272,9 @@ export const createProjectContext = ({
 } & ReturnType<typeof createOrganizationContext> &
 	ReturnType<typeof createGlobalContext>) => {
 	return {
+		...parent,
+		client,
+		organization,
 		project,
 		createNamespaceMutationOptions(opts: {
 			onSuccess?: (data: Namespace) => void;
@@ -347,6 +353,7 @@ export const createProjectContext = ({
 					"access-token",
 				],
 				queryFn: async () => {
+					console.log(client);
 					const response = await client.namespaces.createAccessToken(
 						project,
 						namespace,
@@ -432,6 +439,7 @@ export const createNamespaceContext = ({
 		return response.token;
 	};
 	return {
+		...parent,
 		...createEngineNamespaceContext({
 			...parent,
 			namespace: engineNamespaceName,

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -9,6 +9,15 @@ import {
 } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { match } from "ts-pattern";
+import type {
+	CloudContext,
+	CloudNamespaceContext,
+	EngineContext,
+	EngineNamespaceContext,
+	InspectorContext,
+	OrganizationContext,
+	ProjectContext,
+} from "@/app/data-providers/cache";
 import { FullscreenLoading } from "@/components";
 import { clerk } from "@/lib/auth";
 import { cloudEnv } from "@/lib/env";
@@ -69,6 +78,33 @@ interface RootRouteContext {
 	 */
 	clerk: Clerk;
 	queryClient: QueryClient;
+	getOrCreateCloudContext: (clerk: Clerk) => CloudContext;
+	getOrCreateEngineContext: (
+		engineToken: (() => string) | string | (() => Promise<string>),
+	) => EngineContext;
+	getOrCreateInspectorContext: (opts: {
+		url?: string;
+		token?: string;
+	}) => InspectorContext;
+	getOrCreateOrganizationContext: (
+		parent: CloudContext,
+		organization: string,
+	) => OrganizationContext;
+	getOrCreateProjectContext: (
+		parent: CloudContext & OrganizationContext,
+		organization: string,
+		project: string,
+	) => ProjectContext;
+	getOrCreateCloudNamespaceContext: (
+		parent: CloudContext & OrganizationContext & ProjectContext,
+		namespace: string,
+		engineNamespaceName: string,
+		engineNamespaceId: string,
+	) => CloudNamespaceContext;
+	getOrCreateEngineNamespaceContext: (
+		parent: EngineContext,
+		namespace: string,
+	) => EngineNamespaceContext;
 }
 
 export const Route = createRootRouteWithContext<RootRouteContext>()({

--- a/frontend/src/routes/_context/_cloud/orgs.$organization.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { match } from "ts-pattern";
-import { createOrganizationContext } from "@/app/data-providers/cloud-data-provider";
 
 export const Route = createFileRoute("/_context/_cloud/orgs/$organization")({
 	component: RouteComponent,
@@ -10,14 +9,12 @@ export const Route = createFileRoute("/_context/_cloud/orgs/$organization")({
 				context.clerk.setActive({
 					organization: params.organization,
 				});
+
 				return {
-					dataProvider: {
-						...context.dataProvider,
-						...createOrganizationContext({
-							...context.dataProvider,
-							organization: params.organization,
-						}),
-					},
+					dataProvider: context.getOrCreateOrganizationContext(
+						context.dataProvider,
+						params.organization,
+					),
 				};
 			})
 			.otherwise(() => {

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { match } from "ts-pattern";
-import { createProjectContext } from "@/app/data-providers/cloud-data-provider";
 import { RouteError } from "@/app/route-error";
 import { useDialog } from "@/app/use-dialog";
 import { FullscreenLoading } from "@/components";
@@ -11,16 +10,15 @@ export const Route = createFileRoute(
 	component: RouteComponent,
 	beforeLoad: ({ context, params }) => {
 		return match(context)
-			.with({ __type: "cloud" }, (context) => ({
-				dataProvider: {
-					...context.dataProvider,
-					...createProjectContext({
-						...context.dataProvider,
-						organization: params.organization,
-						project: params.project,
-					}),
-				},
-			}))
+			.with({ __type: "cloud" }, (context) => {
+				return {
+					dataProvider: context.getOrCreateProjectContext(
+						context.dataProvider,
+						params.organization,
+						params.project,
+					),
+				};
+			})
 			.otherwise(() => {
 				throw new Error("Invalid context type for this route");
 			});

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace.tsx
@@ -1,11 +1,5 @@
-import {
-	createFileRoute,
-	redirect,
-	useNavigate,
-	useSearch,
-} from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { posthog } from "posthog-js";
-import { createNamespaceContext } from "@/app/data-providers/cloud-data-provider";
 import { GettingStarted } from "@/app/getting-started";
 import { SidebarlessHeader } from "@/app/layout";
 import { NotFoundCard } from "@/app/not-found-card";
@@ -39,15 +33,12 @@ export const Route = createFileRoute(
 		}
 
 		return {
-			dataProvider: {
-				...context.dataProvider,
-				...createNamespaceContext({
-					...context.dataProvider,
-					namespace: params.namespace,
-					engineNamespaceId: ns.access.engineNamespaceId,
-					engineNamespaceName: ns.access.engineNamespaceName,
-				}),
-			},
+			dataProvider: context.getOrCreateCloudNamespaceContext(
+				context.dataProvider,
+				params.namespace,
+				ns.access.engineNamespaceName,
+				ns.access.engineNamespaceId,
+			),
 		};
 	},
 	loaderDeps(opts) {

--- a/frontend/src/routes/_context/_engine/ns.$namespace.tsx
+++ b/frontend/src/routes/_context/_engine/ns.$namespace.tsx
@@ -1,21 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { match } from "ts-pattern";
-import { createNamespaceContext } from "@/app/data-providers/engine-data-provider";
 import { NotFoundCard } from "@/app/not-found-card";
 import { RouteLayout } from "@/app/route-layout";
 
 export const Route = createFileRoute("/_context/_engine/ns/$namespace")({
 	context: ({ context, params }) => {
 		return match(context)
-			.with({ __type: "engine" }, (ctx) => ({
-				dataProvider: {
-					...ctx.dataProvider,
-					...createNamespaceContext({
-						...ctx.dataProvider,
-						namespace: params.namespace,
-					}),
-				},
-			}))
+			.with({ __type: "engine" }, (ctx) => {
+				return {
+					dataProvider: context.getOrCreateEngineNamespaceContext(
+						ctx.dataProvider,
+						params.namespace,
+					),
+				};
+			})
 			.otherwise(() => {
 				throw new Error("Invalid context type for this route");
 			});


### PR DESCRIPTION
### TL;DR

Implemented a context caching system to maintain stable references across navigation in the frontend.

### What changed?

- Created a new `cache.ts` file with factory functions to create and cache data provider contexts
- Added context getter functions to the router context
- Modified routes to use the cached contexts instead of creating new ones on each navigation
- Removed unused import of `CancelledError` from react-query
- Enhanced context inheritance to properly pass parent context properties to child contexts
- Added redirect handling for inspector URLs

### How to test?

1. Navigate between different parts of the application (organizations, projects, namespaces)
2. Verify that navigation is smooth and state is preserved when returning to previously visited routes
3. Check that inspector URLs are properly redirected when needed
4. Ensure all data provider functionality works as expected with the cached contexts

### Why make this change?

This change improves application performance and user experience by preventing unnecessary recreation of data provider contexts during navigation. By maintaining stable references to these contexts, we avoid redundant API calls and state resets when users navigate between routes. The caching system also ensures proper inheritance of context properties, making the code more maintainable and reducing potential bugs related to missing context data.