### PR TITLE
feat(frontend): ping actor if its in the crash loop

### DIFF
--- a/frontend/src/components/actors/guard-connectable-inspector.tsx
+++ b/frontend/src/components/actors/guard-connectable-inspector.tsx
@@ -39,7 +39,11 @@ import {
 	useActorInspector,
 } from "./actor-inspector-context";
 import { Info } from "./actor-state-tab";
-import { ErrorDetails, QueriedActorError } from "./actor-status-label";
+import {
+	ErrorDetails,
+	QueriedActorError,
+	QueriedActorStatusAdditionalInfo,
+} from "./actor-status-label";
 import { useDataProvider, useEngineCompatDataProvider } from "./data-provider";
 import { useActorInspectorData } from "./hooks/use-actor-inspector-data";
 import type { ActorId, ActorStatus } from "./queries";
@@ -134,16 +138,21 @@ function UnavailableInfo({
 
 				<QueriedActorError actorId={actorId} />
 
-				<HelpDropdown>
-					<Button
-						variant="outline"
-						startIcon={<Icon icon={faQuestionCircle} />}
-					>
-						Need help?
-					</Button>
-				</HelpDropdown>
+				<div className="flex gap-4 items-center mt-4">
+					<WakeUpActorButton actorId={actorId} />
+
+					<HelpDropdown>
+						<Button
+							variant="outline"
+							startIcon={<Icon icon={faQuestionCircle} />}
+						>
+							Need help?
+						</Button>
+					</HelpDropdown>
+				</div>
 			</Info>
 		))
+		.with("crash-loop", () => <CrashLoopActor actorId={actorId} />)
 		.with("pending", () => <NoRunners />)
 		.with("stopped", () => (
 			<Info>
@@ -175,7 +184,44 @@ function SleepingActor({ actorId }: { actorId: ActorId }) {
 		return <AutoWakeUpActor actorId={actorId} />;
 	}
 
-	return <WakeUpActorButton actorId={actorId} />;
+	return (
+		<Info>
+			<p>Actor is sleeping.</p>
+			<WakeUpActorButton actorId={actorId} />
+		</Info>
+	);
+}
+
+function CrashLoopActor({ actorId }: { actorId: ActorId }) {
+	const { data: { rescheduleTs } = {} } = useQuery({
+		...useDataProvider().actorStatusAdditionalInfoQueryOptions(actorId),
+		refetchInterval: 5_000,
+	});
+
+	const rescheduleInFuture = rescheduleTs && rescheduleTs > Date.now();
+
+	return (
+		<Info>
+			<Icon
+				icon={faExclamationTriangle}
+				className="text-4xl text-destructive"
+			/>
+			<p>Actor is failing to start and will be retried.</p>
+			<QueriedActorStatusAdditionalInfo actorId={actorId} />
+
+			<div className="flex gap-4 items-center mt-4">
+				{!rescheduleInFuture && <WakeUpActorButton actorId={actorId} />}
+				<HelpDropdown>
+					<Button
+						variant="outline"
+						startIcon={<Icon icon={faQuestionCircle} />}
+					>
+						Need help?
+					</Button>
+				</HelpDropdown>
+			</div>
+		</Info>
+	);
 }
 
 function NoRunners() {
@@ -581,23 +627,20 @@ function WakeUpActorButton({ actorId }: { actorId: ActorId }) {
 	const { mutate, isPending } = useMutation(actorWakeUpMutationOptions());
 
 	return (
-		<Info>
-			<p>Actor is sleeping.</p>
-			<Button
-				variant="outline"
-				size="sm"
-				onClick={() =>
-					mutate({
-						actorId,
-						credentials,
-					})
-				}
-				isLoading={isPending}
-				startIcon={<Icon icon={faPowerOff} />}
-			>
-				Wake up Actor
-			</Button>
-		</Info>
+		<Button
+			variant="outline"
+			size="sm"
+			onClick={() =>
+				mutate({
+					actorId,
+					credentials,
+				})
+			}
+			isLoading={isPending}
+			startIcon={<Icon icon={faPowerOff} />}
+		>
+			Wake up Actor
+		</Button>
 	);
 }
 


### PR DESCRIPTION
# Description

Added support for crash-loop actor status in the guard connectable inspector. This change introduces a new `CrashLoopActor` component that displays an error state with an exclamation triangle icon, informative messaging about retry behavior, and a "Ping Actor now" button when the actor is not scheduled for future retry. The component fetches additional status information and provides manual intervention capabilities for actors stuck in crash loops.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes