### PR TITLE
docs(self-hosting): restructure kubernetes guide

### DIFF
--- a/website/src/content/docs/self-hosting/kubernetes.mdx
+++ b/website/src/content/docs/self-hosting/kubernetes.mdx
@@ -6,11 +6,11 @@ skill: true
 
 ## Prerequisites
 
-- Kubernetes cluster (v1.24+)
+- Kubernetes cluster
 - `kubectl` configured
 - [Metrics server](https://github.com/kubernetes-sigs/metrics-server) (required for HPA) — included by default in most distributions (k3d, GKE, EKS, AKS)
 
-## Setup Guide
+## Deploy Rivet Engine
 
 <Steps>
   <Step title="Download Manifests">
@@ -65,16 +65,97 @@ skill: true
   </Step>
 </Steps>
 
-## Applying Configuration Updates
 
-When making subsequent changes to `02-engine-configmap.yaml`, restart the engine pods to pick up the new configuration:
+## Deploy RivetKit App
 
-```bash
-kubectl apply -f 02-engine-configmap.yaml
-kubectl -n rivet-engine rollout restart deployment/rivet-engine
-```
+<Steps>
+  <Step title="Create Kubernetes Manifests">
+    Create these two manifest files:
 
-## Using a Managed PostgreSQL Service
+    <CodeGroup>
+
+    ```yaml deployment.yaml
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: rivetkit-app
+      namespace: your-namespace
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: rivetkit-app
+      template:
+        metadata:
+          labels:
+            app: rivetkit-app
+        spec:
+          containers:
+            - name: rivetkit-app
+              image: registry.example.com/your-team/rivetkit-app:latest
+              envFrom:
+                - secretRef:
+                    name: rivetkit-secrets
+    ```
+
+    ```yaml service.yaml
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: rivetkit-app
+      namespace: your-namespace
+    spec:
+      selector:
+        app: rivetkit-app
+      ports:
+        - name: http
+          port: 8080
+          targetPort: 8080
+    ```
+
+    </CodeGroup>
+  </Step>
+
+  <Step title="Setup Environment">
+    Put the following in `rivetkit-secrets.yaml`:
+
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: rivetkit-secrets
+      namespace: your-namespace
+    type: Opaque
+    stringData:
+      RIVET_ENDPOINT: http://my-app:your-admin-token@your-engine.example.com
+      RIVET_PUBLIC_ENDPOINT: http://my-app@your-engine.example.com
+    ```
+  </Step>
+
+  <Step title="Apply Manifests">
+    ```bash
+    kubectl apply -f rivetkit-secrets.yaml
+    kubectl apply -f deployment.yaml
+    kubectl apply -f service.yaml
+    ```
+  </Step>
+
+  <Step title="Configure RivetKit URL in Dashboard">
+    After the service is deployed and reachable from the public internet:
+
+    1. Open the Rivet Engine dashboard in your browser.
+    2. Enter your admin token when prompted.
+    3. Create a namespace (or select an existing namespace) that matches your endpoint namespace (for example, `my-app`).
+    4. In the namespace sidebar, click **Overview**.
+    5. Click **Add Provider**, then choose **Custom**.
+    6. In the connect modal, select **Serverless** and click **Next**.
+    7. Go to **Confirm Connection**, enter your app endpoint (`.../api/rivet`), then click **Add**.
+  </Step>
+</Steps>
+
+## Advanced
+
+### Using a Managed PostgreSQL Service
 
 If you prefer to use a managed PostgreSQL service (e.g. Amazon RDS, Cloud SQL, Azure Database) instead of the bundled Postgres deployment:
 
@@ -84,6 +165,16 @@ If you prefer to use a managed PostgreSQL service (e.g. Amazon RDS, Cloud SQL, A
   - `11-postgres-secret.yaml`
   - `12-postgres-statefulset.yaml`
   - `13-postgres-service.yaml`
+
+### Applying Configuration Updates
+
+When making subsequent changes to `02-engine-configmap.yaml`, restart the engine pods to pick up the new configuration:
+
+```bash
+kubectl apply -f 02-engine-configmap.yaml
+kubectl -n rivet-engine rollout restart deployment/rivet-engine
+```
+
 
 ## Next Steps
 


### PR DESCRIPTION
# Description

Reworks the self-hosted Kubernetes docs flow to split engine deployment and RivetKit app deployment with clearer step ordering.
Renames sections to "Deploy Rivet Engine" and "Deploy RivetKit App", moves RivetKit deployment before managed PostgreSQL guidance, and groups managed PostgreSQL plus config updates under an "Advanced" section.
Updates manifest and secret instructions, including a dedicated `rivetkit-secrets.yaml` step and revised dashboard connection steps.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Not run (documentation-only changes).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
