### PR TITLE
fix: keep admin token off RIVET_PUBLIC_ENDPOINT

### DIFF
--- a/frontend/src/app/env-variables.tsx
+++ b/frontend/src/app/env-variables.tsx
@@ -111,9 +111,21 @@ export const useRivetDsn = ({
 	const dataProvider = useEngineCompatDataProvider();
 	const publishableToken = usePublishableToken();
 	const adminToken = useAdminToken();
-	const token = kind === "publishable" ? publishableToken : adminToken;
+	const namespace = dataProvider.engineNamespace;
 
-	const dsn = `https://${dataProvider.engineNamespace}:${token}@${apiEndpoint
+	let auth: string;
+	if (kind === "secret") {
+		auth = `${namespace}:${adminToken}`;
+	} else if (kind === "publishable") {
+		if (__APP_TYPE__ === "engine") {
+			// Self-hosted engine public endpoint auth only requires namespace.
+			auth = namespace;
+		} else {
+			auth = `${namespace}:${publishableToken}`;
+		}
+	}
+
+	const dsn = `https://${auth}@${apiEndpoint
 		.replace("https://", "")
 		.replace("http://", "")}`;
 


### PR DESCRIPTION
# Description

Fixes self-hosted engine DSN generation so `RIVET_PUBLIC_ENDPOINT` no longer includes the admin token. `RIVET_ENDPOINT` continues to include admin credentials, while public auth in self-hosted engine uses namespace-only auth. This also refactors the auth construction logic for readability and adds an inline comment documenting the self-hosted public behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran git diff review of the branch changes. Frontend typecheck could not be run in this workspace because `frontend/node_modules` is missing (`tsc: command not found`).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
