### PR TITLE
fix: workflow statuses

### DIFF
--- a/frontend/src/components/actors/workflow/workflow-visualizer.tsx
+++ b/frontend/src/components/actors/workflow/workflow-visualizer.tsx
@@ -79,10 +79,14 @@ export function WorkflowVisualizer({
 						nodeTypes={workflowNodeTypes}
 						fitView
 						panOnScroll
-						panOnDrag={[1, 2]}
+						panOnDrag
 						edgesFocusable={false}
+						panActivationKeyCode={null}
 						onNodeClick={onNodeClick}
 						onPaneClick={onPaneClick}
+						nodesDraggable={false}
+						nodesConnectable={false}
+						edgesReconnectable={false}
 						proOptions={{ hideAttribution: true }}
 					>
 						<Background

--- a/frontend/src/components/actors/workflow/xyflow-nodes.tsx
+++ b/frontend/src/components/actors/workflow/xyflow-nodes.tsx
@@ -275,7 +275,7 @@ export function WorkflowNode({ data, selected }: NodeProps<WorkflowNodeType>) {
 							className="text-[9px] font-medium"
 							style={{ color: isFailed ? "#ef4444" : "#f59e0b" }}
 						>
-							x{data.retryCount}
+							x{data.retryCount + 1}
 						</span>
 					</div>
 				)}


### PR DESCRIPTION
# Description

This pull request improves the workflow visualizer component with several enhancements and bug fixes. The changes include reorganizing imports for better readability, fixing the default status logic for workflow entries (changing from "pending" to "completed" when no explicit status is provided), correcting the retry count display to show actual attempts rather than retry attempts, and enhancing the ReactFlow interaction model by disabling node dragging, edge reconnection, and pan activation key while enabling full pan on drag functionality.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes