### PR TITLE
fix(rivetkit): fix inspector history and nested workflow replay

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/queue.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/queue.ts
@@ -226,3 +226,87 @@ export const queueLimitedActor = actor({
 		maxQueueMessageSize: 64,
 	},
 });
+
+export const MANY_QUEUE_NAMES = Array.from(
+	{ length: 32 },
+	(_, i) => `cmd.${i}` as const,
+);
+
+const manyQueueSchemas = Object.fromEntries(
+	MANY_QUEUE_NAMES.map((name) => [
+		name,
+		queue<{ index: number }, { ok: true; index: number }>(),
+	]),
+);
+
+export const manyQueueChildActor = actor({
+	queues: manyQueueSchemas,
+	actions: {
+		ping: (c) => ({ label: c.state.label, pong: true }),
+		getSnapshot: (c) => c.state,
+	},
+	createState: (_c, label: string) => ({
+		label,
+		started: false,
+		processed: [] as string[],
+	}),
+	run: async (c) => {
+		c.state.started = true;
+		for await (const msg of c.queue.iter({
+			names: [...MANY_QUEUE_NAMES],
+			completable: true,
+		})) {
+			c.state.processed.push(msg.name);
+			await msg.complete({
+				ok: true,
+				index: msg.body.index,
+			});
+		}
+	},
+});
+
+export const manyQueueActionParentActor = actor({
+	state: {
+		spawned: [] as string[],
+	},
+	actions: {
+		spawnChild: async (c, key: string) => {
+			const client = c.client<typeof registry>();
+			await client.manyQueueChildActor.getOrCreate([key], {
+				createWithInput: key,
+			});
+			c.state.spawned.push(key);
+			return { key };
+		},
+		getSpawned: (c) => c.state.spawned,
+	},
+});
+
+export const manyQueueRunParentActor = actor({
+	state: {
+		spawned: [] as string[],
+	},
+	queues: {
+		spawn: queue<{ key: string }>(),
+	},
+	actions: {
+		queueSpawn: async (c, key: string) => {
+			await c.queue.send("spawn", { key });
+			return { queued: true };
+		},
+		getSpawned: (c) => c.state.spawned,
+	},
+	run: async (c) => {
+		for await (const msg of c.queue.iter({
+			names: ["spawn"],
+			completable: true,
+		})) {
+			const client = c.client<typeof registry>();
+			await client.manyQueueChildActor.getOrCreate([msg.body.key], {
+				createWithInput: msg.body.key,
+			});
+			c.state.spawned.push(msg.body.key);
+			await msg.complete({ ok: true });
+		}
+	},
+});

--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/registry.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/registry.ts
@@ -38,7 +38,13 @@ import { kvActor } from "./kv";
 import { largePayloadActor, largePayloadConnActor } from "./large-payloads";
 import { counterWithLifecycle } from "./lifecycle";
 import { metadataActor } from "./metadata";
-import { queueActor, queueLimitedActor } from "./queue";
+import {
+	manyQueueActionParentActor,
+	manyQueueChildActor,
+	manyQueueRunParentActor,
+	queueActor,
+	queueLimitedActor,
+} from "./queue";
 import {
 	rawHttpActor,
 	rawHttpHonoActor,
@@ -81,6 +87,11 @@ import {
 	workflowErrorHookActor,
 	workflowErrorHookEffectsActor,
 	workflowErrorHookSleepActor,
+	workflowNestedJoinActor,
+	workflowNestedLoopActor,
+	workflowSpawnChildActor,
+	workflowSpawnParentActor,
+	workflowNestedRaceActor,
 	workflowQueueActor,
 	workflowSleepActor,
 	workflowStopTeardownActor,
@@ -113,9 +124,12 @@ export const registry = setup({
 		inlineClientActor,
 		// From kv.ts
 		kvActor,
-		// From queue.ts
-		queueActor,
-		queueLimitedActor,
+			// From queue.ts
+			queueActor,
+			queueLimitedActor,
+			manyQueueChildActor,
+			manyQueueActionParentActor,
+			manyQueueRunParentActor,
 		// From action-inputs.ts
 		inputActor,
 		// From action-timeout.ts
@@ -182,6 +196,11 @@ export const registry = setup({
 		workflowErrorHookActor,
 		workflowErrorHookEffectsActor,
 		workflowErrorHookSleepActor,
+		workflowNestedLoopActor,
+		workflowNestedJoinActor,
+		workflowNestedRaceActor,
+		workflowSpawnChildActor,
+		workflowSpawnParentActor,
 		// From actor-db-raw.ts
 		dbActorRaw,
 		// From actor-db-drizzle.ts

--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/workflow.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/workflow.ts
@@ -10,6 +10,7 @@ import {
 import type { registry } from "./registry";
 
 const WORKFLOW_QUEUE_NAME = "workflow-default";
+const WORKFLOW_NESTED_QUEUE_NAME = "workflow-nested";
 
 export const workflowCounterActor = actor({
 	state: {
@@ -84,6 +85,268 @@ export const workflowQueueActor = actor({
 				timeout: 1_000,
 			});
 		},
+	},
+});
+
+export const workflowNestedLoopActor = actor({
+	state: {
+		processed: [] as string[],
+	},
+	queues: {
+		[WORKFLOW_NESTED_QUEUE_NAME]: queue<
+			{ items: string[] },
+			{ processed: number }
+		>(),
+	},
+	run: workflow(async (ctx) => {
+		await ctx.loop("command-loop", async (loopCtx) => {
+			const message = await loopCtx.queue.next<{
+				items: string[];
+			}>("wait", {
+				names: [WORKFLOW_NESTED_QUEUE_NAME],
+				completable: true,
+			});
+			let itemIndex = 0;
+			await loopCtx.loop("process-items", async (subLoopCtx) => {
+				const item = message.body.items[itemIndex];
+				if (item === undefined) {
+					return Loop.break(undefined);
+				}
+
+				await subLoopCtx.step(`process-item-${itemIndex}`, async () => {
+					subLoopCtx.state.processed.push(item);
+				});
+				itemIndex += 1;
+				return Loop.continue(undefined);
+			});
+
+			await message.complete?.({ processed: message.body.items.length });
+			return Loop.continue(undefined);
+		});
+	}),
+	actions: {
+		getState: (c) => c.state,
+	},
+	options: {
+		sleepTimeout: 50,
+	},
+});
+
+export const workflowNestedJoinActor = actor({
+	state: {
+		processed: [] as string[],
+	},
+	queues: {
+		[WORKFLOW_NESTED_QUEUE_NAME]: queue<
+			{ items: string[] },
+			{ processed: number }
+		>(),
+	},
+	run: workflow(async (ctx) => {
+		await ctx.loop("command-loop", async (loopCtx) => {
+			const message = await loopCtx.queue.next<{
+				items: string[];
+			}>("wait", {
+				names: [WORKFLOW_NESTED_QUEUE_NAME],
+				completable: true,
+			});
+
+			await loopCtx.join(
+				"process-items",
+				Object.fromEntries(
+					message.body.items.map((item, index) => [
+						`item-${index}`,
+						{
+							run: async (branchCtx) =>
+								await branchCtx.step(
+									`process-item-${index}`,
+									async () => {
+										branchCtx.state.processed.push(item);
+										return item;
+									},
+								),
+						},
+					]),
+				),
+			);
+
+			await message.complete?.({ processed: message.body.items.length });
+			return Loop.continue(undefined);
+		});
+	}),
+	actions: {
+		getState: (c) => c.state,
+	},
+	options: {
+		sleepTimeout: 50,
+	},
+});
+
+export const workflowNestedRaceActor = actor({
+	state: {
+		processed: [] as string[],
+	},
+	queues: {
+		[WORKFLOW_NESTED_QUEUE_NAME]: queue<
+			{ items: string[] },
+			{ processed: number }
+		>(),
+	},
+	run: workflow(async (ctx) => {
+		await ctx.loop("command-loop", async (loopCtx) => {
+			const message = await loopCtx.queue.next<{
+				items: string[];
+			}>("wait", {
+				names: [WORKFLOW_NESTED_QUEUE_NAME],
+				completable: true,
+			});
+			const item = message.body.items[0];
+
+			if (item !== undefined) {
+				await loopCtx.race("process-item", [
+					{
+						name: "fast",
+						run: async (raceCtx) =>
+							await raceCtx.step("process-fast", async () => {
+								raceCtx.state.processed.push(item);
+								return item;
+							}),
+					},
+					{
+						name: "slow",
+						run: async (raceCtx) => {
+							await new Promise<void>((resolve) => {
+								if (raceCtx.abortSignal.aborted) {
+									resolve();
+									return;
+								}
+								raceCtx.abortSignal.addEventListener(
+									"abort",
+									() => resolve(),
+									{ once: true },
+								);
+							});
+							return "slow";
+						},
+					},
+				]);
+			}
+
+			await message.complete?.({ processed: message.body.items.length });
+			return Loop.continue(undefined);
+		});
+	}),
+	actions: {
+		getState: (c) => c.state,
+	},
+	options: {
+		sleepTimeout: 50,
+	},
+});
+
+export const workflowSpawnChildActor = actor({
+	createState: (_c, input?: string) => ({
+		label: input ?? "",
+		started: false,
+		processed: [] as string[],
+	}),
+	queues: {
+		work: queue<{ task: string }, { ok: true }>(),
+	},
+	run: workflow(async (ctx) => {
+		await ctx.step("mark-started", async () => {
+			ctx.state.started = true;
+		});
+
+		await ctx.loop("cmd-loop", async (loopCtx) => {
+			const message = await loopCtx.queue.next<{ task: string }>(
+				"wait-cmd",
+				{
+					names: ["work"],
+					completable: true,
+				},
+			);
+			await loopCtx.step("process-cmd", async () => {
+				loopCtx.state.processed.push(message.body.task);
+			});
+			await message.complete?.({ ok: true });
+			return Loop.continue(undefined);
+		});
+	}),
+	actions: {
+		getState: (c) => c.state,
+	},
+	options: {
+		sleepTimeout: 50,
+	},
+});
+
+export const workflowSpawnParentActor = actor({
+	state: {
+		results: [] as Array<{
+			key: string;
+			result: unknown | null;
+			error: string | null;
+		}>,
+	},
+	queues: {
+		spawn: queue<{ key: string }>(),
+	},
+	run: workflow(async (ctx) => {
+		await ctx.loop("parent-loop", async (loopCtx) => {
+			const message = await loopCtx.queue.next<{ key: string }>(
+				"wait-parent",
+				{
+					names: ["spawn"],
+					completable: true,
+				},
+			);
+
+			await loopCtx.step("spawn-child", async () => {
+				try {
+					const client = loopCtx.client<typeof registry>();
+					const handle = client.workflowSpawnChildActor.getOrCreate(
+						[message.body.key],
+						{
+							createWithInput: message.body.key,
+						},
+					);
+					const result = await handle.send(
+						"work",
+						{ task: "hello" },
+						{
+							wait: true,
+							timeout: 500,
+						},
+					);
+					loopCtx.state.results.push({
+						key: message.body.key,
+						result,
+						error: null,
+					});
+				} catch (error) {
+					loopCtx.state.results.push({
+						key: message.body.key,
+						result: null,
+						error:
+							error instanceof Error ? error.message : String(error),
+					});
+				}
+			});
+
+			await message.complete?.({ ok: true });
+			return Loop.continue(undefined);
+		});
+	}),
+	actions: {
+		triggerSpawn: async (c, key: string) => {
+			await c.queue.send("spawn", { key });
+			return { queued: true };
+		},
+		getState: (c) => c.state,
+	},
+	options: {
+		sleepTimeout: 50,
 	},
 });
 
@@ -428,4 +691,4 @@ function incrementWorkflowSleepTick(
 	ctx.state.ticks += 1;
 }
 
-export { WORKFLOW_QUEUE_NAME };
+export { WORKFLOW_NESTED_QUEUE_NAME, WORKFLOW_QUEUE_NAME };

--- a/rivetkit-typescript/packages/rivetkit/src/actor/router.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/router.ts
@@ -298,6 +298,8 @@ export function createActorRouter(
 			const isStateEnabled = actor.inspector.isStateEnabled();
 			const isDatabaseEnabled = actor.inspector.isDatabaseEnabled();
 			const isWorkflowEnabled = actor.inspector.isWorkflowEnabled();
+			const workflowHistory =
+				actor.inspector.getWorkflowHistoryJson().history;
 
 			const state = isStateEnabled
 				? actor.inspector.getStateJson()
@@ -305,14 +307,6 @@ export function createActorRouter(
 			const connections = actor.inspector.getConnectionsJson();
 			const rpcs = actor.inspector.getRpcs();
 			const queueSize = actor.inspector.getQueueSize();
-			const workflowHistory = actor.inspector.getWorkflowHistory();
-
-			// Convert BigInt values in workflow history to numbers for JSON serialization.
-			const bigIntReplacer = (_key: string, value: unknown) =>
-				typeof value === "bigint" ? Number(value) : value;
-			const safeWorkflowHistory = workflowHistory
-				? JSON.parse(JSON.stringify(workflowHistory, bigIntReplacer))
-				: null;
 
 			return c.json({
 				state,
@@ -322,7 +316,7 @@ export function createActorRouter(
 				isStateEnabled,
 				isDatabaseEnabled,
 				isWorkflowEnabled,
-				workflowHistory: safeWorkflowHistory,
+				workflowHistory,
 			});
 		});
 	}

--- a/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-inspector.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-inspector.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import type { DriverTestConfig } from "../mod";
-import { setupDriverTest } from "../utils";
+import { setupDriverTest, waitFor } from "../utils";
 
 export function runActorInspectorTests(driverTestConfig: DriverTestConfig) {
 	describe("Actor Inspector HTTP API", () => {
@@ -197,6 +197,51 @@ export function runActorInspectorTests(driverTestConfig: DriverTestConfig) {
 			expect(data.history).toBeNull();
 		});
 
+		test("GET /inspector/workflow-history returns populated history for active workflows", async (c) => {
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.workflowCounterActor.getOrCreate([
+				"inspector-workflow-active",
+			]);
+
+			let state = await handle.getState();
+			for (
+				let i = 0;
+				i < 40 &&
+				(state.runCount === 0 || state.history.length === 0);
+				i++
+			) {
+				await waitFor(driverTestConfig, 50);
+				state = await handle.getState();
+			}
+
+			expect(state.runCount).toBeGreaterThan(0);
+			expect(state.history.length).toBeGreaterThan(0);
+
+			const gatewayUrl = await handle.getGatewayUrl();
+			const response = await fetch(
+				`${gatewayUrl}/inspector/workflow-history`,
+				{
+					headers: { Authorization: "Bearer token" },
+				},
+			);
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as {
+				history: {
+					nameRegistry: string[];
+					entries: unknown[];
+					entryMetadata: Record<string, unknown>;
+				} | null;
+				isWorkflowEnabled: boolean;
+			};
+			expect(data.isWorkflowEnabled).toBe(true);
+			expect(data.history).not.toBeNull();
+			expect(data.history?.nameRegistry.length).toBeGreaterThan(0);
+			expect(data.history?.entries.length).toBeGreaterThan(0);
+			expect(
+				Object.keys(data.history?.entryMetadata ?? {}).length,
+			).toBeGreaterThan(0);
+		});
+
 		test("GET /inspector/summary returns full actor snapshot", async (c) => {
 			const { client } = await setupDriverTest(c, driverTestConfig);
 			const handle = client.counter.getOrCreate(["inspector-summary"]);
@@ -226,6 +271,45 @@ export function runActorInspectorTests(driverTestConfig: DriverTestConfig) {
 			expect(typeof data.isDatabaseEnabled).toBe("boolean");
 			expect(data.isWorkflowEnabled).toBe(false);
 			expect(data.workflowHistory).toBeNull();
+		});
+
+		test("GET /inspector/summary returns populated workflow history for active workflows", async (c) => {
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.workflowCounterActor.getOrCreate([
+				"inspector-summary-workflow",
+			]);
+
+			let state = await handle.getState();
+			for (
+				let i = 0;
+				i < 40 &&
+				(state.runCount === 0 || state.history.length === 0);
+				i++
+			) {
+				await waitFor(driverTestConfig, 50);
+				state = await handle.getState();
+			}
+
+			const gatewayUrl = await handle.getGatewayUrl();
+			const response = await fetch(`${gatewayUrl}/inspector/summary`, {
+				headers: { Authorization: "Bearer token" },
+			});
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as {
+				isWorkflowEnabled: boolean;
+				workflowHistory: {
+					nameRegistry: string[];
+					entries: unknown[];
+					entryMetadata: Record<string, unknown>;
+				} | null;
+			};
+			expect(data.isWorkflowEnabled).toBe(true);
+			expect(data.workflowHistory).not.toBeNull();
+			expect(data.workflowHistory?.nameRegistry.length).toBeGreaterThan(0);
+			expect(data.workflowHistory?.entries.length).toBeGreaterThan(0);
+			expect(
+				Object.keys(data.workflowHistory?.entryMetadata ?? {}).length,
+			).toBeGreaterThan(0);
 		});
 
 		test("inspector endpoints require auth in non-dev mode", async (c) => {

--- a/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-queue.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-queue.ts
@@ -1,10 +1,66 @@
 import { describe, expect, test } from "vitest";
 import type { ActorError } from "@/client/mod";
+import { MANY_QUEUE_NAMES } from "../../../fixtures/driver-test-suite/queue";
 import type { DriverTestConfig } from "../mod";
 import { setupDriverTest, waitFor } from "../utils";
 
 export function runActorQueueTests(driverTestConfig: DriverTestConfig) {
 	describe("Actor Queue Tests", () => {
+		async function expectManyQueueChildToDrain(
+			handle: Awaited<ReturnType<typeof setupDriverTest>>["client"]["manyQueueChildActor"],
+			key: string,
+		) {
+			const child = handle.getOrCreate([key]);
+			const conn = child.connect();
+			const messageCount = MANY_QUEUE_NAMES.length * 4;
+
+			try {
+				expect(await conn.ping()).toEqual(
+					expect.objectContaining({
+						pong: true,
+					}),
+				);
+
+				await Promise.all(
+					Array.from({ length: messageCount }, (_, index) =>
+						child.send(
+							MANY_QUEUE_NAMES[index % MANY_QUEUE_NAMES.length],
+							{ index },
+						),
+					),
+				);
+
+				let snapshot = await child.getSnapshot();
+				for (
+					let i = 0;
+					i < 60 && snapshot.processed.length < messageCount;
+					i++
+				) {
+					await waitFor(driverTestConfig, 100);
+					snapshot = await child.getSnapshot();
+				}
+
+				expect(snapshot.started).toBe(true);
+				expect(snapshot.processed).toHaveLength(messageCount);
+				expect(new Set(snapshot.processed)).toEqual(
+					new Set(MANY_QUEUE_NAMES),
+				);
+
+				expect(
+					await child.send(
+						MANY_QUEUE_NAMES[0],
+						{ index: messageCount },
+						{ wait: true, timeout: 1_000 },
+					),
+				).toEqual({
+					status: "completed",
+					response: { ok: true, index: messageCount },
+				});
+			} finally {
+				await conn.dispose().catch(() => undefined);
+			}
+		}
+
 		test("client can send to actor queue", async (c) => {
 			const { client } = await setupDriverTest(c, driverTestConfig);
 			const handle = client.queueActor.getOrCreate(["client-send"]);
@@ -216,6 +272,56 @@ export function runActorQueueTests(driverTestConfig: DriverTestConfig) {
 
 			expect(result.status).toBe("timedOut");
 		});
+
+		test(
+			"drains many-queue child actors created from actions while connected",
+			async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const parent = client.manyQueueActionParentActor.getOrCreate([
+					"many-action-parent",
+				]);
+
+				expect(await parent.spawnChild("many-action-child")).toEqual({
+					key: "many-action-child",
+				});
+
+				await expectManyQueueChildToDrain(
+					client.manyQueueChildActor,
+					"many-action-child",
+				);
+			},
+		);
+
+		test(
+			"drains many-queue child actors created from run handlers while connected",
+			async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const parent = client.manyQueueRunParentActor.getOrCreate([
+					"many-run-parent",
+				]);
+
+				expect(await parent.queueSpawn("many-run-child")).toEqual({
+					queued: true,
+				});
+
+				let spawned = await parent.getSpawned();
+				for (
+					let i = 0;
+					i < 30 && !spawned.includes("many-run-child");
+					i++
+				) {
+					await waitFor(driverTestConfig, 100);
+					spawned = await parent.getSpawned();
+				}
+
+				expect(spawned).toContain("many-run-child");
+
+				await expectManyQueueChildToDrain(
+					client.manyQueueChildActor,
+					"many-run-child",
+				);
+			},
+		);
 
 		test("manual receive retries message when not completed", async (c) => {
 			const { client } = await setupDriverTest(c, driverTestConfig);

--- a/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-workflow.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-workflow.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { WORKFLOW_QUEUE_NAME } from "../../../fixtures/driver-test-suite/workflow";
+import {
+	WORKFLOW_NESTED_QUEUE_NAME,
+	WORKFLOW_QUEUE_NAME,
+} from "../../../fixtures/driver-test-suite/workflow";
 import type { DriverTestConfig } from "../mod";
 import { setupDriverTest, waitFor } from "../utils";
 
@@ -55,6 +58,143 @@ export function runActorWorkflowTests(driverTestConfig: DriverTestConfig) {
 				response: { echo: { value: 123 } },
 			});
 		});
+
+		for (const testCase of [
+			{
+				name: "nested loops",
+				key: "loop" as const,
+				getActor: (
+					client: Awaited<
+						ReturnType<typeof setupDriverTest>
+					>["client"],
+				) => client.workflowNestedLoopActor,
+				firstItems: ["a", "b"],
+				secondItems: ["c"],
+				expected: ["a", "b", "c"],
+			},
+			{
+				name: "nested joins",
+				key: "join" as const,
+				getActor: (
+					client: Awaited<
+						ReturnType<typeof setupDriverTest>
+					>["client"],
+				) => client.workflowNestedJoinActor,
+				firstItems: ["a", "b"],
+				secondItems: ["c"],
+				expected: ["a", "b", "c"],
+			},
+			{
+				name: "nested races",
+				key: "race" as const,
+				getActor: (
+					client: Awaited<
+						ReturnType<typeof setupDriverTest>
+					>["client"],
+				) => client.workflowNestedRaceActor,
+				firstItems: ["a"],
+				secondItems: ["b"],
+				expected: ["a", "b"],
+			},
+			]) {
+				test(
+					`replays ${testCase.name} across workflow queue iterations`,
+				async (c) => {
+					const { client } = await setupDriverTest(
+						c,
+						driverTestConfig,
+					);
+					const actor = testCase.getActor(client).getOrCreate([
+						`workflow-nested-${testCase.key}`,
+					]);
+
+					const first = await actor.send(
+						WORKFLOW_NESTED_QUEUE_NAME,
+						{
+							items: testCase.firstItems,
+						},
+						{
+							wait: true,
+							timeout: 1_000,
+						},
+					);
+					expect(first).toEqual({
+						status: "completed",
+						response: {
+							processed: testCase.firstItems.length,
+						},
+					});
+
+					const second = await actor.send(
+						WORKFLOW_NESTED_QUEUE_NAME,
+						{
+							items: testCase.secondItems,
+						},
+						{
+							wait: true,
+							timeout: 1_000,
+						},
+					);
+					expect(second).toEqual({
+						status: "completed",
+						response: {
+							processed: testCase.secondItems.length,
+						},
+					});
+
+					const state = await actor.getState();
+					expect(state.processed).toEqual(testCase.expected);
+				},
+				);
+			}
+
+			test(
+				"starts child workflows created inside workflow steps",
+				async (c) => {
+					const { client } = await setupDriverTest(
+						c,
+						driverTestConfig,
+					);
+					const parent = client.workflowSpawnParentActor.getOrCreate([
+						"workflow-spawn-parent",
+					]);
+
+					expect(await parent.triggerSpawn("child-1")).toEqual({
+						queued: true,
+					});
+
+					let parentState = await parent.getState();
+					for (
+						let i = 0;
+						i < 30 && parentState.results.length === 0;
+						i++
+					) {
+						await waitFor(driverTestConfig, 100);
+						parentState = await parent.getState();
+					}
+
+					expect(parentState.results).toEqual([
+						{
+							key: "child-1",
+							result: {
+								status: "completed",
+								response: { ok: true },
+							},
+							error: null,
+						},
+					]);
+
+					const child = client.workflowSpawnChildActor.getOrCreate([
+						"child-1",
+					]);
+					const childState = await child.getState();
+					expect(childState).toEqual({
+						label: "child-1",
+						started: true,
+						processed: ["hello"],
+					});
+				},
+			);
 
 		test("db and client are step-only in workflow context", async (c) => {
 			const { client } = await setupDriverTest(c, driverTestConfig);

--- a/rivetkit-typescript/packages/rivetkit/src/inspector/actor-inspector.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/inspector/actor-inspector.ts
@@ -11,6 +11,7 @@ import * as actorErrors from "@/actor/errors";
 import type { AnyActorInstance } from "@/mod";
 import type * as schema from "@/schemas/actor-inspector/mod";
 import { bufferToArrayBuffer } from "@/utils";
+import { serializeWorkflowHistoryForJson } from "./workflow-history-json";
 
 interface ActorInspectorEmitterEvents {
 	stateUpdated: (state: unknown) => void;
@@ -313,14 +314,10 @@ export class ActorInspector {
 		history: unknown | null;
 		isWorkflowEnabled: boolean;
 	} {
-		const bigIntReplacer = (_key: string, value: unknown) =>
-			typeof value === "bigint" ? Number(value) : value;
-		const history = this.getWorkflowHistory();
-		const safeHistory = history
-			? JSON.parse(JSON.stringify(history, bigIntReplacer))
-			: null;
 		return {
-			history: safeHistory,
+			history: serializeWorkflowHistoryForJson(
+				this.getWorkflowHistory(),
+			),
 			isWorkflowEnabled: this.isWorkflowEnabled(),
 		};
 	}

--- a/rivetkit-typescript/packages/rivetkit/src/inspector/workflow-history-json.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/inspector/workflow-history-json.ts
@@ -1,0 +1,309 @@
+import * as cbor from "cbor-x";
+import { decodeWorkflowHistoryTransport } from "@/inspector/transport";
+import type * as transport from "@/schemas/transport/mod";
+
+function decodeWorkflowCbor(data: ArrayBuffer | null): unknown | null {
+	if (data === null) {
+		return null;
+	}
+
+	try {
+		return cbor.decode(new Uint8Array(data));
+	} catch {
+		return null;
+	}
+}
+
+function serializeWorkflowLocation(
+	location: transport.WorkflowLocation,
+): Array<
+	| { tag: "WorkflowNameIndex"; val: number }
+	| {
+			tag: "WorkflowLoopIterationMarker";
+			val: { loop: number; iteration: number };
+	  }
+> {
+	return location.map((segment) => {
+		if (segment.tag === "WorkflowNameIndex") {
+			return {
+				tag: segment.tag,
+				val: segment.val,
+			};
+		}
+
+		return {
+			tag: segment.tag,
+			val: {
+				loop: segment.val.loop,
+				iteration: segment.val.iteration,
+			},
+		};
+	});
+}
+
+function serializeWorkflowBranches(
+	branches: ReadonlyMap<string, transport.WorkflowBranchStatus>,
+): Record<
+	string,
+	{ status: string; output: unknown | null; error: string | null }
+> {
+	return Object.fromEntries(
+		Array.from(branches.entries()).map(([name, branch]) => [
+			name,
+			{
+				status: branch.status,
+				output: decodeWorkflowCbor(branch.output),
+				error: branch.error,
+			},
+		]),
+	);
+}
+
+function serializeWorkflowEntryKind(kind: transport.WorkflowEntryKind):
+	| {
+			tag: "WorkflowStepEntry";
+			val: { output: unknown | null; error: string | null };
+	  }
+	| {
+			tag: "WorkflowLoopEntry";
+			val: {
+				state: unknown | null;
+				iteration: number;
+				output: unknown | null;
+			};
+	  }
+	| {
+			tag: "WorkflowSleepEntry";
+			val: { deadline: number; state: string };
+	  }
+	| {
+			tag: "WorkflowMessageEntry";
+			val: { name: string; messageData: unknown | null };
+	  }
+	| {
+			tag: "WorkflowRollbackCheckpointEntry";
+			val: { name: string };
+	  }
+	| {
+			tag: "WorkflowJoinEntry";
+			val: {
+				branches: Record<
+					string,
+					{
+						status: string;
+						output: unknown | null;
+						error: string | null;
+					}
+				>;
+			};
+	  }
+	| {
+			tag: "WorkflowRaceEntry";
+			val: {
+				winner: string | null;
+				branches: Record<
+					string,
+					{
+						status: string;
+						output: unknown | null;
+						error: string | null;
+					}
+				>;
+			};
+	  }
+	| {
+			tag: "WorkflowRemovedEntry";
+			val: { originalType: string; originalName: string | null };
+	  } {
+	switch (kind.tag) {
+		case "WorkflowStepEntry":
+			return {
+				tag: kind.tag,
+				val: {
+					output: decodeWorkflowCbor(kind.val.output),
+					error: kind.val.error,
+				},
+			};
+		case "WorkflowLoopEntry":
+			return {
+				tag: kind.tag,
+				val: {
+					state: decodeWorkflowCbor(kind.val.state),
+					iteration: kind.val.iteration,
+					output: decodeWorkflowCbor(kind.val.output),
+				},
+			};
+		case "WorkflowSleepEntry":
+			return {
+				tag: kind.tag,
+				val: {
+					deadline: Number(kind.val.deadline),
+					state: kind.val.state,
+				},
+			};
+		case "WorkflowMessageEntry":
+			return {
+				tag: kind.tag,
+				val: {
+					name: kind.val.name,
+					messageData: decodeWorkflowCbor(kind.val.messageData),
+				},
+			};
+		case "WorkflowRollbackCheckpointEntry":
+			return {
+				tag: kind.tag,
+				val: {
+					name: kind.val.name,
+				},
+			};
+		case "WorkflowJoinEntry":
+			return {
+				tag: kind.tag,
+				val: {
+					branches: serializeWorkflowBranches(kind.val.branches),
+				},
+			};
+		case "WorkflowRaceEntry":
+			return {
+				tag: kind.tag,
+				val: {
+					winner: kind.val.winner,
+					branches: serializeWorkflowBranches(kind.val.branches),
+				},
+			};
+		case "WorkflowRemovedEntry":
+			return {
+				tag: kind.tag,
+				val: {
+					originalType: kind.val.originalType,
+					originalName: kind.val.originalName,
+				},
+			};
+	}
+}
+
+export function serializeWorkflowHistoryForJson(
+	data: ArrayBuffer | null,
+):
+	| {
+			nameRegistry: string[];
+			entries: Array<{
+				id: string;
+				location: Array<
+					| { tag: "WorkflowNameIndex"; val: number }
+					| {
+							tag: "WorkflowLoopIterationMarker";
+							val: { loop: number; iteration: number };
+					  }
+				>;
+				kind:
+					| {
+							tag: "WorkflowStepEntry";
+							val: { output: unknown | null; error: string | null };
+					  }
+					| {
+							tag: "WorkflowLoopEntry";
+							val: {
+								state: unknown | null;
+								iteration: number;
+								output: unknown | null;
+							};
+					  }
+					| {
+							tag: "WorkflowSleepEntry";
+							val: { deadline: number; state: string };
+					  }
+					| {
+							tag: "WorkflowMessageEntry";
+							val: { name: string; messageData: unknown | null };
+					  }
+					| {
+							tag: "WorkflowRollbackCheckpointEntry";
+							val: { name: string };
+					  }
+					| {
+							tag: "WorkflowJoinEntry";
+							val: {
+								branches: Record<
+									string,
+									{
+										status: string;
+										output: unknown | null;
+										error: string | null;
+									}
+								>;
+							};
+					  }
+					| {
+							tag: "WorkflowRaceEntry";
+							val: {
+								winner: string | null;
+								branches: Record<
+									string,
+									{
+										status: string;
+										output: unknown | null;
+										error: string | null;
+									}
+								>;
+							};
+					  }
+					| {
+							tag: "WorkflowRemovedEntry";
+							val: {
+								originalType: string;
+								originalName: string | null;
+							};
+					  };
+			}>;
+			entryMetadata: Record<
+				string,
+				{
+					status: string;
+					error: string | null;
+					attempts: number;
+					lastAttemptAt: number;
+					createdAt: number;
+					completedAt: number | null;
+					rollbackCompletedAt: number | null;
+					rollbackError: string | null;
+				}
+			>;
+	  }
+	| null {
+	if (data === null) {
+		return null;
+	}
+
+	const history = decodeWorkflowHistoryTransport(data);
+
+	return {
+		nameRegistry: [...history.nameRegistry],
+		entries: history.entries.map((entry) => ({
+			id: entry.id,
+			location: serializeWorkflowLocation(entry.location),
+			kind: serializeWorkflowEntryKind(entry.kind),
+		})),
+		entryMetadata: Object.fromEntries(
+			Array.from(history.entryMetadata.entries()).map(([entryId, meta]) => [
+				entryId,
+				{
+					status: meta.status,
+					error: meta.error,
+					attempts: meta.attempts,
+					lastAttemptAt: Number(meta.lastAttemptAt),
+					createdAt: Number(meta.createdAt),
+					completedAt:
+						meta.completedAt === null
+							? null
+							: Number(meta.completedAt),
+					rollbackCompletedAt:
+						meta.rollbackCompletedAt === null
+							? null
+							: Number(meta.rollbackCompletedAt),
+					rollbackError: meta.rollbackError,
+				},
+			]),
+		),
+	};
+}

--- a/rivetkit-typescript/packages/workflow-engine/src/context.ts
+++ b/rivetkit-typescript/packages/workflow-engine/src/context.ts
@@ -116,7 +116,7 @@ export class WorkflowContextImpl implements WorkflowContextInterface {
 	private entryInProgress = false;
 	private abortController: AbortController;
 	private currentLocation: Location;
-	private visitedKeys = new Set<string>();
+	private visitedKeys: Set<string>;
 	private mode: "forward" | "rollback";
 	private rollbackActions?: RollbackAction[];
 	private rollbackCheckpointSet: boolean;
@@ -140,6 +140,7 @@ export class WorkflowContextImpl implements WorkflowContextInterface {
 		historyNotifier?: () => void,
 		onError?: WorkflowErrorHandler,
 		logger?: Logger,
+		visitedKeys?: Set<string>,
 	) {
 		this.currentLocation = location;
 		this.abortController = abortController ?? new AbortController();
@@ -149,6 +150,7 @@ export class WorkflowContextImpl implements WorkflowContextInterface {
 		this.historyNotifier = historyNotifier;
 		this.onError = onError;
 		this.logger = logger;
+		this.visitedKeys = visitedKeys ?? new Set();
 	}
 
 	get abortSignal(): AbortSignal {
@@ -204,6 +206,7 @@ export class WorkflowContextImpl implements WorkflowContextInterface {
 			this.historyNotifier,
 			this.onError,
 			this.logger,
+			this.visitedKeys,
 		);
 	}
 

--- a/rivetkit-typescript/packages/workflow-engine/tests/join.test.ts
+++ b/rivetkit-typescript/packages/workflow-engine/tests/join.test.ts
@@ -145,5 +145,108 @@ for (const mode of modes) {
 
 			expect(callCount).toBe(1);
 		});
+
+		it("should support nested joins inside branches", async () => {
+			const workflow = async (ctx: WorkflowContextInterface) => {
+				const results = await ctx.join("outer", {
+					nested: {
+						run: async (ctx) => {
+							const inner = await ctx.join("inner", {
+								left: {
+									run: async (ctx) =>
+										await ctx.step(
+											"left-step",
+											async () => 1,
+										),
+								},
+								right: {
+									run: async (ctx) =>
+										await ctx.step(
+											"right-step",
+											async () => 2,
+										),
+								},
+							});
+
+							return inner.left + inner.right;
+						},
+					},
+					plain: {
+						run: async (ctx) =>
+							await ctx.step("plain-step", async () => 3),
+					},
+				});
+
+				return results.nested + results.plain;
+			};
+
+			const result = await runWorkflow(
+				"wf-1",
+				workflow,
+				undefined,
+				driver,
+				{ mode },
+			).result;
+
+			expect(result.state).toBe("completed");
+			expect(result.output).toBe(6);
+		});
+
+		it("should support nested races inside join branches", async () => {
+			const workflow = async (ctx: WorkflowContextInterface) => {
+				const results = await ctx.join("outer", {
+					raced: {
+						run: async (ctx) => {
+							const nested = await ctx.race("inner-race", [
+								{
+									name: "fast",
+									run: async (ctx) =>
+										await ctx.step(
+											"fast-step",
+											async () => "winner",
+										),
+								},
+								{
+									name: "slow",
+									run: async (ctx) => {
+										await new Promise<void>((resolve) => {
+											if (ctx.abortSignal.aborted) {
+												resolve();
+												return;
+											}
+											ctx.abortSignal.addEventListener(
+												"abort",
+												() => resolve(),
+												{ once: true },
+											);
+										});
+										return "loser";
+									},
+								},
+							]);
+
+							return nested.value;
+						},
+					},
+					plain: {
+						run: async (ctx) =>
+							await ctx.step("plain-step", async () => "plain"),
+					},
+				});
+
+				return `${results.raced}:${results.plain}`;
+			};
+
+			const result = await runWorkflow(
+				"wf-1",
+				workflow,
+				undefined,
+				driver,
+				{ mode },
+			).result;
+
+			expect(result.state).toBe("completed");
+			expect(result.output).toBe("winner:plain");
+		});
 	});
 }

--- a/rivetkit-typescript/packages/workflow-engine/tests/loops.test.ts
+++ b/rivetkit-typescript/packages/workflow-engine/tests/loops.test.ts
@@ -141,6 +141,297 @@ for (const mode of modes) {
 			expect(callCount).toBe(1);
 		});
 
+		it("should resume nested sub-loops across parent loop iterations", async () => {
+			const processed: string[] = [];
+
+			const workflow = async (ctx: WorkflowContextInterface) => {
+				return await ctx.loop("command-loop", async (loopCtx) => {
+					const message = await loopCtx.queue.next<{
+						items: string[];
+					}>("next", {
+						names: ["work"],
+						completable: true,
+					});
+
+					let itemIndex = 0;
+					await loopCtx.loop("process-items", async (subLoopCtx) => {
+						const item = message.body.items[itemIndex];
+						if (item === undefined) {
+							return Loop.break(undefined);
+						}
+
+						await subLoopCtx.step(
+							`process-item-${itemIndex}`,
+							async () => {
+								processed.push(item);
+							},
+						);
+						itemIndex += 1;
+						return Loop.continue(undefined);
+					});
+
+					await message.complete?.({ ok: true });
+
+					if (processed.length >= 3) {
+						return Loop.break([...processed]);
+					}
+
+					return Loop.continue(undefined);
+				});
+			};
+
+			await driver.messageDriver.addMessage({
+				id: "msg-1",
+				name: "work",
+				data: { items: ["a", "b"] },
+				sentAt: Date.now(),
+			});
+
+			if (mode === "yield") {
+				const firstRun = await runWorkflow(
+					"wf-1",
+					workflow,
+					undefined,
+					driver,
+					{ mode },
+				).result;
+
+				expect(firstRun.state).toBe("sleeping");
+				expect(processed).toEqual(["a", "b"]);
+
+				await driver.messageDriver.addMessage({
+					id: "msg-2",
+					name: "work",
+					data: { items: ["c"] },
+					sentAt: Date.now(),
+				});
+
+				const secondRun = await runWorkflow(
+					"wf-1",
+					workflow,
+					undefined,
+					driver,
+					{ mode },
+				).result;
+
+				expect(secondRun.state).toBe("completed");
+				expect(secondRun.output).toEqual(["a", "b", "c"]);
+				return;
+			}
+
+			const handle = runWorkflow("wf-1", workflow, undefined, driver, {
+				mode,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			await handle.message("work", { items: ["c"] });
+
+			const result = await handle.result;
+			expect(result.state).toBe("completed");
+			expect(result.output).toEqual(["a", "b", "c"]);
+		});
+
+		it("should resume nested joins across parent loop iterations", async () => {
+			const processed: string[] = [];
+
+			const workflow = async (ctx: WorkflowContextInterface) => {
+				return await ctx.loop("command-loop", async (loopCtx) => {
+					const message = await loopCtx.queue.next<{
+						items: string[];
+					}>("next", {
+						names: ["work"],
+						completable: true,
+					});
+
+					const branches = Object.fromEntries(
+						message.body.items.map((item, index) => [
+							`item-${index}`,
+							{
+								run: async (
+									branchCtx: WorkflowContextInterface,
+								) =>
+									await branchCtx.step(
+										`process-item-${index}`,
+										async () => {
+											processed.push(item);
+											return item;
+										},
+									),
+							},
+						]),
+					);
+
+					await loopCtx.join("process-items", branches);
+					await message.complete?.({ ok: true });
+
+					if (processed.length >= 3) {
+						return Loop.break([...processed]);
+					}
+
+					return Loop.continue(undefined);
+				});
+			};
+
+			await driver.messageDriver.addMessage({
+				id: "msg-1",
+				name: "work",
+				data: { items: ["a", "b"] },
+				sentAt: Date.now(),
+			});
+
+			if (mode === "yield") {
+				const firstRun = await runWorkflow(
+					"wf-1",
+					workflow,
+					undefined,
+					driver,
+					{ mode },
+				).result;
+
+				expect(firstRun.state).toBe("sleeping");
+				expect(processed).toEqual(["a", "b"]);
+
+				await driver.messageDriver.addMessage({
+					id: "msg-2",
+					name: "work",
+					data: { items: ["c"] },
+					sentAt: Date.now(),
+				});
+
+				const secondRun = await runWorkflow(
+					"wf-1",
+					workflow,
+					undefined,
+					driver,
+					{ mode },
+				).result;
+
+				expect(secondRun.state).toBe("completed");
+				expect(secondRun.output).toEqual(["a", "b", "c"]);
+				return;
+			}
+
+			const handle = runWorkflow("wf-1", workflow, undefined, driver, {
+				mode,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			await handle.message("work", { items: ["c"] });
+
+			const result = await handle.result;
+			expect(result.state).toBe("completed");
+			expect(result.output).toEqual(["a", "b", "c"]);
+		});
+
+		it("should resume nested races across parent loop iterations", async () => {
+			const processed: string[] = [];
+
+			const workflow = async (ctx: WorkflowContextInterface) => {
+				return await ctx.loop("command-loop", async (loopCtx) => {
+					const message = await loopCtx.queue.next<{
+						items: string[];
+					}>("next", {
+						names: ["work"],
+						completable: true,
+					});
+
+					const nested = await loopCtx.race("process-item", [
+						{
+							name: "fast",
+							run: async (raceCtx) =>
+								await raceCtx.step(
+									"process-fast",
+									async () => {
+										const item = message.body.items[0]!;
+										processed.push(item);
+										return item;
+									},
+								),
+						},
+						{
+							name: "slow",
+							run: async (raceCtx) => {
+								await new Promise<void>((resolve) => {
+									if (raceCtx.abortSignal.aborted) {
+										resolve();
+										return;
+									}
+									raceCtx.abortSignal.addEventListener(
+										"abort",
+										() => resolve(),
+										{ once: true },
+									);
+								});
+								return "slow";
+							},
+						},
+					]);
+
+					expect(nested.value).toBe(message.body.items[0]);
+					await message.complete?.({ ok: true });
+
+					if (processed.length >= 2) {
+						return Loop.break([...processed]);
+					}
+
+					return Loop.continue(undefined);
+				});
+			};
+
+			await driver.messageDriver.addMessage({
+				id: "msg-1",
+				name: "work",
+				data: { items: ["a"] },
+				sentAt: Date.now(),
+			});
+
+			if (mode === "yield") {
+				const firstRun = await runWorkflow(
+					"wf-1",
+					workflow,
+					undefined,
+					driver,
+					{ mode },
+				).result;
+
+				expect(firstRun.state).toBe("sleeping");
+				expect(processed).toEqual(["a"]);
+
+				await driver.messageDriver.addMessage({
+					id: "msg-2",
+					name: "work",
+					data: { items: ["b"] },
+					sentAt: Date.now(),
+				});
+
+				const secondRun = await runWorkflow(
+					"wf-1",
+					workflow,
+					undefined,
+					driver,
+					{ mode },
+				).result;
+
+				expect(secondRun.state).toBe("completed");
+				expect(secondRun.output).toEqual(["a", "b"]);
+				return;
+			}
+
+			const handle = runWorkflow("wf-1", workflow, undefined, driver, {
+				mode,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			await handle.message("work", { items: ["b"] });
+
+			const result = await handle.result;
+			expect(result.state).toBe("completed");
+			expect(result.output).toEqual(["a", "b"]);
+		});
+
 		it("should resume loop from saved state", async () => {
 			let iteration = 0;
 

--- a/rivetkit-typescript/packages/workflow-engine/tests/race.test.ts
+++ b/rivetkit-typescript/packages/workflow-engine/tests/race.test.ts
@@ -151,5 +151,138 @@ for (const mode of modes) {
 
 			expect(runs).toBe(1);
 		});
+
+		it("should support nested joins in the winning branch", async () => {
+			const workflow = async (ctx: WorkflowContextInterface) => {
+				return await ctx.race("outer-race", [
+					{
+						name: "fast",
+						run: async (ctx) => {
+							const nested = await ctx.join("inner-join", {
+								left: {
+									run: async (ctx) =>
+										await ctx.step(
+											"left-step",
+											async () => 1,
+										),
+								},
+								right: {
+									run: async (ctx) =>
+										await ctx.step(
+											"right-step",
+											async () => 2,
+										),
+								},
+							});
+
+							return nested.left + nested.right;
+						},
+					},
+					{
+						name: "slow",
+						run: async (ctx) => {
+							await new Promise<void>((resolve) => {
+								if (ctx.abortSignal.aborted) {
+									resolve();
+									return;
+								}
+								ctx.abortSignal.addEventListener(
+									"abort",
+									() => resolve(),
+									{ once: true },
+								);
+							});
+							return 0;
+						},
+					},
+				]);
+			};
+
+			const result = await runWorkflow(
+				"wf-1",
+				workflow,
+				undefined,
+				driver,
+				{ mode },
+			).result;
+
+			expect(result.state).toBe("completed");
+			expect(result.output).toEqual({
+				winner: "fast",
+				value: 3,
+			});
+		});
+
+		it("should support nested races in the winning branch", async () => {
+			const workflow = async (ctx: WorkflowContextInterface) => {
+				return await ctx.race("outer-race", [
+					{
+						name: "fast",
+						run: async (ctx) => {
+							const nested = await ctx.race("inner-race", [
+								{
+									name: "nested-fast",
+									run: async (ctx) =>
+										await ctx.step(
+											"nested-fast-step",
+											async () => "nested-fast",
+										),
+								},
+								{
+									name: "nested-slow",
+									run: async (ctx) => {
+										await new Promise<void>((resolve) => {
+											if (ctx.abortSignal.aborted) {
+												resolve();
+												return;
+											}
+											ctx.abortSignal.addEventListener(
+												"abort",
+												() => resolve(),
+												{ once: true },
+											);
+										});
+										return "nested-slow";
+									},
+								},
+							]);
+
+							return nested.value;
+						},
+					},
+					{
+						name: "slow",
+						run: async (ctx) => {
+							await new Promise<void>((resolve) => {
+								if (ctx.abortSignal.aborted) {
+									resolve();
+									return;
+								}
+								ctx.abortSignal.addEventListener(
+									"abort",
+									() => resolve(),
+									{ once: true },
+								);
+							});
+							return "slow";
+						},
+					},
+				]);
+			};
+
+			const result = await runWorkflow(
+				"wf-1",
+				workflow,
+				undefined,
+				driver,
+				{ mode },
+			).result;
+
+			expect(result.state).toBe("completed");
+			expect(result.output).toEqual({
+				winner: "fast",
+				value: "nested-fast",
+			});
+		});
 	});
 }

--- a/website/src/content/docs/actors/debugging.mdx
+++ b/website/src/content/docs/actors/debugging.mdx
@@ -467,6 +467,8 @@ Returns:
 }
 ```
 
+For workflow-enabled actors, `history` is a JSON object with `nameRegistry`, `entries`, and `entryMetadata`. Step outputs, loop state, and message payloads are decoded from CBOR into normal JSON values.
+
 #### Summary
 
 Get a full snapshot of the actor in a single request:

--- a/website/src/metadata/skill-base-rivetkit.md
+++ b/website/src/metadata/skill-base-rivetkit.md
@@ -30,7 +30,7 @@ Use the inspector HTTP API to examine running actors. These endpoints are access
 - `POST /inspector/action/{name}` - execute an action with `{"args": [...]}`
 - `GET /inspector/queue?limit=50` - queue status
 - `GET /inspector/traces?startMs=0&endMs=...&limit=1000` - trace spans (OTLP JSON)
-- `GET /inspector/workflow-history` - workflow history and status
+- `GET /inspector/workflow-history` - workflow history and status as JSON (`nameRegistry`, `entries`, `entryMetadata`)
 
 In local dev, no auth token is needed. In production, pass `Authorization: Bearer <RIVET_INSPECTOR_TOKEN>`. See the [debugging docs](https://rivet.dev/docs/actors/debugging) for details.
 


### PR DESCRIPTION
# Description

Fix the inspector HTTP workflow history response and the workflow engine's nested branch replay bookkeeping. This also adds regression coverage for nested loop/join/race replay, inspector HTTP responses, child workflow startup, and many-queue child actors, plus the matching inspector docs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- `pnpm test tests/driver-file-system.test.ts -t "populated"`
- `pnpm test tests/loops.test.ts -t "nested sub-loops"`
- `pnpm test tests/loops.test.ts tests/join.test.ts tests/race.test.ts -t "nested"`
- `pnpm test tests/join.test.ts tests/race.test.ts`
- `pnpm test tests/driver-file-system.test.ts -t "replays nested"`
- `pnpm test tests/driver-file-system.test.ts -t "Actor Workflow Tests"`
- `pnpm test tests/driver-file-system.test.ts -t "drains many-queue child actors"`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
