### PR TITLE
feat(frontend): add required dc selector to onboaring

### DIFF
--- a/frontend/src/app/data-providers/engine-data-provider.tsx
+++ b/frontend/src/app/data-providers/engine-data-provider.tsx
@@ -617,6 +617,7 @@ export const createNamespaceContext = ({
 		runnerConfigQueryOptions(opts: {
 			name: string | undefined;
 			variant?: Rivet.RunnerConfigVariant;
+			safe?: boolean;
 		}) {
 			return queryOptions({
 				queryKey: [
@@ -635,14 +636,14 @@ export const createNamespaceContext = ({
 
 					const config = response.runnerConfigs[opts.name!];
 
-					if (!config) {
+					if (!config && !opts.safe) {
 						throw new FetchError(
 							"Provider Config not found",
 							"The specified provider configuration could not be found.",
 						);
 					}
 
-					return config;
+					return config || null;
 				},
 				retry: shouldRetryAllExpect403,
 				meta: {

--- a/frontend/src/app/dialogs/connect-cloudflare-frame.tsx
+++ b/frontend/src/app/dialogs/connect-cloudflare-frame.tsx
@@ -176,7 +176,7 @@ function FormStepper({
 				headers: [],
 				datacenters: {},
 			}}
-			footer={footer}
+			controls={footer}
 		/>
 	);
 }

--- a/frontend/src/app/dialogs/connect-manual-serverfull-frame.tsx
+++ b/frontend/src/app/dialogs/connect-manual-serverfull-frame.tsx
@@ -115,7 +115,7 @@ function FormStepper({
 	return (
 		<StepperForm
 			{...stepper}
-			footer={footer}
+			controls={footer}
 			onSubmit={async ({ values }) => {
 				let existing: Record<string, Rivet.RunnerConfig> = {};
 				try {

--- a/frontend/src/app/dialogs/connect-manual-serverless-frame.tsx
+++ b/frontend/src/app/dialogs/connect-manual-serverless-frame.tsx
@@ -5,12 +5,10 @@ import {
 	usePrefetchInfiniteQuery,
 	useSuspenseInfiniteQuery,
 } from "@tanstack/react-query";
-import confetti from "canvas-confetti";
 import type { ComponentProps, ReactNode } from "react";
 import { useWatch } from "react-hook-form";
 import z from "zod";
 import * as ConnectServerlessForm from "@/app/forms/connect-manual-serverless-form";
-import { endpointSchema } from "@/app/forms/connect-manual-serverless-form";
 import {
 	Accordion,
 	AccordionContent,

--- a/frontend/src/app/forms/connect-manual-serverless-form.tsx
+++ b/frontend/src/app/forms/connect-manual-serverless-form.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/app/serverless-connection-check";
 import {
 	Button,
+	cn,
 	FormControl,
 	FormDescription,
 	FormField,
@@ -90,7 +91,7 @@ export const RunnerName = function RunnerName() {
 };
 
 export const Datacenters = function Datacenter() {
-	const { control } = useFormContext();
+	const { control, watch } = useFormContext();
 	const { data: datacenterCount } = useInfiniteQuery({
 		...useEngineCompatDataProvider().datacentersQueryOptions(),
 		select: (data) =>
@@ -102,16 +103,17 @@ export const Datacenters = function Datacenter() {
 
 	return (
 		<div className="space-y-2">
-			<Label>Datacenters</Label>
-			<FormDescription>
-				Rivet datacenters that actors can be created in.
-			</FormDescription>
-
-			<div className="space-y-4">
-				<FormField
-					control={control}
-					name="datacenters"
-					render={({ field }) => (
+			<FormField
+				control={control}
+				name="datacenters"
+				render={({ field }) => (
+					<>
+						<FormLabel>Datacenters</FormLabel>
+						<FormDescription className="mb-4">
+							{watch("provider") === "rivet"
+								? "Select the region(s) to enable for Rivet. Rivet's edge network handles multi-region routing automatically."
+								: "Select the region(s) that your backend is running in. Rivet's edge network handles multi-region routing automatically."}
+						</FormDescription>
 						<RegionSelect
 							showAuto={false}
 							value={Object.keys(field.value || {}).filter(
@@ -143,9 +145,10 @@ export const Datacenters = function Datacenter() {
 							}}
 							multiple
 						/>
-					)}
-				/>
-			</div>
+						<FormMessage />
+					</>
+				)}
+			/>
 		</div>
 	);
 };
@@ -163,7 +166,7 @@ export const MinRunners = ({ className }: { className?: string }) => {
 						<Input
 							type="number"
 							{...field}
-							value={field.value || ""}
+							value={field.value ?? ""}
 							min={0}
 						/>
 					</FormControl>
@@ -430,6 +433,10 @@ export const Endpoint = ({
 				return (
 					<FormItem className={className}>
 						<FormLabel className="col-span-1">Endpoint</FormLabel>
+						<FormDescription className="col-span-1">
+							Enter the publicly accessible URL of your deployed
+							backend.
+						</FormDescription>
 						<FormControl className="row-start-2">
 							<Input
 								type="text"

--- a/frontend/src/app/forms/stepper-form.tsx
+++ b/frontend/src/app/forms/stepper-form.tsx
@@ -18,7 +18,7 @@ import {
 	useFormContext,
 } from "react-hook-form";
 import type * as z from "zod";
-import { Button } from "@/components";
+import { Button, cn } from "@/components";
 import type { defineStepper } from "@/components/ui/stepper";
 import { HelpDropdown } from "../help-dropdown";
 
@@ -26,6 +26,7 @@ type Step = Stepperize.Step & {
 	assist?: boolean;
 	schema: z.ZodSchema | ((values: Record<string, unknown>) => z.ZodSchema);
 	next?: string;
+	previous?: string;
 	showNext?: boolean;
 	showPrevious?: boolean;
 	group?: string;
@@ -103,7 +104,7 @@ type StepperFormProps<Steps extends Step[]> = StepperProps<Steps> &
 		showAllSteps?: boolean;
 		singlePage?: boolean;
 		initialStep?: Steps[number]["id"];
-		footer?: ReactNode;
+		controls?: ReactNode;
 		children?: ReactNode;
 		formId?: string;
 		className?: string;
@@ -195,7 +196,7 @@ function Content<const Steps extends Step[]>({
 	onSubmit,
 	onPartialSubmit,
 	initialStep,
-	footer,
+	controls,
 	formId,
 	extraChildren,
 	...formProps
@@ -347,7 +348,7 @@ function Content<const Steps extends Step[]>({
 											}
 											step={step}
 											content={content}
-											footer={footer}
+											controls={controls}
 											showNext={step.showNext ?? true}
 											showPrevious={
 												(step.showPrevious ?? true) &&
@@ -415,7 +416,7 @@ function Content<const Steps extends Step[]>({
 											showControls={
 												steps.length - 1 === index
 											}
-											footer={footer}
+											controls={controls}
 											isLastVisible={isLastVisible(
 												step.id,
 											)}
@@ -437,7 +438,7 @@ function Content<const Steps extends Step[]>({
 													}
 													step={step}
 													content={content}
-													footer={footer}
+													controls={controls}
 													showNext={
 														step.showNext ?? true
 													}
@@ -473,7 +474,7 @@ function StepPanel<const Steps extends Step[]>({
 	showPrevious = true,
 	showControls = true,
 	isLastVisible = false,
-	footer,
+	controls,
 }: Pick<StepperFormProps<Steps>, "Stepper" | "content"> & {
 	stepper: Stepperize.Stepper<Steps>;
 	allSteps: Step[];
@@ -483,7 +484,7 @@ function StepPanel<const Steps extends Step[]>({
 	showNext?: boolean;
 	showPrevious?: boolean;
 	isLastVisible?: boolean;
-	footer?: ReactNode;
+	controls?: ReactNode;
 }) {
 	const form = useFormContext();
 
@@ -511,16 +512,30 @@ function StepPanel<const Steps extends Step[]>({
 		<Stepper.Panel className="space-y-6">
 			{stepper.match(step.id, content)}
 			{showControls ? (
-				<Stepper.Controls>
-					{footer}
+				<Stepper.Controls
+					className={cn(
+						"items-center",
+						stepper.isLast && !showNext && "justify-start",
+					)}
+				>
+					{controls}
 					{showPrevious ? (
 						<Button
 							type="button"
 							variant="outline"
-							size="icon"
+							size={step.previous ? undefined : "icon"}
 							onClick={goToPrev}
+							startIcon={
+								step.previous ? (
+									<Icon icon={faArrowLeft} />
+								) : undefined
+							}
 						>
-							<Icon icon={faArrowLeft} />
+							{step.previous ? (
+								step.previous
+							) : (
+								<Icon icon={faArrowLeft} />
+							)}
 						</Button>
 					) : null}
 					{showNext ? (

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -56,6 +56,7 @@ import { DeploymentCheck } from "./deployment-check";
 import { useEndpoint } from "./dialogs/connect-manual-serverfull-frame";
 import {
 	buildServerlessConfig,
+	Configuration,
 	ConfigurationAccordion,
 } from "./dialogs/connect-manual-serverless-frame";
 import { EnvVariables, useRivetDsn } from "./env-variables";
@@ -110,8 +111,8 @@ const stepper = defineStepper(
 		assist: true,
 		group: "deploy",
 		schema: z.object({}),
+		previous: "Edit Provider",
 		showNext: false,
-		showPrevious: false,
 	},
 );
 
@@ -131,6 +132,36 @@ export function GettingStarted({
 		...dataProvider.upsertCurrentNamespaceManagedPoolMutationOptions(),
 	});
 
+	const { data: initialRunnerConfig } = useSuspenseQuery({
+		...dataProvider.runnerConfigQueryOptions({
+			name: "default",
+			safe: true,
+		}),
+		select: (data) => {
+			const config = Object.values(data?.datacenters || {}).find(
+				(dc) => dc.serverless,
+			);
+			const serverlessConfig = config?.serverless;
+
+			if (!serverlessConfig) {
+				return null;
+			}
+
+			return {
+				...serverlessConfig,
+				runnerName: "default",
+				endpoint: serverlessConfig.url,
+				headers: Array.from(
+					Object.entries(serverlessConfig.headers || {}),
+				),
+				provider: deriveProviderFromMetadata(config?.metadata || {}),
+				datacenters: Object.fromEntries(
+					Object.keys(data.datacenters).map((name) => [name, true]),
+				),
+			};
+		},
+	});
+
 	const { mutateAsync } = useMutation({
 		...dataProvider.upsertRunnerConfigMutationOptions(),
 		onSuccess: async () => {
@@ -141,6 +172,18 @@ export function GettingStarted({
 	});
 
 	const navigate = useNavigate();
+
+	const defaultValues = {
+		slotsPerRunner: 1,
+		maxRunners: 1_000,
+		minRunners: 1,
+		runnerMargin: 0,
+		headers: [],
+		requestLifespan: 900,
+		provider: provider || "",
+		datacenters: [],
+		...(initialRunnerConfig || {}),
+	};
 
 	return (
 		<Content className="flex flex-col items-center justify-safe-center">
@@ -164,20 +207,7 @@ export function GettingStarted({
 										? "backend"
 										: undefined
 							}
-							// eslint-disable-next-line @typescript-eslint/no-explicit-any
-							defaultValues={{
-								provider: provider || "",
-								runnerName: "default",
-								slotsPerRunner: 1,
-								maxRunners: 1_000,
-								minRunners: 1,
-								runnerMargin: 0,
-								headers: [],
-								requestLifespan: 900,
-								datacenters: Object.fromEntries(
-									datacenters.map((dc) => [dc.name, true]),
-								),
-							}}
+							defaultValues={defaultValues}
 							content={{
 								install: () => (
 									<StepContent>
@@ -294,9 +324,6 @@ function StepContent({
 	children: ReactNode;
 	wide?: boolean;
 }) {
-	const { formState, watch } = useFormContext();
-
-	console.log(formState.errors, formState.isValid, watch());
 	return (
 		<motion.div
 			className="mx-auto"
@@ -313,9 +340,10 @@ function StepContent({
 
 function StepperFooter() {
 	const s = stepper.useStepper();
-	return (
-		<div className="flex flex-col items-center gap-4 mt-6">
-			{s.current.group === "local" && s.current.id !== "explore" ? (
+
+	if (s.current.group === "local" && s.current.id !== "explore") {
+		return (
+			<div className="flex flex-col items-center gap-4 mt-6">
 				<Button
 					type="button"
 					variant="link"
@@ -326,21 +354,10 @@ function StepperFooter() {
 				>
 					Already have a project working locally? Skip to deploy
 				</Button>
-			) : null}
-			{s.isLast ? (
-				<Button
-					asChild
-					variant="link"
-					size="xs"
-					className="text-muted-foreground"
-				>
-					<Link to="." search={{ modal: "create-actor" }}>
-						Manually Create Actor
-					</Link>
-				</Button>
-			) : null}
-		</div>
-	);
+			</div>
+		);
+	}
+	return null;
 }
 
 function ProviderSetup() {
@@ -1261,6 +1278,7 @@ function BackendSetup() {
 		return (
 			<div className="flex flex-col gap-6">
 				<CopyAgentInstructionsButton provider={provider} />
+
 				<div className="flex gap-3">
 					<StepNumber n={1} />
 					<div className="flex-1 min-w-0">
@@ -1279,15 +1297,20 @@ function BackendSetup() {
 				<div className="flex gap-3">
 					<StepNumber n={2} />
 					<div className="flex-1 min-w-0">
-						<p className="font-medium mb-2">
+						<p className="font-medium mb-4">
 							Paste your deployment endpoint
 						</p>
-						<p className="text-sm text-muted-foreground mb-3">
-							Enter the publicly accessible URL of your deployed
-							backend. Or ask your coding agent to provide it for
-							you.
-						</p>
 						<div className="space-y-2">
+							<Configuration
+								runnerName={false}
+								datacenters
+								headers={false}
+								slotsPerRunner={false}
+								minRunners={false}
+								maxRunners={false}
+								runnerMargin={false}
+								requestLifespan={false}
+							/>
 							<ConnectServerlessForm.Endpoint
 								placeholder={match(provider)
 									.with(
@@ -1303,7 +1326,7 @@ function BackendSetup() {
 										() => "https://your-deployment.com",
 									)}
 							/>
-							<ConfigurationAccordion />
+							<ConfigurationAccordion datacenters={false} />
 							<ConnectServerlessForm.ConnectionCheck
 								provider={provider}
 							/>
@@ -1379,7 +1402,7 @@ function FrontendSetup() {
 
 	return (
 		<div className="space-y-2">
-			<div className="border rounded-md py-10">
+			<div className="border rounded-md py-10 flex flex-col gap-6">
 				<div className="flex gap-2 justify-center items-center py-2 px-8">
 					<div className="relative mr-4">
 						<Ping variant="pending" className="relative" />
@@ -1387,7 +1410,7 @@ function FrontendSetup() {
 					<p>Waiting for an Actor to be created...</p>
 				</div>
 
-				<div className="flex items-center justify-center mt-6 gap-4">
+				<div className="flex items-center flex-col justify-center gap-4">
 					{deploymentUrl ? (
 						<Button variant="outline">
 							<a
@@ -1405,6 +1428,16 @@ function FrontendSetup() {
 							</Link>
 						</Button>
 					)}
+					<Button
+						asChild
+						variant="link"
+						size="xs"
+						className="text-muted-foreground mx-auto inline-block"
+					>
+						<Link to="." search={{ modal: "create-actor" }}>
+							or Manually Create Actor
+						</Link>
+					</Button>
 				</div>
 			</div>
 			<Accordion type="single" collapsible className="mt-10">

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -108,8 +108,8 @@ export const Combobox = <Option extends ComboboxOption>({
 				}
 			} else {
 				onValueChange(newValue);
+				onOpenChange(false);
 			}
-			onOpenChange(false);
 		});
 	};
 


### PR DESCRIPTION
# Description

This pull request improves the getting started flow and form components with several enhancements:

- Added a `safe` parameter to `runnerConfigQueryOptions` to allow graceful handling of missing configurations without throwing errors
- Enhanced the stepper form component with support for custom previous button text and improved control layout
- Improved the serverless connection form with better field descriptions, proper form validation structure, and enhanced datacenter selection messaging
- Updated the getting started flow to pre-populate forms with existing runner configurations when available
- Fixed combobox behavior to only close on single selection, keeping it open for multiple selections
- Reorganized the backend setup step to show configuration options before the endpoint field
- Enhanced the frontend setup waiting state with better layout and additional manual creation option

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes