### PR TITLE
fix(rivetkit): use application token for actor-to-actor calls in serverless mode

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/serverless/router.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/serverless/router.ts
@@ -68,34 +68,43 @@ export function buildServerlessRouter(
 				}
 			}
 
-			// Convert config to runner config
-			const newConfig: RegistryConfig = {
+			const sharedConfig: RegistryConfig = {
 				...config,
-				endpoint: endpoint,
-				namespace: namespace,
-				token: token,
+				endpoint,
+				namespace,
 				runner: {
 					...config.runner,
-					totalSlots: totalSlots,
-					runnerName: runnerName,
+					totalSlots,
+					runnerName,
 					// Not supported on serverless
 					runnerKey: undefined,
 				},
+			};
+			const runnerConfig: RegistryConfig = {
+				...sharedConfig,
+				token,
+			};
+			const clientConfig: RegistryConfig = {
+				...sharedConfig,
+				// Preserve the configured application token for actor-to-actor
+				// calls. The start token is only needed for the runner
+				// connection and may not have gateway permissions.
+				token: config.token ?? token,
 			};
 
 			// Create manager driver on demand based on the properties provided
 			// by headers
 			//
-			// NOTE: This relies on the `newConfig.runner.runnerName` to
+			// NOTE: This relies on the `runnerConfig.runner.runnerName` to
 			// configure which runner to create actors on.
 			const managerDriver = new RemoteManagerDriver(
-				convertRegistryConfigToClientConfig(newConfig),
+				convertRegistryConfigToClientConfig(clientConfig),
 			);
 			const client = createClientWithDriver(managerDriver);
 
 			// Create new actor driver with updated config
 			const actorDriver = driverConfig.actor(
-				newConfig,
+				runnerConfig,
 				managerDriver,
 				client,
 			);


### PR DESCRIPTION
## Description

Split the serverless router config to use separate tokens for the runner connection and actor-to-actor calls. The runner uses the token from the serverless start headers, while the actor client preserves the application-level token for gateway operations. This allows serverless runners to be started with minimal-permission tokens while maintaining full permissions for actor-to-actor communication.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This is a configuration routing fix that separates concerns between runner initialization and client operations. The change maintains backward compatibility by falling back to the start token if no application token is configured.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas