### PR TITLE
feat(dashboard): bring new tabs back

### DIFF
--- a/frontend/src/components/actors/actors-actor-details.tsx
+++ b/frontend/src/components/actors/actors-actor-details.tsx
@@ -1,5 +1,4 @@
 import { faQuestionSquare, Icon } from "@rivet-gg/icons";
-import { useQuery } from "@tanstack/react-query";
 import { memo, type ReactNode, Suspense } from "react";
 import {
 	cn,
@@ -18,7 +17,6 @@ import { ActorQueueTab } from "./actor-queue-tab";
 import { ActorStateTab } from "./actor-state-tab";
 import { QueriedActorStatus } from "./actor-status";
 import { ActorStopButton } from "./actor-stop-button";
-import { ActorTracesTab } from "./actor-traces-tab";
 import { useActorsView } from "./actors-view-context-provider";
 import { ActorConsole } from "./console/actor-console";
 import {
@@ -132,6 +130,21 @@ export function ActorTabs({
 						>
 							Connections
 						</TabsTrigger>
+
+						<TabsTrigger
+							disabled={disabled}
+							value="queue"
+							className="text-xs px-3 py-1 pb-2"
+						>
+							Queue
+						</TabsTrigger>
+						<TabsTrigger
+							disabled={disabled}
+							value="workflow"
+							className="text-xs px-3 py-1 pb-2"
+						>
+							Workflow
+						</TabsTrigger>
 						<TabsTrigger
 							disabled={disabled}
 							value="metadata"
@@ -179,6 +192,21 @@ export function ActorTabs({
 						{guardContent || (
 							<ActorConnectionsTab actorId={actorId} />
 						)}
+					</TabsContent>
+					<TabsContent value="queue" className="min-h-0 flex-1 mt-0">
+						{guardContent || <ActorQueueTab actorId={actorId} />}
+					</TabsContent>
+					<TabsContent
+						value="workflow"
+						className="min-h-0 flex-1 mt-0 h-full"
+					>
+						{guardContent || <ActorWorkflowTab actorId={actorId} />}
+					</TabsContent>
+					<TabsContent
+						value="database"
+						className="min-h-0 min-w-0 flex-1 mt-0 h-full"
+					>
+						{guardContent || <ActorDatabaseTab actorId={actorId} />}
 					</TabsContent>
 					<TabsContent
 						value="state"


### PR DESCRIPTION
# Description

This change adds new tabs to the actor details interface, specifically adding Queue, Workflow, and Database tabs alongside the existing tabs. The implementation includes both the tab triggers in the navigation and their corresponding content components. Additionally, an unused import for `useQuery` from `@tanstack/react-query` and the `ActorTracesTab` import have been removed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes