### PR TITLE
fix: disable selection on drag

### DIFF
--- a/frontend/src/components/actors/workflow/workflow-visualizer.tsx
+++ b/frontend/src/components/actors/workflow/workflow-visualizer.tsx
@@ -1,29 +1,29 @@
 "use client";
 
-import { useMemo, useState, useCallback } from "react";
 import {
 	Background,
 	BackgroundVariant,
 	Controls,
 	MiniMap,
-	ReactFlow,
-	ReactFlowProvider,
 	type Node,
 	type NodeMouseHandler,
+	ReactFlow,
+	ReactFlowProvider,
 } from "@xyflow/react";
+import { useCallback, useMemo, useState } from "react";
 import "@xyflow/react/dist/style.css";
 import { faXmark, Icon } from "@rivet-gg/icons";
 import { cn, DiscreteCopyButton } from "@/components";
 import { ActorObjectInspector } from "../console/actor-inspector";
-import {
-	TYPE_COLORS,
-	TypeIcon,
-	formatDuration,
-	workflowNodeTypes,
-	type WorkflowNodeData,
-} from "./xyflow-nodes";
 import { workflowHistoryToXYFlow } from "./workflow-to-xyflow";
 import type { WorkflowHistory } from "./workflow-types";
+import {
+	formatDuration,
+	TYPE_COLORS,
+	TypeIcon,
+	type WorkflowNodeData,
+	workflowNodeTypes,
+} from "./xyflow-nodes";
 
 type MetaExtendedEntryType =
 	| "step"
@@ -79,7 +79,6 @@ export function WorkflowVisualizer({
 						nodeTypes={workflowNodeTypes}
 						fitView
 						panOnScroll
-						selectionOnDrag
 						panOnDrag={[1, 2]}
 						edgesFocusable={false}
 						onNodeClick={onNodeClick}
@@ -118,7 +117,9 @@ export function WorkflowVisualizer({
 								}}
 							>
 								<TypeIcon
-									type={selectedNode.entryType as MetaExtendedEntryType}
+									type={
+										selectedNode.entryType as MetaExtendedEntryType
+									}
 									size={18}
 								/>
 							</div>
@@ -181,7 +182,9 @@ export function WorkflowVisualizer({
 								Key
 							</div>
 							<DiscreteCopyButton
-								value={selectedNode.nodeKey ?? selectedNode.label}
+								value={
+									selectedNode.nodeKey ?? selectedNode.label
+								}
 								size="sm"
 								className="w-full text-sm text-left justify-between -mx-2"
 							>


### PR DESCRIPTION
# Description

This change removes the `selectionOnDrag` property from the ReactFlow component in the workflow visualizer and reorganizes import statements to follow a consistent ordering pattern. The removal of `selectionOnDrag` disables the ability to select nodes by dragging, which may improve the user experience by preventing accidental selections during pan operations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes