### PR TITLE
docs: add .gitignore, .dockerignore, and Dockerfile to skill base

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/registry/config/runner.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/config/runner.ts
@@ -1,10 +1,14 @@
 import { z } from "zod/v4";
+import { getLogger } from "@/common/log";
 import {
 	isDev,
+	getNodeEnv,
 	getRivetTotalSlots,
 	getRivetRunner,
 	getRivetRunnerVersion,
 } from "@/utils/env-vars";
+
+let warnedMissingVersion = false;
 
 export const RunnerConfigSchema = z.object({
 	// MARK: Runner
@@ -14,7 +18,19 @@ export const RunnerConfigSchema = z.object({
 	runnerKey: z
 		.string()
 		.optional(),
-	version: z.number().default(() => getRivetRunnerVersion() ?? 1),
+	version: z.number().default(() => {
+		const version = getRivetRunnerVersion();
+		if (version !== undefined) return version;
+
+		if (getNodeEnv() === "production" && !warnedMissingVersion) {
+			warnedMissingVersion = true;
+			getLogger("rivetkit").error(
+				"RIVET_RUNNER_VERSION is not set. Actors will not be versioned, which means they won't be drained on deploy. This is only needed when self-hosting or using a custom runner (not needed for Rivet Compute). Set this as a build arg in your Dockerfile. See https://rivet.dev/docs/actors/versions",
+			);
+		}
+
+		return 1;
+	}),
 });
 export type RunnerConfigInput = z.input<typeof RunnerConfigSchema>;
 export type RunnerConfig = z.infer<typeof RunnerConfigSchema>;

--- a/website/src/content/docs/actors/versions.mdx
+++ b/website/src/content/docs/actors/versions.mdx
@@ -16,6 +16,10 @@ Each runner has a **version number**. When you deploy new code with a new versio
 Versions are not configured by default. See [Registry Configuration](/docs/connect/registry-configuration) to learn how to configure the runner version.
 </Note>
 
+<Note>
+`RIVET_RUNNER_VERSION` is only needed when self-hosting or using a custom runner. Rivet Compute handles versioning automatically.
+</Note>
+
 ### Example Scenario
 
 <Tabs>

--- a/website/src/content/docs/general/production-checklist.mdx
+++ b/website/src/content/docs/general/production-checklist.mdx
@@ -21,6 +21,7 @@ We recommend passing this page to your coding agent to verify your configuration
 ### Serverless
 
 - **Check platform timeouts.** Rivet handles migration between invocations automatically, but shorter timeouts increase migration frequency. See [Timeouts](/docs/general/runtime-modes#timeouts).
+- **Configure max runners.** Go to Settings > Providers > Edit Provider > Max Runners to set the limit. The default is 100,000 runners. This is effectively your max actor count.
 
 ### Runner
 

--- a/website/src/metadata/skill-base-rivetkit.md
+++ b/website/src/metadata/skill-base-rivetkit.md
@@ -75,6 +75,58 @@ Use that canonical URL when citing, not the reference file path.
 
 For more information, read the quickstart guide relevant to the user's project.
 
+## Project Setup
+
+### .gitignore
+
+Every RivetKit project should have a `.gitignore`. Include at minimum:
+
+```
+node_modules/
+dist/
+.env
+```
+
+### .dockerignore
+
+Every project with a Dockerfile should have a `.dockerignore` to keep the image small and avoid leaking secrets:
+
+```
+node_modules/
+dist/
+.env
+.git/
+```
+
+### Dockerfile
+
+Use this as a base Dockerfile for deploying a RivetKit project. The `RIVET_RUNNER_VERSION` build arg is only needed when self-hosting or using a custom runner (not needed for Rivet Compute). It lets Rivet track which version of the actor is running and drain old actors on deploy. See https://rivet.dev/docs/actors/versions for details.
+
+```dockerfile
+FROM node:24-alpine
+
+ARG RIVET_RUNNER_VERSION
+ENV RIVET_RUNNER_VERSION=$RIVET_RUNNER_VERSION
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build --if-present
+
+CMD ["node", "dist/index.js"]
+```
+
+Build with:
+
+```bash
+docker build --build-arg RIVET_RUNNER_VERSION=$(date +%s) .
+```
+
+Adjust the `CMD` to match the project's entry point. If the project uses a different output directory or start command, update accordingly.
+
 ## Error Handling Policy
 
 - Prefer fail-fast behavior by default.


### PR DESCRIPTION
## Description

Added project setup documentation to the RivetKit skill base with .gitignore, .dockerignore, and Dockerfile examples. Also added error logging when RIVET_RUNNER_VERSION is missing in production environments and clarified in documentation that this is only needed for self-hosting/custom runners.

## Changes

- **skill-base-rivetkit.md**: Added Project Setup section with .gitignore, .dockerignore, and Dockerfile templates
- **runner.ts**: Added error-level logging in production when RIVET_RUNNER_VERSION is not set
- **versions.mdx**: Added clarification that RIVET_RUNNER_VERSION is only needed for self-hosting/custom runners
- **production-checklist.mdx**: Added guidance for configuring max runners in serverless mode

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings