### PR TITLE
fix(workflow-engine): prevent loop state from being persisted during rollback replay

### DIFF
--- a/rivetkit-typescript/packages/workflow-engine/src/context.ts
+++ b/rivetkit-typescript/packages/workflow-engine/src/context.ts
@@ -787,15 +787,17 @@ export class WorkflowContextImpl implements WorkflowContextInterface {
 			}
 			iteration++;
 
-			// Periodic prune: persist loop state and defer the flush
-			// so it runs in parallel with the next iteration's user code
-			if (iteration % historyPruneInterval === 0) {
+			if (!rollbackMode) {
 				if (entry.kind.type === "loop") {
 					entry.kind.data.state = state;
 					entry.kind.data.iteration = iteration;
 				}
 				entry.dirty = true;
+			}
 
+			// Periodically defer the flush so the next iteration can overlap
+			// with loop pruning and any pending dirty state writes.
+			if (iteration % historyPruneInterval === 0) {
 				const deletions = this.collectLoopPruning(
 					location,
 					iteration,

--- a/rivetkit-typescript/packages/workflow-engine/tests/rollback.test.ts
+++ b/rivetkit-typescript/packages/workflow-engine/tests/rollback.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	InMemoryDriver,
+	loadStorage,
+	Loop,
 	RollbackCheckpointError,
 	runWorkflow,
 	type WorkflowContextInterface,
@@ -130,6 +132,63 @@ for (const mode of modes) {
 			).rejects.toThrow("boom");
 
 			expect(rollbacks).toEqual(["third", "second", "first"]);
+		});
+
+		it("should not persist loop progress while replaying rollback", async () => {
+			const rollbacks: string[] = [];
+			let shouldFail = true;
+
+			const workflow = async (ctx: WorkflowContextInterface) => {
+				await ctx.rollbackCheckpoint("checkpoint");
+				await ctx.step({
+					name: "outside",
+					run: async () => "outside",
+					rollback: async () => {
+						rollbacks.push("outside");
+					},
+				});
+				await ctx.loop({
+					name: "loop",
+					state: 0,
+					run: async (loopCtx, state) => {
+						await loopCtx.step({
+							name: `step-${state}`,
+							run: async () => `step-${state}`,
+							rollback: async () => {
+								rollbacks.push(`loop-${state}`);
+							},
+						});
+
+						if (state === 0) {
+							return Loop.continue(1);
+						}
+
+						if (shouldFail) {
+							shouldFail = false;
+							throw new Error("boom");
+						}
+
+						return Loop.continue(2);
+					},
+				});
+			};
+
+			await expect(
+				runWorkflow("wf-1", workflow, undefined, driver, { mode }).result,
+			).rejects.toThrow("boom");
+
+			const storage = await loadStorage(driver);
+			const loopEntry = [...storage.history.entries.values()].find(
+				(entry) => entry.kind.type === "loop",
+			);
+
+			expect(loopEntry?.kind.type).toBe("loop");
+			if (loopEntry?.kind.type !== "loop") {
+				throw new Error("Expected loop entry");
+			}
+
+			expect(loopEntry.kind.data.iteration).toBe(1);
+			expect(rollbacks).toContain("outside");
 		});
 	});
 }

--- a/rivetkit-typescript/packages/workflow-engine/tests/sleep.test.ts
+++ b/rivetkit-typescript/packages/workflow-engine/tests/sleep.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	InMemoryDriver,
+	Loop,
 	runWorkflow,
 	type WorkflowContextInterface,
 } from "../src/testing.js";
@@ -201,6 +202,63 @@ for (const mode of modes) {
 			const result = await handle.result;
 			expect(result.state).toBe("completed");
 			expect(driver.getAlarm("wf-1")).toBeUndefined();
+		});
+
+		it("should not replay the previous loop iteration after sleep", async () => {
+			driver.workerPollInterval = 0;
+			const seen: string[] = [];
+
+			const workflow = async (ctx: WorkflowContextInterface) => {
+				return await ctx.loop({
+					name: "drain",
+					state: 0,
+					run: async (loopCtx, state) => {
+						if (state === 0) {
+							seen.push("first");
+							return Loop.continue(1);
+						}
+
+						await loopCtx.sleep("pause", 20);
+						return Loop.break([...seen]);
+					},
+				});
+			};
+
+			if (mode === "yield") {
+				const firstRun = await runWorkflow(
+					"wf-1",
+					workflow,
+					undefined,
+					driver,
+					{ mode },
+				).result;
+				expect(firstRun.state).toBe("sleeping");
+
+				await new Promise((resolve) => setTimeout(resolve, 30));
+
+				const secondRun = await runWorkflow(
+					"wf-1",
+					workflow,
+					undefined,
+					driver,
+					{ mode },
+				).result;
+				expect(secondRun.state).toBe("completed");
+				expect(secondRun.output).toEqual(["first"]);
+				expect(seen).toEqual(["first"]);
+				return;
+			}
+
+			const result = await runWorkflow(
+				"wf-1",
+				workflow,
+				undefined,
+				driver,
+				{ mode },
+			).result;
+			expect(result.state).toBe("completed");
+			expect(result.output).toEqual(["first"]);
+			expect(seen).toEqual(["first"]);
 		});
 	});
 }


### PR DESCRIPTION
## Description

Fixes a bug where loop entry state (iteration count and state value) was being incorrectly persisted during rollback replay. Previously, the loop's progress was unconditionally updated every `historyPruneInterval` iterations, even when the engine was replaying history during a rollback. This corrupted the saved loop progress by advancing the persisted iteration counter while merely replaying previously-completed iterations.

The fix separates two concerns: state persistence (which should only happen outside rollback mode) and history pruning (which is safe and desirable regardless of mode).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `rollback.test.ts`: Verifies that when a loop iteration fails and triggers a rollback, the persisted loop iteration count reflects only the progress made before the failure (not the replayed iterations).
- `sleep.test.ts`: Verifies that after a sleep inside a loop, resuming the workflow does not re-execute previous loop iterations.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective