### PR TITLE
docs: clarify service keys vs admin tokens for actor management

### DIFF
--- a/website/src/content/docs/actors/debugging.mdx
+++ b/website/src/content/docs/actors/debugging.mdx
@@ -119,15 +119,14 @@ Use your local manager URL in development (`http://localhost:6420`) or `https://
 
 If auth is enabled, pass a bearer token:
 
+- **Rivet Cloud**: Use the service key (`sk_*`) from your `RIVET_ENDPOINT` URL. Find this in the dashboard under **Settings > Advanced > Backend Configuration** (e.g. the `sk_...` portion of `https://default:sk_abc123@api.rivet.dev`).
+- **Self-hosted**: Use an admin token.
+
 ```bash
 export RIVET_API="https://api.rivet.dev"
 export RIVET_NAMESPACE="default"
-export RIVET_TOKEN="YOUR_API_TOKEN"
+export RIVET_TOKEN="your-token"
 ```
-
-<Note>
-	On Rivet Cloud, create a Cloud API token in the dashboard and use it as `RIVET_TOKEN` here.
-</Note>
 
 ### List Runner Names
 

--- a/website/src/content/docs/actors/destroy.mdx
+++ b/website/src/content/docs/actors/destroy.mdx
@@ -41,14 +41,17 @@ const userActor = actor({
 
 ### Destroy via HTTP
 
-Send a DELETE request to destroy an actor. This requires an admin token for authentication.
+Send a DELETE request to destroy an actor. This requires a token for authentication:
+
+- **Rivet Cloud**: Use the service key (`sk_*`) from your `RIVET_ENDPOINT` URL. Find this in the dashboard under **Settings > Advanced > Backend Configuration** (e.g. the `sk_...` portion of `https://default:sk_abc123@api.rivet.dev`).
+- **Self-hosted**: Use an admin token.
 
 <CodeGroup>
 
 ```typescript
 const actorId = "your-actor-id";
 const namespace = "default";
-const token = "your-admin-token";
+const token = "your-token";
 
 await fetch(`https://api.rivet.dev/actors/${actorId}?namespace=${namespace}`, {
   method: "DELETE",
@@ -64,9 +67,12 @@ curl -X DELETE "https://api.rivet.dev/actors/{actorId}?namespace={namespace}" \
 ```
 </CodeGroup>
 
-<Note>
-	On Rivet Cloud, create an API token from Settings > Advanced > Cloud API Tokens > Create API Token, then use it as the bearer token above.
-</Note>
+To find the actor ID, you can list actors first:
+
+```bash
+curl "https://api.rivet.dev/actors?namespace={namespace}" \
+  -H "Authorization: Bearer {token}"
+```
 
 ### Destroy via Dashboard
 


### PR DESCRIPTION
## Summary

Fix incorrect guidance in actor management documentation by clarifying the difference between service keys (for Rivet Cloud) and admin tokens (for self-hosted):

- Replace confusing "admin token" and "Cloud API token" language with accurate guidance
- Rivet Cloud uses service keys (`sk_*`) from `RIVET_ENDPOINT`
- Self-hosted deployments use admin tokens
- Add `GET /actors` endpoint example for discovering actor IDs before destroying
- Remove dead-end notes about unsupported admin tokens

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Files changed

- `website/src/content/docs/actors/debugging.mdx` – Runner API auth guidance
- `website/src/content/docs/actors/destroy.mdx` – HTTP destroy and listing endpoints