### PR TITLE
fix(frontend): fix streaming logs even if there's no connected event

### DIFF
--- a/frontend/src/components/use-deployment-logs-stream.ts
+++ b/frontend/src/components/use-deployment-logs-stream.ts
@@ -112,6 +112,7 @@ export function useDeploymentLogsStream({
 		const controller = new AbortController();
 
 		function onEntry(entry: RivetSse.LogStreamEvent.Log) {
+			setIsLoading(false);
 			pendingRef.current.push(entry);
 			if (!pausedRef.current) {
 				const toFlush = pendingRef.current;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"overrides": {
 			"react": "19.1.0",
 			"react-dom": "19.1.0",
-			"@rivet-gg/cloud": "https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2",
+			"@rivet-gg/cloud": "https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c",
 			"@codemirror/state": "6.5.2",
 			"@codemirror/view": "6.38.2",
 			"@codemirror/autocomplete": "6.18.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   '@clerk/shared': 3.27.1
   react: 19.1.0
   react-dom: 19.1.0
-  '@rivet-gg/cloud': https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2
+  '@rivet-gg/cloud': https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c
   '@codemirror/state': 6.5.2
   '@codemirror/view': 6.38.2
   '@codemirror/autocomplete': 6.18.7
@@ -464,8 +464,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@rivet-gg/cloud':
-        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2
-        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2
+        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c
+        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c
       '@rivetkit/engine-api-full':
         specifier: workspace:*
         version: link:../../engine/sdks/typescript/api-full
@@ -3487,8 +3487,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@rivet-gg/cloud':
-        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2
-        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2
+        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c
+        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c
       '@rivet-gg/icons':
         specifier: workspace:*
         version: link:packages/icons
@@ -4626,8 +4626,8 @@ importers:
         specifier: 25.5.3
         version: 25.5.3
       '@rivet-gg/cloud':
-        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2
-        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2
+        specifier: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c
+        version: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c
       '@rivet-gg/components':
         specifier: workspace:*
         version: link:../frontend/packages/components
@@ -9307,8 +9307,8 @@ packages:
   '@rivet-gg/api@25.5.3':
     resolution: {integrity: sha512-pj8xYQ+I/aQDbThmicPxvR+TWAzGoLSE53mbJi4QZHF8VH2oMvU7CMWqy7OTFH30DIRyVzsnHHRJZKGwtmQL3g==}
 
-  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2':
-    resolution: {tarball: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2}
+  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c':
+    resolution: {tarball: https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c}
     version: 0.0.0
 
   '@rivetkit/bare-ts@0.6.2':
@@ -23618,7 +23618,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@6d356d2':
+  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@413534c':
     dependencies:
       cross-fetch: 4.1.0
       form-data: 4.0.5


### PR DESCRIPTION
# Description

This pull request fixes a loading state issue in the deployment logs stream component and updates the `@rivet-gg/cloud` dependency to a newer version.

The main change addresses a bug where the loading indicator would remain active even after log entries started streaming. Now, `setIsLoading(false)` is called when the first log entry is received, ensuring the UI properly reflects that data is being loaded.

Additionally, the `@rivet-gg/cloud` package has been updated from commit `6d356d2` to `413534c` to incorporate the latest changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes