### PR TITLE
feat(dashboard): add usage alerts

### DIFF
--- a/frontend/src/app/billing/billing-limit-alert.tsx
+++ b/frontend/src/app/billing/billing-limit-alert.tsx
@@ -1,0 +1,70 @@
+import { faExclamationTriangle, Icon } from "@rivet-gg/icons";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Button, cn } from "@/components";
+import { useCloudProjectDataProvider } from "@/components/actors";
+import { useHighestUsagePercent } from "./hooks";
+
+export function BillingLimitAlert() {
+	const dataProvider = useCloudProjectDataProvider();
+	const { data: billingData } = useQuery({
+		...dataProvider.currentProjectBillingDetailsQueryOptions(),
+	});
+
+	const usagePercent = useHighestUsagePercent();
+	const plan = billingData?.billing.activePlan || "free";
+
+	if (plan !== "free" || usagePercent < 80) {
+		return null;
+	}
+
+	return (
+		<div
+			className={cn(
+				"mx-0.5 mb-2 p-2 rounded-md border  text-xs",
+				usagePercent < 100 && "border-warning/60 bg-warning/10",
+				usagePercent >= 100 &&
+					"border-destructive/60 bg-destructive/20",
+			)}
+		>
+			<div className="flex items-start gap-2">
+				<Icon
+					icon={faExclamationTriangle}
+					className={cn(
+						"text-warning shrink-0 mt-0.5",
+						usagePercent >= 100 && "text-destructive",
+					)}
+				/>
+				<div className="flex-1 flex min-w-0 items-center justify-center">
+					<div className="flex-1">
+						<p className="text-foreground font-medium">
+							{usagePercent >= 100
+								? "Usage limit reached"
+								: "Approaching usage limit"}
+						</p>
+						<p className="text-muted-foreground mt-0.5">
+							{usagePercent >= 100
+								? "Upgrade to continue using Actors."
+								: `You have used ${usagePercent}% of your plan's free usage.`}
+						</p>
+					</div>
+					<div>
+						<Button
+							size="sm"
+							className="h-7 text-xs"
+							variant="ghost"
+							asChild
+						>
+							<Link
+								from="/orgs/$organization/projects/$project/ns/$namespace"
+								to="/orgs/$organization/projects/$project/ns/$namespace/billing"
+							>
+								Upgrade
+							</Link>
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/app/billing/billing-plan-badge.tsx
+++ b/frontend/src/app/billing/billing-plan-badge.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import { Badge, Skeleton } from "@/components";
+import { Badge, cn, Skeleton } from "@/components";
 import {
 	useCloudDataProvider,
 	useCloudProjectDataProvider,
@@ -9,8 +9,17 @@ import { VisibilitySensor } from "@/components/visibility-sensor";
 
 const planLabels: Record<string, string> = {
 	free: "Free",
+	team: "Team",
 	pro: "Pro",
 	enterprise: "Enterprise",
+};
+
+const getPlanVariant = (
+	plan: string | undefined,
+): "secondary" | "premium" | "premium-blue" => {
+	if (plan === "team") return "premium-blue";
+	if (plan === "pro" || plan === "enterprise") return "premium";
+	return "secondary";
 };
 
 export function BillingPlanBadge() {
@@ -22,9 +31,15 @@ export function BillingPlanBadge() {
 	if (isLoading) {
 		return <SkeletonBadge />;
 	}
+
+	const plan = data?.billing.activePlan || "free";
+
 	return (
-		<Badge variant="secondary">
-			{planLabels[data?.billing.activePlan || "free"]}
+		<Badge
+			variant={getPlanVariant(plan)}
+			className="min-w-12 justify-center my-px"
+		>
+			{planLabels[plan]}
 		</Badge>
 	);
 }
@@ -32,9 +47,11 @@ export function BillingPlanBadge() {
 export function LazyBillingPlanBadge({
 	project,
 	organization,
+	className,
 }: {
 	project: string;
 	organization: string;
+	className?: string;
 }) {
 	const [isVisible, setIsVisible] = useState(false);
 	const dataProvider = useCloudDataProvider();
@@ -43,18 +60,22 @@ export function LazyBillingPlanBadge({
 		...dataProvider.billingDetailsQueryOptions({ project, organization }),
 	});
 
-	if (isLoading) {
-		return (
-			<>
-				<SkeletonBadge />
-				<VisibilitySensor onChange={() => setIsVisible(true)} />
-			</>
-		);
-	}
+	const plan = data?.billing.activePlan || "free";
+
 	return (
-		<Badge variant="secondary">
-			{planLabels[data?.billing.activePlan || "free"]}
-		</Badge>
+		<>
+			{isLoading || !isVisible ? (
+				<SkeletonBadge />
+			) : (
+				<Badge
+					variant={getPlanVariant(plan)}
+					className={cn("min-w-12 justify-center my-px", className)}
+				>
+					{planLabels[plan]}
+				</Badge>
+			)}
+			<VisibilitySensor onChange={() => setIsVisible(true)} />
+		</>
 	);
 }
 

--- a/frontend/src/app/billing/billing-plans.tsx
+++ b/frontend/src/app/billing/billing-plans.tsx
@@ -156,8 +156,9 @@ function buttonText(
 		);
 	}
 	if (plan === data.activePlan) {
-		return "Cancel";
+		return "Current Plan";
 	}
+
 	return comparePlans(plan, data.futurePlan || Rivet.BillingPlan.Free) > 0
 		? "Upgrade"
 		: "Downgrade";

--- a/frontend/src/app/billing/plan-card.tsx
+++ b/frontend/src/app/billing/plan-card.tsx
@@ -62,13 +62,9 @@ function PlanCard({
 						variant="secondary"
 						className="w-full mt-4"
 						{...buttonProps}
-					>
-						Current Plan
-					</Button>
+					/>
 				) : (
-					<Button className="w-full mt-4" {...buttonProps}>
-						{custom ? "Contact Us" : "Upgrade"}
-					</Button>
+					<Button className="w-full mt-4" {...buttonProps} />
 				)
 			) : null}
 		</div>
@@ -158,6 +154,10 @@ export const EnterprisePlan = (props: Partial<PlanCardProps>) => {
 				{ icon: faCheck, label: "Volume Pricing" },
 			]}
 			{...props}
+			buttonProps={{
+				...props.buttonProps,
+				children: "Contact Us",
+			}}
 		/>
 	);
 };

--- a/frontend/src/app/data-providers/cloud-data-provider.tsx
+++ b/frontend/src/app/data-providers/cloud-data-provider.tsx
@@ -108,7 +108,7 @@ export const createOrganizationContext = ({
 			queryFn: async ({ pageParam }) => {
 				const data = await client.namespaces.list(opts.project, {
 					org: opts.organization,
-					limit: RECORDS_PER_PAGE,
+					limit: 100,
 					cursor: pageParam ?? undefined,
 				});
 				return {
@@ -122,7 +122,7 @@ export const createOrganizationContext = ({
 				};
 			},
 			getNextPageParam: (lastPage) => {
-				if (lastPage.namespaces.length < RECORDS_PER_PAGE) {
+				if (lastPage.namespaces.length < 100) {
 					return undefined;
 				}
 				return lastPage.pagination.cursor;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -44,6 +44,7 @@ import { useRootLayoutOptional } from "@/components/actors/root-layout-context";
 import type { HeaderLinkProps } from "@/components/header/header-link";
 import { ensureTrailingSlash } from "@/lib/utils";
 import { ActorBuildsList } from "./actor-builds-list";
+import { BillingLimitAlert } from "./billing/billing-limit-alert";
 import { BillingPlanBadge } from "./billing/billing-plan-badge";
 import { BillingUsageGauge } from "./billing/billing-usage-gauge";
 import { Changelog } from "./changelog";
@@ -648,6 +649,7 @@ function CloudSidebarContentInner() {
 		<div className="flex gap-0.5 flex-col">
 			{hasDataProvider && hasQuery ? (
 				<div className="w-full pt-1.5">
+					<BillingLimitAlert />
 					<span className="block text-muted-foreground text-xs px-2 py-1 transition-colors mb-0.5">
 						Actors
 					</span>

--- a/frontend/src/components/tailwind-base.ts
+++ b/frontend/src/components/tailwind-base.ts
@@ -148,6 +148,14 @@ const config = {
 						transform: "translate3d(4px, 0, 0)",
 					},
 				},
+				"shimmer-slide": {
+					"0%": { transform: "translateX(-100%)" },
+					"100%": { transform: "translateX(100%)" },
+				},
+				"border-glow": {
+					"0%, 100%": { opacity: "0.5" },
+					"50%": { opacity: "1" },
+				},
 			},
 			animation: {
 				shake: "shake 0.82s cubic-bezier(.36,.07,.19,.97) both",
@@ -155,6 +163,8 @@ const config = {
 				"accordion-up": "accordion-up 0.2s ease-out",
 				"caret-blink": "caret-blink 1.25s ease-out infinite",
 				"bounce-x": "bounce-x 5s ease infinite",
+				"shimmer-slide": "shimmer-slide 2s ease-in-out infinite",
+				"border-glow": "border-glow 2s ease-in-out infinite",
 			},
 
 			typography: {

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -23,6 +23,8 @@ const badgeVariants = cva(
 					"border-transparent bg-muted-destructive text-muted-destructive-foreground",
 				warning: "border-warning/60 text-foreground",
 				outline: "text-foreground",
+				premium: "border-transparent",
+				"premium-blue": "border-transparent",
 			},
 		},
 		defaultVariants: {
@@ -39,8 +41,50 @@ export interface BadgeProps
 }
 
 const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
-	({ className, variant, asChild, ...props }, ref) => {
+	({ className, variant, asChild, children, ...props }, ref) => {
 		const Comp = asChild ? Slot : "div";
+
+		if (variant === "premium" || variant === "premium-blue") {
+			const isBlue = variant === "premium-blue";
+			const gradientClasses = isBlue
+				? "from-blue-500 via-sky-400 to-blue-500"
+				: "from-primary via-orange-400 to-primary";
+			const shimmerClasses = isBlue
+				? "via-blue-500/10"
+				: "via-primary/10";
+
+			return (
+				<div
+					ref={ref}
+					className={cn(
+						"relative inline-flex items-center justify-center rounded-full px-2.5 py-0.5 shrink-0",
+						`bg-gradient-to-r ${gradientClasses}`,
+						getCommonHelperClass(props),
+						className,
+					)}
+					{...omitCommonHelperProps(props)}
+				>
+					<div className="absolute inset-px rounded-full bg-background" />
+					<div className="pointer-events-none absolute inset-px overflow-hidden rounded-full">
+						<div
+							className={cn(
+								`absolute inset-0 bg-gradient-to-r from-transparent to-transparent animate-shimmer-slide`,
+								shimmerClasses,
+							)}
+						/>
+					</div>
+					<span
+						className={cn(
+							`relative z-10 text-xs font-semibold bg-gradient-to-r bg-clip-text text-transparent whitespace-nowrap`,
+							gradientClasses,
+						)}
+					>
+						{children}
+					</span>
+				</div>
+			);
+		}
+
 		return (
 			<Comp
 				ref={ref}
@@ -50,7 +94,9 @@ const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
 					className,
 				)}
 				{...omitCommonHelperProps(props)}
-			/>
+			>
+				{children}
+			</Comp>
 		);
 	},
 );


### PR DESCRIPTION
### TL;DR

Enhanced billing UI with new plan badges, usage alerts, and improved context switcher integration.

### What changed?

- Added a new `BillingLimitAlert` component that displays warnings when approaching or exceeding usage limits
- Enhanced the `BillingPlanBadge` with new styling and support for a "Team" plan tier
- Updated the usage gauge to show different visual indicators based on usage percentage
- Improved the context switcher to display plan badges next to projects and sort current selections to the top
- Updated billing plan card UI with clearer button text and styling
- Added premium badge variants with gradient and animation effects
- Fixed namespace list pagination by increasing the limit from the default to 100

### How to test?

1. Check the billing UI with different usage percentages to see the alerts and gauge changes
2. Verify the new premium badge styling for Team, Pro, and Enterprise plans
3. Open the context switcher to see plan badges next to projects
4. Test the sorting behavior in project and namespace lists
5. Verify that the billing limit alert appears when usage is high on the free plan

### Why make this change?

These changes improve the visibility of billing information throughout the application, making it easier for users to understand their current plan and usage status. The new alerts help prevent unexpected service interruptions by proactively notifying users when they're approaching usage limits. The premium badge styling creates visual distinction between different plan tiers, and the context switcher improvements help users quickly identify which projects are on which plans.