### PR TITLE
fix(rivetkit): deserialize actor keys properly in manager router

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/manager/router.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/manager/router.ts
@@ -6,7 +6,7 @@ import invariant from "invariant";
 import { z } from "zod";
 import { Forbidden, RestrictedFeature } from "@/actor/errors";
 
-import { serializeActorKey } from "@/actor/keys";
+import { deserializeActorKey, serializeActorKey } from "@/actor/keys";
 
 import type { Encoding } from "@/client/mod";
 import {
@@ -171,7 +171,7 @@ export function buildManagerRouter(
 					const actorOutput = await managerDriver.getWithKey({
 						c,
 						name,
-						key: [key], // Convert string to ActorKey array
+						key: deserializeActorKey(key),
 					});
 					if (actorOutput) {
 						actors.push(actorOutput);
@@ -242,10 +242,11 @@ export function buildManagerRouter(
 				const body = c.req.valid("json");
 
 				// Check if actor already exists
+				const actorKey = deserializeActorKey(body.key);
 				const existingActor = await managerDriver.getWithKey({
 					c,
 					name: body.name,
-					key: [body.key], // Convert string to ActorKey array
+					key: actorKey,
 				});
 
 				if (existingActor) {
@@ -259,7 +260,7 @@ export function buildManagerRouter(
 				const newActor = await managerDriver.getOrCreateWithKey({
 					c,
 					name: body.name,
-					key: [body.key], // Convert string to ActorKey array
+					key: actorKey,
 					input: body.input
 						? cbor.decode(Buffer.from(body.input, "base64"))
 						: undefined,
@@ -288,10 +289,14 @@ export function buildManagerRouter(
 				const body = c.req.valid("json");
 
 				// Create actor using the driver
+				const key =
+					body.key === undefined || body.key === null
+						? [crypto.randomUUID()]
+						: deserializeActorKey(body.key);
 				const actorOutput = await managerDriver.createActor({
 					c,
 					name: body.name,
-					key: [body.key || crypto.randomUUID()], // Generate key if not provided, convert to ActorKey array
+					key,
 					input: body.input
 						? cbor.decode(Buffer.from(body.input, "base64"))
 						: undefined,


### PR DESCRIPTION
## Bug
`c.key` in actor context returns `['orgId/documentId/page']` instead of `['orgId', 'documentId', 'page']`

When creating an actor with:
```ts
rivetClient.document.getOrCreate([orgId, documentId, documentType])
```

Expected `c.key`: `[orgId, documentId, documentType]` (array of 3 strings)
Actual `c.key`: `['orgId/documentId/documentType']` (array with 1 joined string)

## Root Cause
The manager router was wrapping serialized key strings in single-element arrays (`key: [body.key]`) instead of deserializing them back to ActorKey arrays using `deserializeActorKey()`.

## Fix
- Import `deserializeActorKey` from `@/actor/keys`
- `GET /actors`: deserialize key query param
- `PUT /actors`: deserialize `body.key` for `getWithKey` and `getOrCreateWithKey`
- `POST /actors`: deserialize `body.key`, generate UUID only if null/undefined

## Files Changed
- `rivetkit-typescript/packages/rivetkit/src/manager/router.ts`