### PR TITLE
fix(rivetkit): shorten local dev client retry backoff

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/utils/env-vars.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/utils/env-vars.ts
@@ -65,3 +65,18 @@ export const getNodeEnv = (): string | undefined => getEnvUniversal("NODE_ENV");
 export const getNextPhase = (): string | undefined =>
 	getEnvUniversal("NEXT_PHASE");
 export const isDev = (): boolean => getNodeEnv() !== "production";
+export const isLocalDev = (): boolean => {
+	if (typeof window !== "undefined") {
+		const hostname = window?.location?.hostname;
+		if (hostname) {
+			return (
+				hostname === "localhost" ||
+				hostname === "127.0.0.1" ||
+				hostname === "::1" ||
+				hostname === "[::1]"
+			);
+		}
+	}
+
+	return isDev();
+};


### PR DESCRIPTION
## Problem
Client uses extensive exponential backoff in local development, which is frustrating when iterating quickly.

## Solution
- Add `isLocalDev()` helper in `env-vars.ts`:
  - Server: checks `NODE_ENV !== 'production'`
  - Browser: checks if hostname is localhost/127.0.0.1/::1
- Reduce retry intervals to fixed 1s in local dev (was exponential 250ms-30s)
- Production backoff behavior unchanged

## Changes
- `rivetkit-typescript/packages/rivetkit/src/utils/env-vars.ts` - new `isLocalDev()` helper
- `rivetkit-typescript/packages/rivetkit/src/client/actor-conn.ts` - use fixed 1s retries in local dev
- `rivetkit-typescript/packages/rivetkit/src/remote-manager-driver/metadata.ts` - use fixed 1s retries in local dev