### PR TITLE
docs: add pitfalls section to queue docs

### DIFF
--- a/website/src/content/docs/actors/queues.mdx
+++ b/website/src/content/docs/actors/queues.mdx
@@ -432,6 +432,14 @@ This means you can run normal code in `run` without worrying about sleep interru
 - Add `timeout` when callers need bounded wait behavior.
 - Use `wait: true` only when the caller actually needs a response.
 
+## Pitfalls
+
+### Avoid `wait: true` between actors
+
+`wait: true` blocks the sender's run loop until the receiver finishes. Between actors, this adds unnecessary overhead and risks deadlocks, especially if the target actor needs to communicate back. If an actor sends a `wait: true` message to *itself*, it is a guaranteed deadlock because the run loop is already busy processing the current message.
+
+Reserve `wait: true` for external callers (HTTP handlers, CLI tools, client apps). For actor-to-actor communication, send a queue message to the other actor without `wait: true`, then have that actor send a queue message back when the work is done.
+
 ## Tips
 
 ### Message TTL


### PR DESCRIPTION
## Description

Added a new "Pitfalls" section to the actor queues documentation warning against using `wait: true` for actor-to-actor communication. This prevents self-deadlocks and unnecessary overhead by clarifying that `wait: true` should only be used for external callers, and actor-to-actor communication should use fire-and-forget queue messages with push-based responses.

## Type of change

- [x] Documentation update

This change guides developers away from a common deadlock pattern where actors send completable messages to themselves or other actors with `wait: true`, blocking their run loops unnecessarily.