### PR TITLE
feat: Comic Sans font for light mode (experimental)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,6 +11,10 @@
 	body {
 		@apply bg-background text-foreground min-h-screen;
 	}
+	/* Comic Sans for light mode only - experimental feature */
+	:root:not(.dark) body {
+		font-family: "Comic Sans MS", cursive, sans-serif;
+	}
 	#root {
 		@apply min-h-screen;
 	}


### PR DESCRIPTION
## Overview

This PR introduces Comic Sans MS font as an experimental feature for light mode only. This is intended for UI testing, demos, and experimental purposes.

## Changes

**Frontend (`frontend/src/index.css`):**
- Added Comic Sans MS font family to light mode only
- Used `:root:not(.dark)` selector for better CSS specificity 
- Dark mode continues using default system fonts
- Clearly documented as experimental feature

## Implementation Details

```css
/* Comic Sans for light mode only - experimental feature */
:root:not(.dark) body {
    font-family: "Comic Sans MS", cursive, sans-serif;
}
```

**CSS Specificity:**
- Uses `:not(.dark)` pseudo-class for explicit light mode targeting
- Fallback fonts: `cursive, sans-serif`
- No impact on dark mode styling

## Use Cases

- **UI/UX experiments:** Testing different font personalities
- **Demo purposes:** Showcasing theme customization capabilities  
- **Design exploration:** Evaluating font choices in the design system

## Notes

- ⚠️ **Experimental only** - not intended for production
- 🌙 **Dark mode unaffected** - maintains system font stack
- 🎨 **Easily reversible** - isolated CSS change
- 🚀 **Performance neutral** - Comic Sans MS is a system font

## Testing

- ✅ Light mode displays Comic Sans MS
- ✅ Dark mode displays system fonts
- ✅ Font fallbacks work correctly
- ✅ No layout shifts or performance impact