### PR TITLE
fix: fix link to Rivet Bluesky Profile.

### DIFF
--- a/website/src/components/marketing/sections/CommunitySection.tsx
+++ b/website/src/components/marketing/sections/CommunitySection.tsx
@@ -13,7 +13,7 @@ export function CommunitySection() {
       label: 'X'
     },
     {
-      href: 'https://bsky.app/profile/rivet.dev',
+      href: 'https://bsky.app/profile/rivet.gg',
       icon: faBluesky,
       label: 'Bluesky'
     },


### PR DESCRIPTION
# Description

The previous link linked to rivet.dev as the handle, when the actual handle is rivet.gg.

I had previously tried and failed to follow Rivet using the link at the bottom of the website and only found the actual profle on the GitHub README.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Not at all.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes