### PR TITLE
Raise runner default counts to 100k

### DIFF
--- a/frontend/src/app/dialogs/connect-cloudflare-frame.tsx
+++ b/frontend/src/app/dialogs/connect-cloudflare-frame.tsx
@@ -170,7 +170,7 @@ function FormStepper({
 				runnerName: "default",
 				slotsPerRunner: 1,
 				minRunners: 1,
-				maxRunners: 10_000,
+				maxRunners: 100_000,
 				runnerMargin: 0,
 				requestLifespan: 25,
 				headers: [],

--- a/frontend/src/app/dialogs/connect-manual-serverless-frame.tsx
+++ b/frontend/src/app/dialogs/connect-manual-serverless-frame.tsx
@@ -118,7 +118,7 @@ function FormStepper({
 			defaultValues={{
 				runnerName: "default",
 				slotsPerRunner: 1,
-				maxRunners: 10000,
+				maxRunners: 100_000,
 				minRunners: 1,
 				runnerMargin: 0,
 				headers: [],

--- a/frontend/src/app/dialogs/connect-quick-railway-frame.tsx
+++ b/frontend/src/app/dialogs/connect-quick-railway-frame.tsx
@@ -107,7 +107,7 @@ function FormStepper({ onClose }: { onClose?: () => void }) {
 				runnerName: "default",
 				slotsPerRunner: 1,
 				minRunners: 1,
-				maxRunners: 10_000,
+				maxRunners: 100_000,
 				runnerMargin: 0,
 				requestLifespan: 55,
 				headers: [],

--- a/frontend/src/app/dialogs/connect-quick-vercel-frame.tsx
+++ b/frontend/src/app/dialogs/connect-quick-vercel-frame.tsx
@@ -106,7 +106,7 @@ function FormStepper({
 				runnerName: "default",
 				slotsPerRunner: 1,
 				minRunners: 1,
-				maxRunners: 10_000,
+				maxRunners: 100_000,
 				runnerMargin: 0,
 				headers: [],
 				plan: "hobby",

--- a/frontend/src/app/dialogs/connect-railway-frame.tsx
+++ b/frontend/src/app/dialogs/connect-railway-frame.tsx
@@ -109,7 +109,7 @@ function FormStepper({ onClose }: { onClose?: () => void }) {
 				runnerName: "default",
 				slotsPerRunner: 1,
 				minRunners: 1,
-				maxRunners: 10_000,
+				maxRunners: 100_000,
 				runnerMargin: 0,
 				requestLifespan: 55,
 				headers: [],

--- a/frontend/src/app/dialogs/connect-rivet-frame.tsx
+++ b/frontend/src/app/dialogs/connect-rivet-frame.tsx
@@ -45,7 +45,7 @@ export default function ConnectRivetFrameContent({
 			displayName: "default",
 			pool: "default",
 			minCount: 0,
-			maxCount: 1000,
+			maxCount: 100_000,
 		});
 	}, [upsertManagedPool]);
 

--- a/frontend/src/app/dialogs/connect-vercel-frame.tsx
+++ b/frontend/src/app/dialogs/connect-vercel-frame.tsx
@@ -109,7 +109,7 @@ function FormStepper({
 				runnerName: "default",
 				slotsPerRunner: 1,
 				minRunners: 1,
-				maxRunners: 10_000,
+				maxRunners: 100_000,
 				runnerMargin: 0,
 				headers: [],
 				datacenters: Object.fromEntries(

--- a/frontend/src/app/dialogs/edit-runner-config.tsx
+++ b/frontend/src/app/dialogs/edit-runner-config.tsx
@@ -24,7 +24,7 @@ import { queryClient } from "@/queries/global";
 
 const defaultServerlessConfig: Rivet.RunnerConfigServerless = {
 	url: "",
-	maxRunners: 10,
+	maxRunners: 100_000,
 	minRunners: 0,
 	requestLifespan: 300,
 	runnersMargin: 2,

--- a/frontend/src/app/dialogs/upsert-deployment-frame.tsx
+++ b/frontend/src/app/dialogs/upsert-deployment-frame.tsx
@@ -68,7 +68,7 @@ export default function UpsertDeploymentFrameContent({
 							pool: "default",
 							image: defaultImage,
 							minCount: 0,
-							maxCount: 1000,
+							maxCount: 100_000,
 							environment: {},
 							command: undefined,
 							args: [],

--- a/frontend/src/app/forms/upsert-deployment-form.tsx
+++ b/frontend/src/app/forms/upsert-deployment-form.tsx
@@ -187,7 +187,7 @@ export const MinMaxCount = () => {
 			</FormDescription>
 			<Slider
 				min={0}
-				max={100}
+				max={100_000}
 				step={1}
 				value={[minCount, maxCount]}
 				onValueChange={([min, max]) => {
@@ -205,7 +205,7 @@ export const MinMaxCount = () => {
 			/>
 			<div className="flex justify-between text-xs text-muted-foreground">
 				<span>0</span>
-				<span>100</span>
+				<span>100,000</span>
 			</div>
 		</div>
 	);

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -165,7 +165,7 @@ export function GettingStarted({
 								provider: provider || "rivet",
 								runnerName: "default",
 								slotsPerRunner: 1,
-								maxRunners: 10000,
+								maxRunners: 100_000,
 								minRunners: 1,
 								runnerMargin: 0,
 								headers: [],
@@ -227,7 +227,7 @@ export function GettingStarted({
 										displayName: "default",
 										pool: "default",
 										minCount: 0,
-										maxCount: 1000,
+										maxCount: 100_000,
 									});
 									return;
 								}

--- a/rivetkit-typescript/packages/rivetkit/src/serverless/configure.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/serverless/configure.ts
@@ -49,7 +49,7 @@ export async function configureServerlessRunner(
 			serverless: {
 				url: customConfig.url,
 				headers: customConfig.headers ?? {},
-				max_runners: customConfig.maxRunners ?? 1000,
+				max_runners: customConfig.maxRunners ?? 100_000,
 				min_runners: customConfig.minRunners ?? 0,
 				request_lifespan: customConfig.requestLifespan ?? 15 * 60,
 				runners_margin: customConfig.runnersMargin ?? 0,


### PR DESCRIPTION
# Description

Raises managed-pool and runner config defaults from 1k or 10k to 100k across the Rivet and serverless setup flows. This aligns the frontend defaults, the deployment form ceiling, and the RivetKit serverless fallback so new configs consistently start at 100,000.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `git diff --check`
- Targeted grep for remaining active `1000` and `10_000` runner defaults in `frontend/src` and `rivetkit-typescript/packages/rivetkit/src`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
