### PR TITLE
fix(pegboard): widen runner_version from u32 to u64

### DIFF
--- a/engine/packages/api-public/src/runner_configs/utils.rs
+++ b/engine/packages/api-public/src/runner_configs/utils.rs
@@ -14,7 +14,7 @@ pub struct ServerlessMetadata {
 	pub runtime: String,
 	pub version: String,
 	pub actor_names: HashMap<String, serde_json::Value>,
-	pub runner_version: Option<u32>,
+	pub runner_version: Option<u64>,
 }
 
 impl From<pegboard::ops::serverless_metadata::fetch::Output> for ServerlessMetadata {

--- a/engine/packages/pegboard/src/ops/serverless_metadata/fetch.rs
+++ b/engine/packages/pegboard/src/ops/serverless_metadata/fetch.rs
@@ -33,7 +33,7 @@ pub struct Output {
 	pub runtime: String,
 	pub version: String,
 	pub actor_names: Vec<ActorNameMetadata>,
-	pub runner_version: Option<u32>,
+	pub runner_version: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Hash)]
@@ -44,7 +44,7 @@ pub struct ActorNameMetadata {
 
 #[derive(Deserialize)]
 struct ServerlessMetadataRunner {
-	version: Option<u32>,
+	version: Option<u64>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary
- Runner version values (e.g. `1773390978291`) can exceed `u32::MAX`, causing serde deserialization to fail on the entire metadata payload
- The serverless health check endpoint returns `invalid_response_json` even though the JSON is valid
- Widens `runner_version` from `u32` to `u64` in `ServerlessMetadataRunner`, `Output`, and `ServerlessMetadata`

## Test plan
- [ ] Verify `serverless-health-check` endpoint no longer returns `invalid_response_json` for runners with large version numbers
- [ ] Confirm existing runner version drain logic still works correctly