### PR TITLE
Add preventSleep actor sleep controls

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/registry.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/registry.ts
@@ -61,6 +61,7 @@ import {
 	sleep,
 	sleepWithLongRpc,
 	sleepWithNoSleepOption,
+	sleepWithPreventSleep,
 	sleepWithRawHttp,
 	sleepWithRawWebSocket,
 } from "./sleep";
@@ -104,6 +105,7 @@ export const registry = setup({
 		sleepWithRawHttp,
 		sleepWithRawWebSocket,
 		sleepWithNoSleepOption,
+		sleepWithPreventSleep,
 		// From error-handling.ts
 		errorHandlingActor,
 		customTimeoutActor,

--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/sleep.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/sleep.ts
@@ -199,3 +199,42 @@ export const sleepWithNoSleepOption = actor({
 		noSleep: true,
 	},
 });
+
+export const sleepWithPreventSleep = actor({
+	state: {
+		startCount: 0,
+		sleepCount: 0,
+		preventSleepOnWake: false,
+	},
+	onWake: (c) => {
+		c.state.startCount += 1;
+		c.setPreventSleep(c.state.preventSleepOnWake);
+	},
+	onSleep: (c) => {
+		c.state.sleepCount += 1;
+	},
+	actions: {
+		triggerSleep: (c) => {
+			c.sleep();
+		},
+		getStatus: (c) => {
+			return {
+				startCount: c.state.startCount,
+				sleepCount: c.state.sleepCount,
+				preventSleep: c.preventSleep,
+				preventSleepOnWake: c.state.preventSleepOnWake,
+			};
+		},
+		setPreventSleep: (c, prevent: boolean) => {
+			c.setPreventSleep(prevent);
+			return c.preventSleep;
+		},
+		setPreventSleepOnWake: (c, prevent: boolean) => {
+			c.state.preventSleepOnWake = prevent;
+			return c.state.preventSleepOnWake;
+		},
+	},
+	options: {
+		sleepTimeout: SLEEP_TIMEOUT,
+	},
+});

--- a/rivetkit-typescript/packages/rivetkit/src/actor/config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/config.ts
@@ -212,7 +212,7 @@ export const ActorConfigSchema = z
 				onDestroyTimeout: z.number().positive().default(5000),
 				stateSaveInterval: z.number().positive().default(10_000),
 				actionTimeout: z.number().positive().default(60_000),
-				// Max time to wait for waitUntil background promises during shutdown
+				// Deprecated timeout for legacy background shutdown tasks
 				waitUntilTimeout: z.number().positive().default(15_000),
 				// Max time to wait for run handler to stop during shutdown
 				runStopTimeout: z.number().positive().default(15_000),
@@ -498,8 +498,8 @@ interface BaseActorConfig<
 	 * - Custom workflow logic
 	 *
 	 * **Important:** The actor may go to sleep at any time during the `run`
-	 * handler. Use `c.keepAwake(promise)` to wrap async operations that should
-	 * not be interrupted by sleep.
+	 * handler. Use `c.setPreventSleep(true)` while work is active, then clear
+	 * it with `c.setPreventSleep(false)` once the actor can sleep again.
 	 *
 	 * The handler receives an abort signal via `c.abortSignal` and a
 	 * `c.aborted` alias for loop checks. Use these to gracefully exit.
@@ -1046,7 +1046,7 @@ export const DocActorOptionsSchema = z
 			.number()
 			.optional()
 			.describe(
-				"Max time in ms to wait for waitUntil background promises during shutdown. Default: 15000",
+				"Deprecated. Max time in ms to wait for legacy background shutdown tasks. Default: 15000",
 			),
 		runStopTimeout: z
 			.number()

--- a/rivetkit-typescript/packages/rivetkit/src/actor/contexts/base/actor.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/contexts/base/actor.ts
@@ -274,19 +274,42 @@ export class ActorContext<
 
 	/**
 	 * Prevents the actor from sleeping until promise is complete.
+	 *
+	 * @deprecated Use `onSleep` for shutdown or flush work, or
+	 * `c.setPreventSleep(true)` while work is active if the actor must stay
+	 * awake until it finishes.
 	 */
 	waitUntil(promise: Promise<void>): void {
 		this.#actor.waitUntil(promise);
 	}
 
 	/**
-	 * Prevents the actor from sleeping while the given promise is running.
+	 * Prevents the actor from automatically sleeping until cleared.
 	 *
-	 * Use this when performing async operations in the `run` handler or other
-	 * background contexts where you need to ensure the actor stays awake.
+	 * @experimental
+	 */
+	setPreventSleep(prevent: boolean): void {
+		this.#actor.setPreventSleep(prevent);
+	}
+
+	/**
+	 * True when the actor is explicitly blocking automatic sleep.
+	 *
+	 * @experimental
+	 */
+	get preventSleep(): boolean {
+		return this.#actor.preventSleep;
+	}
+
+	/**
+	 * Prevents the actor from sleeping while the given promise is running.
 	 *
 	 * Returns the resolved value and resets the sleep timer on completion.
 	 * Errors are propagated to the caller.
+	 *
+	 * @deprecated Use `c.setPreventSleep(true)` while work is active, or move
+	 * shutdown and flush work to `onSleep` if it can wait until the actor is
+	 * sleeping.
 	 */
 	keepAwake<T>(promise: Promise<T>): Promise<T> {
 		return this.#actor.keepAwake(promise);

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/mod.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/mod.ts
@@ -77,6 +77,7 @@ enum CanSleep {
 	Yes,
 	NotReady,
 	NotStarted,
+	PreventSleep,
 	ActiveConns,
 	ActiveDisconnectCallbacks,
 	ActiveHonoHttpRequests,
@@ -181,6 +182,7 @@ export class ActorInstance<
 	// MARK: - HTTP/WebSocket Tracking
 	#activeHonoHttpRequests = 0;
 	#activeKeepAwakeCount = 0;
+	#preventSleep = false;
 
 	// MARK: - Deprecated (kept for compatibility)
 	#schedule!: Schedule;
@@ -327,6 +329,10 @@ export class ActorInstance<
 
 	get abortSignal(): AbortSignal {
 		return this.#abortController.signal;
+	}
+
+	get preventSleep(): boolean {
+		return this.#preventSleep;
 	}
 
 	get actions(): string[] {
@@ -1014,6 +1020,17 @@ export class ActorInstance<
 		}
 	}
 
+	setPreventSleep(prevent: boolean) {
+		if (this.#preventSleep === prevent) return;
+
+		this.#preventSleep = prevent;
+		this.#rLog.debug({
+			msg: "updated prevent sleep state",
+			prevent,
+		});
+		this.resetSleepTimer();
+	}
+
 	beginQueueWait() {
 		this.assertReady(true);
 		this.#activeQueueWaitCount++;
@@ -1657,6 +1674,7 @@ export class ActorInstance<
 	#canSleep(): CanSleep {
 		if (!this.#ready) return CanSleep.NotReady;
 		if (!this.#started) return CanSleep.NotReady;
+		if (this.#preventSleep) return CanSleep.PreventSleep;
 		if (this.#activeHonoHttpRequests > 0)
 			return CanSleep.ActiveHonoHttpRequests;
 		if (this.#activeKeepAwakeCount > 0) return CanSleep.ActiveKeepAwake;

--- a/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-sleep.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-sleep.ts
@@ -411,5 +411,82 @@ export function runActorSleepTests(driverTestConfig: DriverTestConfig) {
 				expect(startCount).toBe(1); // Still the same instance
 			}
 		});
+
+		test("preventSleep blocks auto sleep until cleared", async (c) => {
+			const { client } = await setupDriverTest(c, driverTestConfig);
+
+			const sleepActor = client.sleepWithPreventSleep.getOrCreate();
+
+			{
+				const status = await sleepActor.getStatus();
+				expect(status.sleepCount).toBe(0);
+				expect(status.startCount).toBe(1);
+				expect(status.preventSleep).toBe(false);
+				expect(status.preventSleepOnWake).toBe(false);
+			}
+
+			expect(await sleepActor.setPreventSleep(true)).toBe(true);
+
+			await waitFor(driverTestConfig, SLEEP_TIMEOUT + 250);
+
+			{
+				const status = await sleepActor.getStatus();
+				expect(status.sleepCount).toBe(0);
+				expect(status.startCount).toBe(1);
+				expect(status.preventSleep).toBe(true);
+			}
+
+			expect(await sleepActor.setPreventSleep(false)).toBe(false);
+
+			await waitFor(driverTestConfig, SLEEP_TIMEOUT + 250);
+
+			{
+				const status = await sleepActor.getStatus();
+				expect(status.sleepCount).toBe(1);
+				expect(status.startCount).toBe(2);
+				expect(status.preventSleep).toBe(false);
+			}
+		});
+
+		test("preventSleep can be restored during onWake", async (c) => {
+			const { client } = await setupDriverTest(c, driverTestConfig);
+
+			const sleepActor = client.sleepWithPreventSleep.getOrCreate();
+
+			expect(await sleepActor.setPreventSleepOnWake(true)).toBe(true);
+
+			await sleepActor.triggerSleep();
+			await waitFor(driverTestConfig, 250);
+
+			{
+				const status = await sleepActor.getStatus();
+				expect(status.sleepCount).toBe(1);
+				expect(status.startCount).toBe(2);
+				expect(status.preventSleep).toBe(true);
+				expect(status.preventSleepOnWake).toBe(true);
+			}
+
+			await waitFor(driverTestConfig, SLEEP_TIMEOUT + 250);
+
+			{
+				const status = await sleepActor.getStatus();
+				expect(status.sleepCount).toBe(1);
+				expect(status.startCount).toBe(2);
+				expect(status.preventSleep).toBe(true);
+			}
+
+			expect(await sleepActor.setPreventSleepOnWake(false)).toBe(false);
+			expect(await sleepActor.setPreventSleep(false)).toBe(false);
+
+			await waitFor(driverTestConfig, SLEEP_TIMEOUT + 250);
+
+			{
+				const status = await sleepActor.getStatus();
+				expect(status.sleepCount).toBe(2);
+				expect(status.startCount).toBe(3);
+				expect(status.preventSleep).toBe(false);
+				expect(status.preventSleepOnWake).toBe(false);
+			}
+		});
 	});
 }

--- a/rivetkit-typescript/packages/rivetkit/src/workflow/context.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/workflow/context.ts
@@ -453,11 +453,31 @@ export class ActorWorkflowContext<
 		return this.#runCtx.log;
 	}
 
+	setPreventSleep(prevent: boolean): void {
+		this.#ensureActorAccess("setPreventSleep");
+		this.#runCtx.setPreventSleep(prevent);
+	}
+
+	get preventSleep(): boolean {
+		this.#ensureActorAccess("preventSleep");
+		return this.#runCtx.preventSleep;
+	}
+
+	/**
+	 * @deprecated Use `c.setPreventSleep(true)` while work is active, or move
+	 * shutdown and flush work to `onSleep` if it can wait until the actor is
+	 * sleeping.
+	 */
 	keepAwake<T>(promise: Promise<T>): Promise<T> {
 		this.#ensureActorAccess("keepAwake");
 		return this.#runCtx.keepAwake(promise);
 	}
 
+	/**
+	 * @deprecated Use `onSleep` for shutdown or flush work, or
+	 * `c.setPreventSleep(true)` while work is active if the actor must stay
+	 * awake until it finishes.
+	 */
 	waitUntil(promise: Promise<void>): void {
 		this.#ensureActorAccess("waitUntil");
 		this.#runCtx.waitUntil(promise);

--- a/rivetkit-typescript/packages/rivetkit/tests/actor-types.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/actor-types.test.ts
@@ -109,6 +109,23 @@ describe("ActorDefinition", () => {
 				>
 			>();
 		});
+
+		it("exposes preventSleep controls on actor contexts", () => {
+			const dummyActor = actor({
+				state: {},
+				actions: {},
+			});
+
+			type DummyContext = ActorContextOf<typeof dummyActor>;
+
+			expectTypeOf<DummyContext["preventSleep"]>().toEqualTypeOf<boolean>();
+			expectTypeOf<
+				Parameters<DummyContext["setPreventSleep"]>
+			>().toEqualTypeOf<[prevent: boolean]>();
+			expectTypeOf<
+				ReturnType<DummyContext["setPreventSleep"]>
+			>().toEqualTypeOf<void>();
+		});
 	});
 
 	describe("queue type inference", () => {
@@ -502,6 +519,24 @@ describe("ActorDefinition", () => {
 			expectTypeOf<
 				WorkflowContextOfFromRoot<typeof workflowHelperActor>
 			>().toEqualTypeOf<WorkflowContextOf<typeof workflowHelperActor>>();
+		});
+
+		it("exposes preventSleep controls on workflow contexts", () => {
+			const workflowHelperActor = actor({
+				state: {},
+				run: workflow(async () => {}),
+				actions: {},
+			});
+
+			type WorkflowCtx = WorkflowContextOf<typeof workflowHelperActor>;
+
+			expectTypeOf<WorkflowCtx["preventSleep"]>().toEqualTypeOf<boolean>();
+			expectTypeOf<
+				Parameters<WorkflowCtx["setPreventSleep"]>
+			>().toEqualTypeOf<[prevent: boolean]>();
+			expectTypeOf<
+				ReturnType<WorkflowCtx["setPreventSleep"]>
+			>().toEqualTypeOf<void>();
 		});
 	});
 

--- a/website/src/content/docs/actors/lifecycle.mdx
+++ b/website/src/content/docs/actors/lifecycle.mdx
@@ -266,7 +266,7 @@ The `run` hook is called after the actor starts and runs in the background witho
 The handler exposes `c.aborted` for loop checks and `c.abortSignal` for canceling operations when the actor is stopping. You should always check or listen for shutdown to exit gracefully.
 
 **Important behavior:**
-- The actor may go to sleep at any time during the `run` handler. Use `c.keepAwake(promise)` to wrap async operations that should not be interrupted.
+- The actor may go to sleep at any time during the `run` handler. Use `c.setPreventSleep(true)` while work is active, then clear it with `c.setPreventSleep(false)` once the actor can sleep again.
 - If the `run` handler exits (returns), the actor follows its normal idle sleep timeout once it becomes idle
 - If the `run` handler throws an error, the actor logs the error and then follows its normal idle sleep timeout once it becomes idle
 - On shutdown, the actor waits for the `run` handler to complete (with configurable timeout via `options.runStopTimeout`)
@@ -723,9 +723,6 @@ const myActor = actor({
     // Timeout for action execution (default: 60000ms)
     actionTimeout: 60_000,
 
-    // Max time to wait for background promises during shutdown (default: 15000ms)
-    waitUntilTimeout: 15_000,
-
     // Max time to wait for run handler to stop during shutdown (default: 15000ms)
     runStopTimeout: 15_000,
 
@@ -759,7 +756,6 @@ const myActor = actor({
 | `onDestroyTimeout` | 5000ms | Timeout for `onDestroy` hook |
 | `stateSaveInterval` | 10000ms | Interval for persisting state |
 | `actionTimeout` | 60000ms | Timeout for action execution |
-| `waitUntilTimeout` | 15000ms | Max time to wait for background promises during shutdown |
 | `runStopTimeout` | 15000ms | Max time to wait for run handler to stop during shutdown |
 | `connectionLivenessTimeout` | 2500ms | Timeout for connection liveness check |
 | `connectionLivenessInterval` | 5000ms | Interval for connection liveness check |
@@ -769,85 +765,41 @@ const myActor = actor({
 
 ## Advanced
 
-### Preventing Sleep with `keepAwake`
+### Preventing Sleep with `preventSleep`
 
-The actor may go to sleep at any time when idle, including during the `run` handler. If you have async operations that should not be interrupted by sleep, wrap them with `c.keepAwake(promise)`.
+If actor state says the actor should stay awake, call `c.setPreventSleep(true)` and clear it once the actor can sleep again.
 
-The method prevents the actor from sleeping while the promise is running, returns the resolved value, and resets the sleep timer on completion. Errors are propagated to the caller.
-
-```typescript
-import { actor } from "rivetkit";
-
-const tickActor = actor({
-  state: { tickCount: 0 },
-
-  run: async (c) => {
-    while (!c.abortSignal.aborted) {
-      // Keep actor awake while making the API call
-      const data = await c.keepAwake(
-        fetch('https://api.example.com/data').then(res => res.json())
-      );
-
-      c.state.tickCount++;
-      c.log.info({ msg: "fetched data", data, tickCount: c.state.tickCount });
-
-      // Wait before next iteration
-      await new Promise<void>((resolve) => {
-        const timeout = setTimeout(resolve, 5000);
-        c.abortSignal.addEventListener("abort", () => {
-          clearTimeout(timeout);
-          resolve();
-        }, { once: true });
-      });
-    }
-  },
-
-  actions: {
-    getTickCount: (c) => c.state.tickCount
-  }
-});
-```
-
-### Fire-and-Forget with `waitUntil`
-
-The `c.waitUntil` method allows you to execute promises asynchronously without blocking the actor's main execution flow. This is useful for fire-and-forget operations where you don't need to wait for completion or handle errors.
-
-Common use cases:
-- **Analytics and logging**: Send events to external services without delaying responses
-- **State sync**: Populate external databases or APIs with updates to actor state in the background
+This is useful when the sleep-blocking lifetime is driven by actor state instead of a single promise. You can read `c.preventSleep` to inspect the current flag.
 
 ```typescript
 import { actor } from "rivetkit";
 
-const gameRoom = actor({
+const sessionActor = actor({
   state: {
-    players: {} as Record<string, { joinedAt: number }>,
-    scores: {} as Record<string, number>,
+    activeTurns: 0,
   },
 
   actions: {
-    playerJoined: (c, playerId: string) => {
-      c.state.players[playerId] = { joinedAt: Date.now() };
+    beginTurn: async (c) => {
+      c.state.activeTurns += 1;
+      c.setPreventSleep(true);
 
-      // Send analytics event without blocking
-      c.waitUntil(
-        fetch('https://analytics.example.com/events', {
-          method: 'POST',
-          body: JSON.stringify({
-            event: 'player_joined',
-            playerId,
-            timestamp: Date.now()
-          })
-        }).then(() => console.log('Analytics sent'))
-      );
-
-      return { success: true };
+      try {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 1_000);
+        });
+      } finally {
+        c.state.activeTurns -= 1;
+        c.setPreventSleep(c.state.activeTurns > 0);
+      }
     },
+    status: (c) => ({
+      activeTurns: c.state.activeTurns,
+      preventSleep: c.preventSleep,
+    }),
   }
 });
 ```
-
-Note that errors thrown in `waitUntil` promises are logged but not propagated to the caller.
 
 ### Actor Shutdown Abort Signal
 

--- a/website/src/content/docs/actors/limits.mdx
+++ b/website/src/content/docs/actors/limits.mdx
@@ -120,7 +120,6 @@ See [Actor Input](/docs/actors/input) for details.
 | On connect timeout | 5 seconds | — | Timeout for `onConnect` hook. Configurable via `onConnectTimeout`. |
 | On sleep timeout | 5 seconds | — | Timeout for `onSleep` hook. Configurable via `onSleepTimeout`. |
 | On destroy timeout | 5 seconds | — | Timeout for `onDestroy` hook. Configurable via `onDestroyTimeout`. |
-| Wait until timeout | 15 seconds | — | Max time to wait for `waitUntil` background promises during shutdown. Configurable via `waitUntilTimeout`. |
 | Run stop timeout | 15 seconds | — | Max time for `run` handler to stop during shutdown. Configurable via `runStopTimeout`. |
 | Sleep timeout | 30 seconds | — | Time of inactivity before actor hibernates. Configurable via `sleepTimeout`. |
 | State save interval | 10 seconds | — | Interval between automatic state saves. Configurable via `stateSaveInterval`. |

--- a/website/src/content/docs/actors/versions.mdx
+++ b/website/src/content/docs/actors/versions.mdx
@@ -130,10 +130,9 @@ Several timeouts control how long each part of the shutdown process can take:
 | `actor_stop_threshold` | 30s | Engine-side limit on how long each actor has to stop before being marked lost | [Engine config](/docs/self-hosting/configuration) (`pegboard.actor_stop_threshold`) |
 | `onSleepTimeout` | 5s | How long the `onSleep` hook can run | [Actor options](/docs/actors/lifecycle#options) |
 | `runStopTimeout` | 15s | How long to wait for the `run` handler to exit | [Actor options](/docs/actors/lifecycle#options) |
-| `waitUntilTimeout` | 15s | How long to wait for background `waitUntil` promises to resolve | [Actor options](/docs/actors/lifecycle#options) |
 | `runner_lost_threshold` | 15s | Fallback detection if the runner dies without graceful shutdown | [Engine config](/docs/self-hosting/configuration) (`pegboard.runner_lost_threshold`) |
 
-The per-actor timeouts (`onSleepTimeout`, `runStopTimeout`, `waitUntilTimeout`) must fit within `actor_stop_threshold`. The runner's 120-second wait is a hard upper bound on the entire shutdown process.
+The per-actor timeouts (`onSleepTimeout`, `runStopTimeout`) must fit within `actor_stop_threshold`. The runner's 120-second wait is a hard upper bound on the entire shutdown process.
 
 ## Related
 


### PR DESCRIPTION
# Description

Adds `preventSleep` as the recommended actor sleep-control API, wires it through actor and workflow contexts, and adds coverage for direct toggling plus wake-time restoration. This also deprecates `keepAwake` and `waitUntil` ahead of 2.2, and removes their public docs coverage in favor of `setPreventSleep` and `onSleep`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- `pnpm test actor-types`
- `pnpm test driver-file-system -t "preventSleep"`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
