### PR TITLE
Add actor reschedule endpoint

### DIFF
--- a/engine/packages/api-peer/src/actors/mod.rs
+++ b/engine/packages/api-peer/src/actors/mod.rs
@@ -4,3 +4,4 @@ pub mod get_or_create;
 pub mod kv_get;
 pub mod list;
 pub mod list_names;
+pub mod reschedule;

--- a/engine/packages/api-peer/src/actors/reschedule.rs
+++ b/engine/packages/api-peer/src/actors/reschedule.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+use gas::prelude::*;
+use rivet_api_builder::ApiCtx;
+use rivet_api_types::actors::reschedule::*;
+use rivet_util::Id;
+
+#[utoipa::path(
+	post,
+	operation_id = "actors_reschedule",
+	path = "/actors/{actor_id}/reschedule",
+	params(
+		("actor_id" = Id, Path),
+		RescheduleQuery,
+	),
+	responses(
+		(status = 200, body = RescheduleResponse),
+	),
+)]
+#[tracing::instrument(skip_all)]
+pub async fn reschedule(
+	ctx: ApiCtx,
+	path: ReschedulePath,
+	query: RescheduleQuery,
+	_body: (),
+) -> Result<RescheduleResponse> {
+	let actors_res = ctx
+		.op(pegboard::ops::actor::get::Input {
+			actor_ids: vec![path.actor_id],
+			fetch_error: false,
+		})
+		.await?;
+
+	let actor = actors_res
+		.actors
+		.into_iter()
+		.next()
+		.ok_or_else(|| pegboard::errors::Actor::NotFound.build())?;
+
+	let namespace = ctx
+		.op(namespace::ops::resolve_for_name_global::Input {
+			name: query.namespace,
+		})
+		.await?
+		.ok_or_else(|| namespace::errors::Namespace::NotFound.build())?;
+
+	if actor.namespace_id != namespace.namespace_id || actor.destroy_ts.is_some() {
+		return Err(pegboard::errors::Actor::NotFound.build());
+	}
+
+	let res = ctx
+		.signal(pegboard::workflows::actor::Reschedule {
+			reset_rescheduling: true,
+		})
+		.to_workflow::<pegboard::workflows::actor::Workflow>()
+		.tag("actor_id", path.actor_id)
+		.graceful_not_found()
+		.send()
+		.await?;
+	if res.is_none() {
+		return Err(pegboard::errors::Actor::NotFound.build());
+	}
+
+	Ok(RescheduleResponse {})
+}

--- a/engine/packages/api-peer/src/router.rs
+++ b/engine/packages/api-peer/src/router.rs
@@ -26,6 +26,10 @@ pub async fn router(
 			.route("/actors", post(actors::create::create))
 			.route("/actors", put(actors::get_or_create::get_or_create))
 			.route("/actors/{actor_id}", delete(actors::delete::delete))
+			.route(
+				"/actors/{actor_id}/reschedule",
+				post(actors::reschedule::reschedule),
+			)
 			.route("/actors/names", get(actors::list_names::list_names))
 			.route(
 				"/actors/{actor_id}/kv/keys/{key}",

--- a/engine/packages/api-public/src/actors/mod.rs
+++ b/engine/packages/api-public/src/actors/mod.rs
@@ -4,4 +4,5 @@ pub mod get_or_create;
 pub mod kv_get;
 pub mod list;
 pub mod list_names;
+pub mod reschedule;
 pub mod utils;

--- a/engine/packages/api-public/src/actors/reschedule.rs
+++ b/engine/packages/api-public/src/actors/reschedule.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+use axum::response::{IntoResponse, Response};
+use rivet_api_builder::{
+	ApiError,
+	extract::{Extension, Json, Path, Query},
+};
+use rivet_api_types::actors::reschedule::*;
+use rivet_api_util::request_remote_datacenter_raw;
+use rivet_util::Id;
+
+use crate::ctx::ApiCtx;
+
+#[utoipa::path(
+	post,
+	operation_id = "actors_reschedule",
+	path = "/actors/{actor_id}/reschedule",
+	params(
+		("actor_id" = Id, Path),
+		RescheduleQuery,
+	),
+	responses(
+		(status = 200, body = RescheduleResponse),
+	),
+	security(("bearer_auth" = [])),
+)]
+#[tracing::instrument(skip_all)]
+pub async fn reschedule(
+	Extension(ctx): Extension<ApiCtx>,
+	Path(path): Path<ReschedulePath>,
+	Query(query): Query<RescheduleQuery>,
+) -> Response {
+	match reschedule_inner(ctx, path, query).await {
+		Ok(response) => response,
+		Err(err) => ApiError::from(err).into_response(),
+	}
+}
+
+#[tracing::instrument(skip_all)]
+async fn reschedule_inner(
+	ctx: ApiCtx,
+	path: ReschedulePath,
+	query: RescheduleQuery,
+) -> Result<Response> {
+	ctx.auth().await?;
+
+	if path.actor_id.label() == ctx.config().dc_label() {
+		let res =
+			rivet_api_peer::actors::reschedule::reschedule(ctx.into(), path, query, ()).await?;
+
+		Ok(Json(res).into_response())
+	} else {
+		request_remote_datacenter_raw(
+			&ctx,
+			path.actor_id.label(),
+			&format!("/actors/{}/reschedule", path.actor_id),
+			axum::http::Method::POST,
+			Some(&query),
+			Option::<&()>::None,
+		)
+		.await
+	}
+}

--- a/engine/packages/api-public/src/router.rs
+++ b/engine/packages/api-public/src/router.rs
@@ -87,6 +87,10 @@ pub async fn router(
 				axum::routing::delete(actors::delete::delete),
 			)
 			.route(
+				"/actors/{actor_id}/reschedule",
+				axum::routing::post(actors::reschedule::reschedule),
+			)
+			.route(
 				"/actors/names",
 				axum::routing::get(actors::list_names::list_names),
 			)

--- a/engine/packages/api-types/src/actors/mod.rs
+++ b/engine/packages/api-types/src/actors/mod.rs
@@ -3,3 +3,4 @@ pub mod delete;
 pub mod get_or_create;
 pub mod list;
 pub mod list_names;
+pub mod reschedule;

--- a/engine/packages/api-types/src/actors/reschedule.rs
+++ b/engine/packages/api-types/src/actors/reschedule.rs
@@ -1,0 +1,20 @@
+use rivet_util::Id;
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
+#[derive(Debug, Deserialize, Serialize, IntoParams)]
+#[serde(deny_unknown_fields)]
+#[into_params(parameter_in = Query)]
+pub struct RescheduleQuery {
+	pub namespace: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReschedulePath {
+	pub actor_id: Id,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+#[schema(as = ActorsRescheduleResponse)]
+pub struct RescheduleResponse {}

--- a/engine/packages/engine/tests/api_actors_reschedule.rs
+++ b/engine/packages/engine/tests/api_actors_reschedule.rs
@@ -1,0 +1,165 @@
+use std::sync::{Arc, Mutex};
+
+mod common;
+
+#[test]
+fn reschedule_running_actor() {
+	common::run(common::TestOpts::new(1), |ctx| async move {
+		let (namespace, _) = common::setup_test_namespace(ctx.leader_dc()).await;
+
+		let runner = common::setup_runner(ctx.leader_dc(), &namespace, |builder| {
+			builder.with_actor_behavior("test-actor", |_| {
+				Box::new(common::test_runner::EchoActor::new())
+			})
+		})
+		.await;
+
+		let res = common::create_actor(
+			ctx.leader_dc().guard_port(),
+			&namespace,
+			"test-actor",
+			runner.name(),
+			rivet_types::actors::CrashPolicy::Destroy,
+		)
+		.await;
+		let actor_id = res.actor.actor_id;
+
+		let first_connectable_ts = loop {
+			let actor = common::try_get_actor(
+				ctx.leader_dc().guard_port(),
+				&actor_id.to_string(),
+				&namespace,
+			)
+			.await
+			.expect("failed to get actor")
+			.expect("actor should exist");
+
+			if let Some(connectable_ts) = actor.connectable_ts {
+				break connectable_ts;
+			}
+
+			tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+		};
+
+		common::api::public::actors_reschedule(
+			ctx.leader_dc().guard_port(),
+			common::api_types::actors::reschedule::ReschedulePath { actor_id },
+			common::api_types::actors::reschedule::RescheduleQuery {
+				namespace: namespace.clone(),
+			},
+		)
+		.await
+		.expect("failed to reschedule actor");
+
+		let actor = loop {
+			let actor = common::try_get_actor(
+				ctx.leader_dc().guard_port(),
+				&actor_id.to_string(),
+				&namespace,
+			)
+			.await
+			.expect("failed to get actor")
+			.expect("actor should exist");
+
+			if actor
+				.connectable_ts
+				.is_some_and(|ts| ts > first_connectable_ts)
+			{
+				break actor;
+			}
+
+			tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+		};
+
+		assert!(
+			actor.destroy_ts.is_none(),
+			"rescheduled actor should remain alive",
+		);
+	});
+}
+
+#[test]
+fn reschedule_bypasses_existing_backoff() {
+	common::run(common::TestOpts::new(1), |ctx| async move {
+		let (namespace, _) = common::setup_test_namespace(ctx.leader_dc()).await;
+
+		let crash_count = Arc::new(Mutex::new(0));
+
+		let runner = common::setup_runner(ctx.leader_dc(), &namespace, |builder| {
+			builder.with_actor_behavior("crash-recover-actor", move |_| {
+				Box::new(common::test_runner::CrashNTimesThenSucceedActor::new(
+					1,
+					crash_count.clone(),
+				))
+			})
+		})
+		.await;
+
+		let res = common::create_actor(
+			ctx.leader_dc().guard_port(),
+			&namespace,
+			"crash-recover-actor",
+			runner.name(),
+			rivet_types::actors::CrashPolicy::Restart,
+		)
+		.await;
+		let actor_id = res.actor.actor_id;
+
+		let scheduled_reschedule_ts = loop {
+			let actor = common::try_get_actor(
+				ctx.leader_dc().guard_port(),
+				&actor_id.to_string(),
+				&namespace,
+			)
+			.await
+			.expect("failed to get actor")
+			.expect("actor should exist");
+
+			if let Some(reschedule_ts) = actor.reschedule_ts {
+				break reschedule_ts;
+			}
+
+			tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+		};
+
+		assert!(
+			scheduled_reschedule_ts > rivet_util::timestamp::now(),
+			"actor should still be waiting on backoff before manual reschedule",
+		);
+
+		common::api::public::actors_reschedule(
+			ctx.leader_dc().guard_port(),
+			common::api_types::actors::reschedule::ReschedulePath { actor_id },
+			common::api_types::actors::reschedule::RescheduleQuery {
+				namespace: namespace.clone(),
+			},
+		)
+		.await
+		.expect("failed to reschedule actor");
+
+		let actor = loop {
+			let actor = common::try_get_actor(
+				ctx.leader_dc().guard_port(),
+				&actor_id.to_string(),
+				&namespace,
+			)
+			.await
+			.expect("failed to get actor")
+			.expect("actor should exist");
+
+			if actor.connectable_ts.is_some() {
+				break actor;
+			}
+
+			tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+		};
+
+		assert!(
+			actor
+				.connectable_ts
+				.expect("actor should have connectable_ts after recovery")
+				< scheduled_reschedule_ts,
+			"manual reschedule should bypass the existing backoff window",
+		);
+	});
+}

--- a/engine/packages/engine/tests/common/api/peer.rs
+++ b/engine/packages/engine/tests/common/api/peer.rs
@@ -206,6 +206,30 @@ pub async fn actors_delete(
 	parse_response(response).await
 }
 
+pub async fn build_actors_reschedule_request(
+	port: u16,
+	path: actors::reschedule::ReschedulePath,
+	query: actors::reschedule::RescheduleQuery,
+) -> Result<reqwest::RequestBuilder> {
+	let client = rivet_pools::reqwest::client().await?;
+	Ok(client.post(format!(
+		"{}/actors/{}/reschedule?{}",
+		get_endpoint(port),
+		path.actor_id,
+		&serde_html_form::to_string(&query)?
+	)))
+}
+
+pub async fn actors_reschedule(
+	port: u16,
+	path: actors::reschedule::ReschedulePath,
+	query: actors::reschedule::RescheduleQuery,
+) -> Result<actors::reschedule::RescheduleResponse> {
+	let request = build_actors_reschedule_request(port, path, query).await?;
+	let response = request.send().await?;
+	parse_response(response).await
+}
+
 pub async fn build_actors_list_names_request(
 	port: u16,
 	query: actors::list_names::ListNamesQuery,

--- a/engine/packages/engine/tests/common/api/public.rs
+++ b/engine/packages/engine/tests/common/api/public.rs
@@ -369,6 +369,30 @@ pub async fn actors_delete(
 	parse_response(response).await
 }
 
+pub async fn build_actors_reschedule_request(
+	port: u16,
+	path: actors::reschedule::ReschedulePath,
+	query: actors::reschedule::RescheduleQuery,
+) -> Result<reqwest::RequestBuilder> {
+	let client = rivet_pools::reqwest::client().await?;
+	Ok(client.post(format!(
+		"{}/actors/{}/reschedule?{}",
+		get_endpoint(port),
+		path.actor_id,
+		serde_html_form::to_string(&query)?
+	)))
+}
+
+pub async fn actors_reschedule(
+	port: u16,
+	path: actors::reschedule::ReschedulePath,
+	query: actors::reschedule::RescheduleQuery,
+) -> Result<actors::reschedule::RescheduleResponse> {
+	let request = build_actors_reschedule_request(port, path, query).await?;
+	let response = request.send().await?;
+	parse_response(response).await
+}
+
 pub async fn build_actors_list_names_request(
 	port: u16,
 	query: actors::list_names::ListNamesQuery,

--- a/engine/packages/pegboard/src/workflows/actor/mod.rs
+++ b/engine/packages/pegboard/src/workflows/actor/mod.rs
@@ -626,13 +626,116 @@ pub async fn pegboard_actor(ctx: &mut WorkflowCtx, input: &Input) -> Result<()> 
 										"cannot wake an actor that intends to sleep but has not stopped yet, deferring wake until after stop",
 									);
 								}
-							} else {
-								tracing::debug!(
-									actor_id=?input.actor_id,
-									"cannot wake actor that is not sleeping",
-								);
-							}
+						} else {
+							tracing::debug!(
+								actor_id=?input.actor_id,
+								"cannot wake actor that is not sleeping",
+							);
 						}
+					},
+						Main::Reschedule(sig) => {
+							if sig.reset_rescheduling {
+								state.reschedule_state = Default::default();
+							}
+
+							if state.sleeping && state.runner_id.is_none() {
+								state.sleeping = false;
+								state.will_wake = false;
+								state.force_reschedule = false;
+
+								match runtime::reschedule_actor(
+									ctx,
+									&input,
+									state,
+									metrics_workflow_id,
+									AllocationOverride::DontSleep {
+										pending_timeout: None,
+									},
+								)
+								.await?
+								{
+									runtime::SpawnActorOutput::Allocated { .. } => {}
+									runtime::SpawnActorOutput::Sleep => {
+										state.sleeping = true;
+									}
+									runtime::SpawnActorOutput::Destroy => {
+										return Ok(Loop::Break(runtime::LifecycleResult {
+											generation: state.generation,
+										}));
+									}
+								}
+							} else if let (
+								Some(runner_id),
+								Some(runner_workflow_id),
+								Some(runner_protocol_version),
+							) = (
+								state.runner_id,
+								state.runner_workflow_id,
+								state.runner_protocol_version,
+							) {
+								state.force_reschedule = true;
+
+								if !state.stopping {
+									state.gc_timeout_ts = Some(
+										util::timestamp::now()
+											+ ctx.config().pegboard().actor_stop_threshold(),
+									);
+									state.going_away = true;
+									state.stopping = true;
+
+									ctx.activity(runtime::SetNotConnectableInput {
+										actor_id: input.actor_id,
+									})
+									.await?;
+
+									if protocol::is_mk2(runner_protocol_version) {
+										ctx.activity(runtime::InsertAndSendCommandsInput {
+											actor_id: input.actor_id,
+											generation: state.generation,
+											runner_id,
+											commands: vec![protocol::mk2::Command::CommandStopActor],
+										})
+										.await?;
+									} else {
+										ctx.signal(crate::workflows::runner::Command {
+											inner: protocol::Command::CommandStopActor(
+												protocol::CommandStopActor {
+													actor_id: input.actor_id.to_string(),
+													generation: state.generation,
+												},
+											),
+										})
+										.to_workflow_id(runner_workflow_id)
+										.send()
+										.await?;
+									}
+								}
+							} else {
+								state.force_reschedule = false;
+
+								match runtime::reschedule_actor(
+									ctx,
+									&input,
+									state,
+									metrics_workflow_id,
+									AllocationOverride::DontSleep {
+										pending_timeout: None,
+									},
+								)
+								.await?
+								{
+									runtime::SpawnActorOutput::Allocated { .. } => {}
+									runtime::SpawnActorOutput::Sleep => {
+										state.sleeping = true;
+									}
+									runtime::SpawnActorOutput::Destroy => {
+										return Ok(Loop::Break(runtime::LifecycleResult {
+											generation: state.generation,
+										}));
+									}
+								}
+							}
+						},
 						Main::Lost(sig) => {
 							// Ignore signals for previous generations
 							if sig.generation != state.generation {
@@ -955,47 +1058,48 @@ async fn handle_stopped(
 ) -> Result<StoppedResult> {
 	tracing::debug!(?variant, "actor stopped");
 
-	let force_reschedule = match &variant {
-		StoppedVariant::Normal {
-			code: protocol::mk2::StopCode::Ok,
-			..
-		} => {
-			// Reset retry count on successful exit
-			state.reschedule_state = Default::default();
+	let force_reschedule = state.force_reschedule
+		|| match &variant {
+			StoppedVariant::Normal {
+				code: protocol::mk2::StopCode::Ok,
+				..
+			} => {
+				// Reset retry count on successful exit
+				state.reschedule_state = Default::default();
 
-			false
-		}
-		StoppedVariant::Normal {
-			code: protocol::mk2::StopCode::Error,
-			message,
-		} => {
-			ctx.v(3)
-				.activity(runtime::SetFailureReasonInput {
-					failure_reason: FailureReason::Crashed {
-						message: message.clone(),
-					},
-				})
-				.await?;
-
-			false
-		}
-		StoppedVariant::Lost {
-			force_reschedule,
-			failure_reason,
-		} => {
-			// Set runner failure reason if actor was lost unexpectedly.
-			// This is set early (before crash policy handling) because it applies to all crash policies.
-			if let Some(failure_reason) = &failure_reason {
+				false
+			}
+			StoppedVariant::Normal {
+				code: protocol::mk2::StopCode::Error,
+				message,
+			} => {
 				ctx.v(3)
 					.activity(runtime::SetFailureReasonInput {
-						failure_reason: failure_reason.clone(),
+						failure_reason: FailureReason::Crashed {
+							message: message.clone(),
+						},
 					})
 					.await?;
-			}
 
-			*force_reschedule
-		}
-	};
+				false
+			}
+			StoppedVariant::Lost {
+				force_reschedule,
+				failure_reason,
+			} => {
+				// Set runner failure reason if actor was lost unexpectedly.
+				// This is set early (before crash policy handling) because it applies to all crash policies.
+				if let Some(failure_reason) = &failure_reason {
+					ctx.v(3)
+						.activity(runtime::SetFailureReasonInput {
+							failure_reason: failure_reason.clone(),
+						})
+						.await?;
+				}
+
+				*force_reschedule
+			}
+		};
 
 	// Clear stop gc timeout to prevent being marked as lost in the lifecycle loop
 	state.gc_timeout_ts = None;
@@ -1214,6 +1318,7 @@ async fn handle_stopped(
 
 	state.will_wake = false;
 	state.going_away = false;
+	state.force_reschedule = false;
 
 	ctx.msg(Stopped {})
 		.topic(("actor_id", input.actor_id))
@@ -1275,6 +1380,14 @@ pub struct Wake {
 	pub allocation_override: AllocationOverride,
 }
 
+#[derive(Debug)]
+#[signal("pegboard_actor_reschedule")]
+pub struct Reschedule {
+	/// Resets the rescheduling retry count to 0.
+	#[serde(default)]
+	pub reset_rescheduling: bool,
+}
+
 /// Reason why an actor was lost.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1328,10 +1441,24 @@ join_signal!(PendingAllocation {
 	// Comment to prevent invalid formatting
 });
 
+join_signal!(PendingAllocationWait {
+	Allocate,
+	Destroy,
+	Reschedule,
+	// Comment to prevent invalid formatting
+});
+
+join_signal!(RescheduleBackoff {
+	Destroy,
+	Reschedule,
+	// Comment to prevent invalid formatting
+});
+
 join_signal!(Main {
 	Event,
 	Events,
 	Wake,
+	Reschedule,
 	Lost,
 	GoingAway,
 	Destroy,

--- a/engine/packages/pegboard/src/workflows/actor/runtime.rs
+++ b/engine/packages/pegboard/src/workflows/actor/runtime.rs
@@ -19,7 +19,7 @@ use vbare::OwnedVersionedData;
 
 use crate::{keys, metrics};
 
-use super::{Allocate, Destroy, Input, PendingAllocation, State, destroy};
+use super::{Allocate, Input, PendingAllocationWait, RescheduleBackoff, State, destroy};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LifecycleRunnerState {
@@ -57,6 +57,8 @@ pub struct LifecycleState {
 	/// If a wake was received in between an actor's intent to sleep and actor stop.
 	#[serde(default)]
 	pub will_wake: bool,
+	#[serde(default)]
+	pub force_reschedule: bool,
 	pub alarm_ts: Option<i64>,
 	/// Handles cleaning up the actor if it does not receive a certain state before the timeout (ex.
 	/// created -> running event, stop intent -> stop event). If the timeout is reached, the actor is
@@ -83,6 +85,7 @@ impl LifecycleState {
 			stopping: false,
 			going_away: false,
 			will_wake: false,
+			force_reschedule: false,
 			alarm_ts: None,
 			gc_timeout_ts: Some(util::timestamp::now() + actor_start_threshold),
 			reschedule_state: RescheduleState::default(),
@@ -100,6 +103,7 @@ impl LifecycleState {
 			stopping: false,
 			going_away: false,
 			will_wake: false,
+			force_reschedule: false,
 			alarm_ts: None,
 			gc_timeout_ts: None,
 			reschedule_state: RescheduleState::default(),
@@ -775,158 +779,24 @@ pub async fn spawn_actor(
 				}
 			}
 
-			let signal = match allocation_override {
-				AllocationOverride::DontSleep {
-					pending_timeout: Some(timeout),
-				}
-				| AllocationOverride::PendingTimeout {
-					pending_timeout: timeout,
-				} => {
-					ctx.listen_with_timeout::<PendingAllocation>(timeout)
-						.await?
-				}
-				_ => Some(ctx.listen::<PendingAllocation>().await?),
-			};
-
-			// If allocation fails, the allocate txn already inserted this actor into the queue. Now we wait for
-			// an `Allocate` signal
-			match signal {
-				Some(PendingAllocation::Allocate(sig)) => {
-					let runner_protocol_version =
-						sig.runner_protocol_version.unwrap_or(PROTOCOL_MK1_VERSION);
-
-					ctx.activity(UpdateRunnerInput {
-						actor_id: input.actor_id,
-						runner_id: sig.runner_id,
-						runner_workflow_id: sig.runner_workflow_id,
-					})
-					.await?;
-
-					if protocol::is_mk2(runner_protocol_version) {
-						ctx.activity(InsertAndSendCommandsInput {
-							actor_id: input.actor_id,
-							generation,
-							runner_id: sig.runner_id,
-							commands: vec![protocol::mk2::Command::CommandStartActor(
-								protocol::mk2::CommandStartActor {
-									config: protocol::mk2::ActorConfig {
-										name: input.name.clone(),
-										key: input.key.clone(),
-										create_ts: util::timestamp::now(),
-										input: input
-											.input
-											.as_ref()
-											.map(|x| BASE64_STANDARD.decode(x))
-											.transpose()?,
-									},
-									// Empty because request ids are ephemeral. This is intercepted by guard and
-									// populated before it reaches the runner
-									hibernating_requests: Vec::new(),
-								},
-							)],
-						})
-						.await?;
-					} else {
-						ctx.signal(crate::workflows::runner::Command {
-							inner: protocol::Command::CommandStartActor(
-								protocol::CommandStartActor {
-									actor_id: input.actor_id.to_string(),
-									generation,
-									config: protocol::ActorConfig {
-										name: input.name.clone(),
-										key: input.key.clone(),
-										create_ts: util::timestamp::now(),
-										input: input
-											.input
-											.as_ref()
-											.map(|x| BASE64_STANDARD.decode(x))
-											.transpose()?,
-									},
-									// Empty because request ids are ephemeral. This is intercepted by guard and
-									// populated before it reaches the runner
-									hibernating_requests: Vec::new(),
-								},
-							),
-						})
-						.to_workflow_id(sig.runner_workflow_id)
-						.send()
-						.await?;
+			let spawn_output = loop {
+				let signal = match allocation_override {
+					AllocationOverride::DontSleep {
+						pending_timeout: Some(timeout),
 					}
-
-					Ok(SpawnActorOutput::Allocated {
-						runner_id: sig.runner_id,
-						runner_workflow_id: sig.runner_workflow_id,
-						runner_protocol_version,
-					})
-				}
-				Some(PendingAllocation::Destroy(_)) => {
-					tracing::debug!(actor_id=?input.actor_id, "destroying before actor allocated");
-
-					let cleared = ctx
-						.activity(ClearPendingAllocationInput {
-							actor_id: input.actor_id,
-							namespace_id: input.namespace_id,
-							runner_name_selector: input.runner_name_selector.clone(),
-							pending_allocation_ts,
-						})
-						.await?;
-
-					// If this actor was no longer present in the queue it means it was allocated. We must now
-					// wait for the allocated signal to prevent a race condition.
-					if !cleared {
-						let sig = ctx.listen::<Allocate>().await?;
-
-						ctx.activity(UpdateRunnerInput {
-							actor_id: input.actor_id,
-							runner_id: sig.runner_id,
-							runner_workflow_id: sig.runner_workflow_id,
-						})
-						.await?;
+					| AllocationOverride::PendingTimeout {
+						pending_timeout: timeout,
+					} => {
+						ctx.listen_with_timeout::<PendingAllocationWait>(timeout)
+							.await?
 					}
-					// Bump the pool so it can scale down
-					else if allocate_res.serverless {
-						let res = ctx
-							.v(2)
-							.signal(crate::workflows::runner_pool::Bump::default())
-							.to_workflow::<crate::workflows::runner_pool::Workflow>()
-							.tag("namespace_id", input.namespace_id)
-							.tag("runner_name", input.runner_name_selector.clone())
-							.send()
-							.await;
+					_ => Some(ctx.listen::<PendingAllocationWait>().await?),
+				};
 
-						if let Some(WorkflowError::WorkflowNotFound) = res
-							.as_ref()
-							.err()
-							.and_then(|x| x.chain().find_map(|x| x.downcast_ref::<WorkflowError>()))
-						{
-							tracing::warn!(
-								namespace_id=%input.namespace_id,
-								runner_name=%input.runner_name_selector,
-								"serverless pool workflow not found, respective runner config likely deleted"
-							);
-						} else {
-							res?;
-						}
-					}
-
-					Ok(SpawnActorOutput::Destroy)
-				}
-				None => {
-					tracing::debug!(actor_id=?input.actor_id, "timed out before actor allocated");
-
-					let cleared = ctx
-						.activity(ClearPendingAllocationInput {
-							actor_id: input.actor_id,
-							namespace_id: input.namespace_id,
-							runner_name_selector: input.runner_name_selector.clone(),
-							pending_allocation_ts,
-						})
-						.await?;
-
-					// If this actor was no longer present in the queue it means it was allocated. We must now
-					// wait for the allocated signal to prevent a race condition.
-					if !cleared {
-						let sig = ctx.listen::<Allocate>().await?;
+				// If allocation fails, the allocate txn already inserted this actor into the queue. Now we wait
+				// for an `Allocate` signal.
+				match signal {
+					Some(PendingAllocationWait::Allocate(sig)) => {
 						let runner_protocol_version =
 							sig.runner_protocol_version.unwrap_or(PROTOCOL_MK1_VERSION);
 
@@ -988,14 +858,38 @@ pub async fn spawn_actor(
 							.await?;
 						}
 
-						Ok(SpawnActorOutput::Allocated {
+						break SpawnActorOutput::Allocated {
 							runner_id: sig.runner_id,
 							runner_workflow_id: sig.runner_workflow_id,
 							runner_protocol_version,
-						})
-					} else {
+						};
+					}
+					Some(PendingAllocationWait::Destroy(_)) => {
+						tracing::debug!(actor_id=?input.actor_id, "destroying before actor allocated");
+
+						let cleared = ctx
+							.activity(ClearPendingAllocationInput {
+								actor_id: input.actor_id,
+								namespace_id: input.namespace_id,
+								runner_name_selector: input.runner_name_selector.clone(),
+								pending_allocation_ts,
+							})
+							.await?;
+
+						// If this actor was no longer present in the queue it means it was allocated. We must now
+						// wait for the allocated signal to prevent a race condition.
+						if !cleared {
+							let sig = ctx.listen::<Allocate>().await?;
+
+							ctx.activity(UpdateRunnerInput {
+								actor_id: input.actor_id,
+								runner_id: sig.runner_id,
+								runner_workflow_id: sig.runner_workflow_id,
+							})
+							.await?;
+						}
 						// Bump the pool so it can scale down
-						if allocate_res.serverless {
+						else if allocate_res.serverless {
 							let res = ctx
 								.v(2)
 								.signal(crate::workflows::runner_pool::Bump::default())
@@ -1019,10 +913,130 @@ pub async fn spawn_actor(
 							}
 						}
 
-						Ok(SpawnActorOutput::Sleep)
+						break SpawnActorOutput::Destroy;
+					}
+					Some(PendingAllocationWait::Reschedule(_)) => {
+						tracing::debug!(
+							actor_id=?input.actor_id,
+							"actor is already pending allocation, ignoring manual reschedule",
+						);
+						continue;
+					}
+					None => {
+						tracing::debug!(actor_id=?input.actor_id, "timed out before actor allocated");
+
+						let cleared = ctx
+							.activity(ClearPendingAllocationInput {
+								actor_id: input.actor_id,
+								namespace_id: input.namespace_id,
+								runner_name_selector: input.runner_name_selector.clone(),
+								pending_allocation_ts,
+							})
+							.await?;
+
+						// If this actor was no longer present in the queue it means it was allocated. We must now
+						// wait for the allocated signal to prevent a race condition.
+						if !cleared {
+							let sig = ctx.listen::<Allocate>().await?;
+							let runner_protocol_version =
+								sig.runner_protocol_version.unwrap_or(PROTOCOL_MK1_VERSION);
+
+							ctx.activity(UpdateRunnerInput {
+								actor_id: input.actor_id,
+								runner_id: sig.runner_id,
+								runner_workflow_id: sig.runner_workflow_id,
+							})
+							.await?;
+
+							if protocol::is_mk2(runner_protocol_version) {
+								ctx.activity(InsertAndSendCommandsInput {
+									actor_id: input.actor_id,
+									generation,
+									runner_id: sig.runner_id,
+									commands: vec![protocol::mk2::Command::CommandStartActor(
+										protocol::mk2::CommandStartActor {
+											config: protocol::mk2::ActorConfig {
+												name: input.name.clone(),
+												key: input.key.clone(),
+												create_ts: util::timestamp::now(),
+												input: input
+													.input
+													.as_ref()
+													.map(|x| BASE64_STANDARD.decode(x))
+													.transpose()?,
+											},
+											// Empty because request ids are ephemeral. This is intercepted by guard and
+											// populated before it reaches the runner
+											hibernating_requests: Vec::new(),
+										},
+									)],
+								})
+								.await?;
+							} else {
+								ctx.signal(crate::workflows::runner::Command {
+									inner: protocol::Command::CommandStartActor(
+										protocol::CommandStartActor {
+											actor_id: input.actor_id.to_string(),
+											generation,
+											config: protocol::ActorConfig {
+												name: input.name.clone(),
+												key: input.key.clone(),
+												create_ts: util::timestamp::now(),
+												input: input
+													.input
+													.as_ref()
+													.map(|x| BASE64_STANDARD.decode(x))
+													.transpose()?,
+											},
+											// Empty because request ids are ephemeral. This is intercepted by guard and
+											// populated before it reaches the runner
+											hibernating_requests: Vec::new(),
+										},
+									),
+								})
+								.to_workflow_id(sig.runner_workflow_id)
+								.send()
+								.await?;
+							}
+
+							break SpawnActorOutput::Allocated {
+								runner_id: sig.runner_id,
+								runner_workflow_id: sig.runner_workflow_id,
+								runner_protocol_version,
+							};
+						} else {
+							// Bump the pool so it can scale down
+							if allocate_res.serverless {
+								let res = ctx
+									.v(2)
+									.signal(crate::workflows::runner_pool::Bump::default())
+									.to_workflow::<crate::workflows::runner_pool::Workflow>()
+									.tag("namespace_id", input.namespace_id)
+									.tag("runner_name", input.runner_name_selector.clone())
+									.send()
+									.await;
+
+								if let Some(WorkflowError::WorkflowNotFound) =
+									res.as_ref().err().and_then(|x| {
+										x.chain().find_map(|x| x.downcast_ref::<WorkflowError>())
+									}) {
+									tracing::warn!(
+										namespace_id=%input.namespace_id,
+										runner_name=%input.runner_name_selector,
+										"serverless pool workflow not found, respective runner config likely deleted"
+									);
+								} else {
+									res?;
+								}
+							}
+
+							break SpawnActorOutput::Sleep;
+						}
 					}
 				}
-			}
+			};
+
+			Ok(spawn_output)
 		}
 		AllocateActorStatus::Sleep => Ok(SpawnActorOutput::Sleep),
 	}
@@ -1066,13 +1080,24 @@ pub async fn reschedule_actor(
 		let next = backoff.step().expect("should not have max retry");
 
 		// Sleep for backoff or destroy early
-		if let Some(_sig) = ctx
-			.listen_with_timeout::<Destroy>(Instant::from(next) - Instant::now())
+		if let Some(sig) = ctx
+			.listen_with_timeout::<RescheduleBackoff>(Instant::from(next) - Instant::now())
 			.await?
 		{
-			tracing::debug!("destroying before actor start");
+			match sig {
+				RescheduleBackoff::Destroy(_) => {
+					tracing::debug!("destroying before actor start");
 
-			return Ok(SpawnActorOutput::Destroy);
+					return Ok(SpawnActorOutput::Destroy);
+				}
+				RescheduleBackoff::Reschedule(sig) => {
+					tracing::debug!(actor_id=?input.actor_id, "interrupting actor reschedule backoff");
+
+					if sig.reset_rescheduling {
+						state.reschedule_state = Default::default();
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description

Add a public `POST /actors/{actor_id}/reschedule` endpoint and wire it through the peer API into the existing pegboard actor workflow. This adds a manual reschedule signal that can recycle healthy running actors, wake sleeping actors into immediate reallocation, and interrupt reschedule backoff while resetting retry state. It also adds API helpers and integration coverage for the new endpoint.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `cargo check -p pegboard -p rivet-api-public -p rivet-api-peer -p rivet-api-types`
- `cargo test -p rivet-engine --test api_actors_reschedule --no-run` was started but not completed

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
