### PR TITLE
fix(rivetkit): prestart local manager after setup

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
@@ -48,13 +48,17 @@ export class Registry<A extends RegistryActors> {
 	constructor(config: RegistryConfigInput<A>) {
 		this.#config = config;
 
-		if (config.serverless?.spawnEngine || config.serveManager) {
-			// Auto-prepare on next tick (gives time for sync config modification)
-			setTimeout(() => {
+		// Start the local manager or engine before /api/rivet is hit so clients can
+		// reach the public endpoint preemptively. This waits one tick because some
+		// integrations mutate registry config immediately after setup() returns.
+		setTimeout(() => {
+			const parsedConfig = this.parseConfig();
+
+			if (parsedConfig.serverless.spawnEngine || parsedConfig.serveManager) {
 				// biome-ignore lint/nursery/noFloatingPromises: fire-and-forget auto-prepare
 				this.#ensureRuntime();
-			}, 0);
-		}
+			}
+		}, 0);
 	}
 
 	/** Creates runtime if not already created. Idempotent. */


### PR DESCRIPTION
# Description

This changes `Registry` startup so `setup()` schedules runtime preparation on the next tick, then decides from the parsed config whether to pre-start the local manager or spawned engine. This makes the local manager available on port 6420 before `/api/rivet` is first hit while still allowing integrations to synchronously mutate registry config immediately after `setup()` returns.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Started a temporary Node server using the example React server entrypoint logic, without hitting `/api/rivet`, and verified `http://127.0.0.1:6420/health` returned `200 OK` with `{"status":"ok","runtime":"rivetkit","version":"2.1.6"}`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
