### PR TITLE
feat(dashboard): skip onboarding on non production ns, provide alert when no providers connected

### DIFF
--- a/frontend/src/app/billing/usage-card.tsx
+++ b/frontend/src/app/billing/usage-card.tsx
@@ -206,8 +206,13 @@ export function UsageCard({
 											<motion.div
 												className="absolute h-1.5 rounded-l-full bg-primary"
 												initial={{ width: 0 }}
-												animate={{ width: `${currentPercent}%` }}
-												transition={{ duration: 1, ease: "circIn" }}
+												animate={{
+													width: `${currentPercent}%`,
+												}}
+												transition={{
+													duration: 1,
+													ease: "circIn",
+												}}
 											/>
 										</div>
 

--- a/frontend/src/app/data-providers/cloud-data-provider.tsx
+++ b/frontend/src/app/data-providers/cloud-data-provider.tsx
@@ -673,6 +673,9 @@ export const createNamespaceContext = ({
 				},
 			});
 		},
+		currentNamespaceQueryOptions() {
+			return parent.currentProjectNamespaceQueryOptions({ namespace });
+		},
 		currentNamespaceMetricsQueryOptions(
 			opts: Omit<
 				Parameters<typeof parent.currentProjectMetricsQueryOptions>[0],

--- a/frontend/src/app/forms/edit-single-runner-config-form.tsx
+++ b/frontend/src/app/forms/edit-single-runner-config-form.tsx
@@ -1,4 +1,8 @@
-import { FieldPath, useFormContext, type UseFormReturn } from "react-hook-form";
+import {
+	type FieldPath,
+	type UseFormReturn,
+	useFormContext,
+} from "react-hook-form";
 import z from "zod";
 import {
 	Checkbox,

--- a/frontend/src/app/motion-link.tsx
+++ b/frontend/src/app/motion-link.tsx
@@ -1,17 +1,12 @@
 import { createLink } from "@tanstack/react-router";
 import { motion } from "framer-motion";
-import React, { ComponentProps } from "react";
+import React, { type ComponentProps } from "react";
 
 const MotionLinkComponent = React.forwardRef<
-    HTMLAnchorElement,
-    ComponentProps<typeof motion.a>
+	HTMLAnchorElement,
+	ComponentProps<typeof motion.a>
 >((props, ref) => {
-    return (
-        <motion.a
-            ref={ref}
-            {...props}
-        />
-    );
+	return <motion.a ref={ref} {...props} />;
 });
 
 export const MotionLink = createLink(MotionLinkComponent);

--- a/frontend/src/app/runner-config-table.tsx
+++ b/frontend/src/app/runner-config-table.tsx
@@ -40,7 +40,7 @@ import {
 	useEngineCompatDataProvider,
 } from "@/components/actors";
 import { REGION_LABEL } from "@/components/matchmaker/lobby-region";
-import { RivetActorError } from "@/queries/types";
+import type { RivetActorError } from "@/queries/types";
 
 interface RunnerConfigsTableProps {
 	isLoading?: boolean;

--- a/frontend/src/components/actors/actor-status-label.tsx
+++ b/frontend/src/components/actors/actor-status-label.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { formatISO } from "date-fns";
 import { isObject } from "lodash";
 import { match, P } from "ts-pattern";
+import type { RivetActorError } from "@/queries/types";
 import { CodePreview } from "../code-preview/code-preview";
 import { RelativeTime } from "../relative-time";
 import {
@@ -14,7 +15,6 @@ import { ScrollArea } from "../ui/scroll-area";
 import { Code } from "../ui/typography";
 import { useDataProvider } from "./data-provider";
 import type { ActorId, ActorStatus } from "./queries";
-import { RivetActorError } from "@/queries/types";
 
 export const ACTOR_STATUS_LABEL_MAP = {
 	unknown: "Unknown",

--- a/frontend/src/components/external-link-card.tsx
+++ b/frontend/src/components/external-link-card.tsx
@@ -1,6 +1,6 @@
 import { Slot, Slottable } from "@radix-ui/react-slot";
 import { faChevronRight, Icon, type IconProp } from "@rivet-gg/icons";
-import { cloneElement, type ComponentProps } from "react";
+import { type ComponentProps, cloneElement } from "react";
 import { cn } from "./lib/utils";
 
 interface ExternalLinkCardProps {
@@ -49,13 +49,11 @@ export function ExternalCard({
 	icon,
 	title,
 	description = "Opens in a new tab",
-}: Omit<ExternalLinkCardProps, "href"> ) {
-	
+}: Omit<ExternalLinkCardProps, "href">) {
 	return (
-				<div className="border rounded-lg p-4 hover:border-primary transition-colors cursor-pointer">
-					<Card icon={icon} title={title} description={description} />
-				</div>
-		
+		<div className="border rounded-lg p-4 hover:border-primary transition-colors cursor-pointer">
+			<Card icon={icon} title={title} description={description} />
+		</div>
 	);
 }
 

--- a/frontend/src/content/data.ts
+++ b/frontend/src/content/data.ts
@@ -11,4 +11,5 @@ export const docsLinks = {
 		nextjs: "https://www.rivet.dev/docs/actors/quickstart/next-js",
 	},
 	runtimeModes: "https://www.rivet.dev/docs/general/runtime-modes/",
+	runnersSetup: "https://www.rivet.dev/docs/connect/",
 };

--- a/frontend/src/queries/accessors.ts
+++ b/frontend/src/queries/accessors.ts
@@ -1,5 +1,5 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
 import type { UseSuspenseQueryOptions } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { match } from "ts-pattern";
 import { getConfig } from "@/components";
 import {

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace.tsx
@@ -55,6 +55,17 @@ export const Route = createFileRoute(
 			ls.onboarding.getSkipWelcome(params.project, params.namespace) ||
 			deps.skipOnboarding;
 
+		const namespace = await context.queryClient.fetchQuery(
+			context.dataProvider.currentNamespaceQueryOptions(),
+		);
+
+		if (namespace.displayName !== "Production" || isSkipped === true) {
+			return {
+				displayOnboarding: false,
+				displayBackendOnboarding: false,
+			};
+		}
+
 		const [runnerNames, runnerConfigs] = await Promise.all([
 			context.queryClient.fetchInfiniteQuery(
 				context.dataProvider.runnerNamesQueryOptions(),
@@ -74,11 +85,9 @@ export const Route = createFileRoute(
 		const hasActors = actors > 0;
 
 		const displayOnboarding =
-			!isSkipped &&
-			((!hasRunnerNames && !hasRunnerConfigs) || !hasActors);
+			(!hasRunnerNames && !hasRunnerConfigs) || !hasActors;
 
-		const displayBackendOnboarding =
-			!isSkipped && !hasRunnerNames && !hasRunnerConfigs;
+		const displayBackendOnboarding = !hasRunnerNames && !hasRunnerConfigs;
 
 		return { displayOnboarding, displayBackendOnboarding };
 	},

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/settings.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/settings.tsx
@@ -1,5 +1,7 @@
 import {
 	faAws,
+	faBook,
+	faExclamationTriangle,
 	faGoogleCloud,
 	faHetznerH,
 	faPlus,
@@ -38,7 +40,12 @@ import {
 	Ping,
 	Skeleton,
 } from "@/components";
-import { ActorRegion, useEngineCompatDataProvider } from "@/components/actors";
+import {
+	ActorRegion,
+	useDataProvider,
+	useEngineCompatDataProvider,
+} from "@/components/actors";
+import { docsLinks } from "@/content/data";
 import { CloudApiTokens, PublishableToken, SecretToken } from "./tokens";
 
 export const Route = createFileRoute(
@@ -78,12 +85,79 @@ export function RouteComponent() {
 				<hr className="mb-6" />
 
 				<div className="px-4">
+					<NoRunnersAlert />
 					<Providers />
 					<Runners />
 					<Advanced />
 				</div>
 			</div>
 		</Content>
+	);
+}
+
+function NoRunnersAlert() {
+	const dataProvider = useDataProvider();
+	const { data: runnerNamesCount = 0 } = useInfiniteQuery({
+		...dataProvider.runnerNamesQueryOptions(),
+		select: (data) => data.pages.flatMap((page) => page.names).length,
+	});
+
+	const { data: runnerConfigsCount = 0 } = useInfiniteQuery({
+		...dataProvider.runnerConfigsQueryOptions(),
+		select: (data) =>
+			data.pages.flatMap((page) => Object.keys(page.runnerConfigs))
+				.length,
+	});
+
+	const runnersCount = runnerConfigsCount + runnerNamesCount;
+
+	if (runnersCount > 0) {
+		return null;
+	}
+
+	return (
+		<div className="max-w-5xl mx-auto mb-6 px-6 @6xl:px-0 flex flex-col items-start">
+			<div className="bg-amber-950/50 text-warning-foreground rounded-md p-4 flex gap-4 border border-amber-900 w-full">
+				<div className="flex-1 flex gap-2">
+					<Icon
+						icon={faExclamationTriangle}
+						className="text-warning-foreground text-xl mt-1"
+					/>
+					<div>
+						<H4 className="mb-2">No Providers Connected</H4>
+						<p>
+							You currently have no Providers connected. Connect a
+							Provider to start deploying and running Rivet
+							Actors.
+						</p>
+					</div>
+				</div>
+
+				<div className="flex-col flex gap-4">
+					<ProviderDropdown>
+						<Button
+							variant="ghost"
+							startIcon={<Icon icon={faPlus} />}
+						>
+							Connect Runner
+						</Button>
+					</ProviderDropdown>
+					<Button
+						startIcon={<Icon icon={faBook} />}
+						asChild
+						variant="ghost"
+					>
+						<a
+							href={docsLinks.runnersSetup}
+							target="_blank"
+							rel="noreferrer"
+						>
+							Read Docs
+						</a>
+					</Button>
+				</div>
+			</div>
+		</div>
 	);
 }
 


### PR DESCRIPTION
# Description

Added a "No Providers Connected" alert to improve the user experience when no runners are configured. This alert appears in both the actors list view and the settings page, providing guidance on how to connect providers and links to relevant documentation.

Also added a new `currentNamespaceQueryOptions` method to the cloud data provider to support checking namespace details, and updated the onboarding logic to only show onboarding for Production namespaces.

Additional changes include:
- Added a `useRunnerConfigs` hook to check for available runner configurations
- Added a link to runner setup documentation in content data
- Improved type imports across multiple files with proper `type` prefixes
- Fixed code formatting in several components

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified that the alert appears correctly when no runners are configured and disappears when runners are added. Tested the onboarding flow to ensure it only appears for Production namespaces.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings