### PR TITLE
refactor(metrics): use project metrics for better performance

### DIFF
--- a/frontend/src/app/billing/billing-page.tsx
+++ b/frontend/src/app/billing/billing-page.tsx
@@ -13,7 +13,7 @@ import { endOfMonth, startOfMonth } from "date-fns";
 import { BillingPlans } from "@/app/billing/billing-plans";
 import { BillingStatus } from "@/app/billing/billing-status";
 import { CurrentBillTotal } from "@/app/billing/current-bill-card";
-import { useAggregatedMetrics } from "@/app/billing/hooks";
+import { useBilledMetrics } from "@/app/billing/hooks";
 import { ManageBillingButton } from "@/app/billing/manage-billing-button";
 import { type MetricType, UsageCard } from "@/app/billing/usage-card";
 import { HelpDropdown } from "@/app/help-dropdown";
@@ -88,7 +88,7 @@ export function BillingPage() {
 	const { data } = useSuspenseQuery({
 		...dataProvider.currentProjectBillingDetailsQueryOptions(),
 	});
-	const metrics = useAggregatedMetrics();
+	const metrics = useBilledMetrics();
 	const plan = data?.billing.activePlan || "free";
 
 	const totalOverageCents = USAGE_METRICS.reduce((total, { key }) => {

--- a/frontend/src/app/billing/billing-plans.tsx
+++ b/frontend/src/app/billing/billing-plans.tsx
@@ -1,5 +1,10 @@
 import { Rivet } from "@rivet-gg/cloud";
-import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import {
+	type UseQueryOptions,
+	useMutation,
+	useQuery,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
 import type { ComponentProps } from "react";
 import { Button, type ButtonProps } from "@/components";
 import { useCloudProjectDataProvider } from "@/components/actors";
@@ -25,10 +30,12 @@ export function BillingPlans() {
 				predicate(query) {
 					return (
 						query.queryKey[1] ===
-						dataProvider.currentProjectLatestMetricsQueryOptions({
-							name: [],
-							namespace: "",
-						}).queryKey[1]
+						dataProvider.currentProjectNamespaceLatestMetricsQueryOptions(
+							{
+								name: [],
+								namespace: "",
+							},
+						).queryKey[1]
 					);
 				},
 			});
@@ -36,7 +43,13 @@ export function BillingPlans() {
 	});
 
 	const { refetch: createUpdateSubscriptionSession, data } = useQuery({
-		...dataProvider.currentProjectBillingSubscriptionUpdateSessionQueryOptions(),
+		...((billing.activePlan !== Rivet.BillingPlan.Free
+			? dataProvider.currentProjectBillingSubscriptionUpdateSessionQueryOptions()
+			: dataProvider.billingCustomerPortalSessionQueryOptions()) as UseQueryOptions<
+			string,
+			unknown,
+			string
+		>),
 	});
 
 	return (
@@ -63,7 +76,7 @@ export function BillingPlans() {
 							},
 							onClick: () => {
 								if (!billing.canChangePlan) {
-									return window.open(data?.url, "_blank");
+									return window.open(data, "_blank");
 								}
 								if (billing.futurePlan === plan) {
 									return mutate({

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"overrides": {
 			"react": "19.1.0",
 			"react-dom": "19.1.0",
-			"@rivet-gg/cloud": "https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff",
+			"@rivet-gg/cloud": "https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29",
 			"@codemirror/state": "^6.5.2"
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   '@clerk/shared': 3.27.1
   react: 19.1.0
   react-dom: 19.1.0
-  '@rivet-gg/cloud': https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff
+  '@rivet-gg/cloud': https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29
   '@codemirror/state': ^6.5.2
 
 importers:
@@ -492,8 +492,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@rivet-gg/cloud':
-        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff
-        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff
+        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29
+        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29
       '@rivetkit/engine-api-full':
         specifier: workspace:*
         version: link:../../engine/sdks/typescript/api-full
@@ -2879,8 +2879,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@rivet-gg/cloud':
-        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff
-        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff
+        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29
+        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29
       '@rivet-gg/icons':
         specifier: workspace:*
         version: link:packages/icons
@@ -3866,8 +3866,8 @@ importers:
         specifier: 25.5.3
         version: 25.5.3
       '@rivet-gg/cloud':
-        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff
-        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff
+        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29
+        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29
       '@rivet-gg/components':
         specifier: workspace:*
         version: link:../frontend/packages/components
@@ -8166,8 +8166,8 @@ packages:
   '@rivet-gg/api@25.5.3':
     resolution: {integrity: sha512-pj8xYQ+I/aQDbThmicPxvR+TWAzGoLSE53mbJi4QZHF8VH2oMvU7CMWqy7OTFH30DIRyVzsnHHRJZKGwtmQL3g==}
 
-  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff':
-    resolution: {tarball: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff}
+  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29':
+    resolution: {tarball: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29}
     version: 0.0.0
 
   '@rivetkit/bare-ts@0.6.2':
@@ -11860,6 +11860,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
@@ -15280,7 +15281,7 @@ packages:
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -21167,7 +21168,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@199a6ff':
+  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@2243d29':
     dependencies:
       cross-fetch: 4.1.0
       form-data: 4.0.5


### PR DESCRIPTION
# Description

This PR refactors the billing metrics system to use project-level metrics instead of aggregating metrics across namespaces. The changes include:

1. Renamed `useAggregatedMetrics()` to `useBilledMetrics()` and simplified its implementation to use project-level metrics directly
2. Updated the billing page to use the new hook
3. Added new data provider methods for project-level metrics
4. Fixed the billing subscription update session to properly handle free plans by using the customer portal session
5. Updated the Rivet Cloud SDK to version 2243d29

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Verified that the billing page correctly displays usage metrics and that plan changes work properly for both free and paid plans.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes