### PR TITLE
docs(website): clarify FoundationDB is enterprise in self-hosting section

### DIFF
--- a/website/src/components/marketing/sections/HostingSection.tsx
+++ b/website/src/components/marketing/sections/HostingSection.tsx
@@ -67,7 +67,7 @@ export const HostingSection = () => (
           </div>
           <h3 className='mb-2 text-base font-normal text-white'>Self-Host</h3>
           <p className='mb-6 text-sm leading-relaxed text-zinc-500'>
-            Single Rust binary or Docker container. Works with Postgres, file system, or FoundationDB. Full dashboard included.
+            Single Rust binary or Docker container. Works with Postgres, file system, or FoundationDB (enterprise). Full dashboard included.
           </p>
           <div className='mb-6 font-mono text-xs text-zinc-500'>
             <div className='flex gap-2'>


### PR DESCRIPTION
# Description

Updated the self-hosting section of the landing page to clarify that FoundationDB support is enterprise-only, by adding "(enterprise)" next to FoundationDB in the HostingSection component.

## Type of change

- [x] Documentation change

## How Has This Been Tested?

Reviewed the landing page component and verified the text change is accurate.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code