### PR TITLE
fix(inspector): fix pagination

### DIFF
--- a/frontend/src/app/data-providers/engine-data-provider.tsx
+++ b/frontend/src/app/data-providers/engine-data-provider.tsx
@@ -264,7 +264,7 @@ export const createNamespaceContext = ({
 					if (lastPage.actors.length < RECORDS_PER_PAGE) {
 						return undefined;
 					}
-					return lastPage.pagination.cursor;
+					return lastPage.pagination?.cursor;
 				},
 				retry: shouldRetryAllExpect403,
 				throwOnError: noThrow,
@@ -288,10 +288,10 @@ export const createNamespaceContext = ({
 					return data;
 				},
 				getNextPageParam: (lastPage) => {
-					// TEMPORARILY DISABLED PAGINATION
-					// FIXME(@NathanFlurry)
-					return undefined;
-					// return lastPage.pagination?.cursor;
+					if (Object.keys(lastPage.names).length < RECORDS_PER_PAGE) {
+						return undefined;
+					}
+					return lastPage.pagination?.cursor;
 				},
 				retry: shouldRetryAllExpect403,
 				throwOnError: noThrow,


### PR DESCRIPTION
# Description

This PR fixes two issues in the engine data provider:

1. Added optional chaining to `lastPage.pagination.cursor` in the actors query to prevent potential null reference errors.
2. Re-enabled pagination for the names query by uncommenting and implementing the `getNextPageParam` function, which now properly checks if the number of names is less than `RECORDS_PER_PAGE` before returning the cursor.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified that the actors query handles cases where pagination might be null, and confirmed that names pagination now works correctly when fetching multiple pages of data.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings