### PR TITLE
fix(rivetkit): pack inspector in pkg-pr-new

### DIFF
--- a/.github/workflows/pkg-pr-new.yaml
+++ b/.github/workflows/pkg-pr-new.yaml
@@ -14,5 +14,6 @@ jobs:
         with:
           node-version: '22'
       - run: pnpm install
-      - run: npx turbo build:publish -F rivetkit -F '@rivetkit/*' -F '!@rivetkit/mcp-hub'
+      - run: pnpm build -F rivetkit -F '@rivetkit/*' -F '!@rivetkit/shared-data' -F '!@rivetkit/engine-frontend' -F '!@rivetkit/mcp-hub'
+      - run: npx turbo build:pack-inspector -F rivetkit
       - run: pnpm dlx pkg-pr-new publish 'shared/typescript/*' 'engine/sdks/typescript/runner/' 'engine/sdks/typescript/runner-protocol/' 'rivetkit-typescript/packages/*' --packageManager pnpm --template './examples/*'


### PR DESCRIPTION
# Description

Align the `pkg-pr-new` workflow with the release pipeline for RivetKit inspector packaging.
The workflow now builds publishable RivetKit packages with the release exclusions and then runs `build:pack-inspector` explicitly so the real inspector frontend is bundled before preview publishing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Compared the workflow steps against the release scripts and reviewed the resulting PR diff.
Ran `npx turbo run build:pack-inspector -F rivetkit --dry=json` to confirm the pack step still depends on `@rivetkit/engine-frontend#build:inspector`.
Did not run the full build or publish pipeline.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
