### PR TITLE
fix(website): restore docs build

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/client/mod.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/mod.ts
@@ -34,6 +34,7 @@ export { ActorHandleRaw } from "./actor-handle";
 export type {
 	ActorAccessor,
 	Client,
+	ClientConfigInput,
 	ClientRaw,
 	CreateOptions,
 	ExtractActorsFromRegistry,

--- a/website/src/content/docs/clients/javascript.mdx
+++ b/website/src/content/docs/clients/javascript.mdx
@@ -56,7 +56,7 @@ await handle.increment(1);
 
 // Stateful: keep a connection open for realtime events
 const conn = handle.connect();
-conn.on("count", (value: number) => console.log(value));
+conn.on("count", (value) => console.log(value));
 await conn.increment(1);
 ```
 
@@ -97,7 +97,7 @@ import { createClient } from "rivetkit/client";
 
 const client = createClient();
 const conn = client.chatRoom.getOrCreate(["general"]).connect();
-conn.on("message", (msg: string) => console.log(msg));
+conn.on("message", (msg) => console.log(msg));
 conn.once("gameOver", () => console.log("done"));
 ```
 


### PR DESCRIPTION
## Summary
- export ClientConfigInput from rivetkit/client so @rivetkit/react DTS build succeeds during website code-block typecheck
- update JavaScript client docs snippets to remove explicit callback parameter type annotations that conflicted with inferred unknown payloads

## Repro
- before: cd website && pnpm build failed
- after: cd website && pnpm build passes
