### PR TITLE
fix(rivetkit): close manager server on SIGTERM/SIGINT for hot-reload port reuse

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/runtime/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/runtime/index.ts
@@ -165,6 +165,21 @@ export class Runtime<A extends RegistryActors> {
 				serveRuntime,
 			);
 			upgradeWebSocket = out.upgradeWebSocket;
+
+			// Close the server on SIGTERM/SIGINT so the port is freed quickly
+			// during hot reload. Dev servers like tsx --watch, nodemon, etc.
+			// sometimes start the new process before the old one fully exits,
+			// causing findFreePort to skip the preferred port.
+			//
+			// Only do this for the manager, not the engine. Closing the engine
+			// server on signal would cause running actors to hard fail.
+			if (out.closeServer && process.env.NODE_ENV !== "production") {
+				const shutdown = () => {
+					out.closeServer!();
+				};
+				process.on("SIGTERM", shutdown);
+				process.on("SIGINT", shutdown);
+			}
 		}
 
 		// Create runtime

--- a/rivetkit-typescript/packages/rivetkit/src/utils/serve.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/utils/serve.ts
@@ -40,7 +40,7 @@ export async function crossPlatformServe(
 	managerPort: number,
 	app: Hono<any>,
 	runtime: Runtime = detectRuntime(),
-): Promise<{ upgradeWebSocket: any }> {
+): Promise<{ upgradeWebSocket: any; closeServer?: () => void }> {
 	logger().debug({ msg: "detected runtime for serve", runtime });
 
 	switch (runtime) {
@@ -89,7 +89,7 @@ async function serveNode(
 	config: RegistryConfig,
 	managerPort: number,
 	app: Hono<any>,
-): Promise<{ upgradeWebSocket: any }> {
+): Promise<{ upgradeWebSocket: any; closeServer: () => void }> {
 	// Import @hono/node-server using string variable to prevent static analysis
 	const nodeServerModule = "@hono/node-server";
 	let serve: any;
@@ -137,7 +137,11 @@ async function serveNode(
 	);
 	injectWebSocket(server);
 
-	return { upgradeWebSocket };
+	const closeServer = () => {
+		server.close();
+	};
+
+	return { upgradeWebSocket, closeServer };
 }
 
 async function serveDeno(


### PR DESCRIPTION
## Description

Fixes manager server port drift during hot reload. When a dev server hot-reloads (e.g., with tsx --watch or nodemon), the new process may start before the old one fully shuts down, causing the manager to bind to a different port (6420 → 6421 → 6422, etc.).

This change registers SIGTERM/SIGINT handlers that close the HTTP server immediately in development mode, freeing the port for the next process. Only applies to the manager in dev; engine servers are excluded to avoid causing running actors to hard fail.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Reproduced the race condition by starting two RivetKit instances simultaneously. Without the fix, the second instance gets port 6421. With the fix, SIGTERM frees port 6420, allowing the second instance to bind to the preferred port.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas