### PR TITLE
fix(cloudflare-workers): do not use i/o operations outside fetch context

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
@@ -1,6 +1,7 @@
 import type { Client } from "@/client/client";
 import { createClient } from "@/client/mod";
-import { getNodeEnv, isDev } from "@/utils/env-vars";
+import { isDev } from "@/utils/env-vars";
+import { Runtime } from "../../runtime";
 import {
 	type RegistryActors,
 	type RegistryConfig,
@@ -12,7 +13,6 @@ import {
 	type LegacyRunnerConfigInput,
 	LegacyRunnerConfigSchema,
 } from "./config/legacy-runner";
-import { Runtime } from "../../runtime";
 
 export type FetchHandler = (
 	request: Request,
@@ -48,8 +48,8 @@ export class Registry<A extends RegistryActors> {
 	constructor(config: RegistryConfigInput<A>) {
 		this.#config = config;
 
-		// Auto-prepare on next tick (gives time for sync config modification)
-		if (getNodeEnv() !== "test") {
+		if (config.serverless?.spawnEngine || config.serveManager) {
+			// Auto-prepare on next tick (gives time for sync config modification)
 			setTimeout(() => {
 				// biome-ignore lint/nursery/noFloatingPromises: fire-and-forget auto-prepare
 				this.#ensureRuntime();


### PR DESCRIPTION
Closes RVT-5342



### TL;DR

Only auto-prepare the runtime when necessary based on configuration.

### What changed?

Added a conditional check before auto-preparing the runtime in the Registry constructor. Now, the runtime is only auto-prepared when either `config.serverless?.spawnEngine` or `config.serveManager` is set to a truthy value.

Also reordered the imports to place the Runtime import with the other imports from external files.

### How to test?

1. Create a Registry instance with `serverless.spawnEngine` set to `false` and `serveManager` set to `false`
2. Verify that the runtime is not automatically prepared
3. Create a Registry instance with either `serverless.spawnEngine` or `serveManager` set to `true`
4. Verify that the runtime is automatically prepared

### Why make this change?

This optimization prevents unnecessary runtime preparation when it's not needed based on the configuration. This can improve performance and reduce resource usage in scenarios where the runtime isn't required.