### PR TITLE
fix(frontend): proper billing calculations

### DIFF
--- a/frontend/src/app/billing/usage-card.tsx
+++ b/frontend/src/app/billing/usage-card.tsx
@@ -31,6 +31,12 @@ function formatMetricValue(value: bigint, type: MetricType): string {
 	switch (type) {
 		case "hours": {
 			const hours = num / 3600;
+			if (hours >= 1_000_000_000) {
+				return `${stripTrailingZeros(hours / 1_000_000_000, 1)}B hrs`;
+			}
+			if (hours >= 1_000_000) {
+				return `${stripTrailingZeros(hours / 1_000_000, 1)}M hrs`;
+			}
 			if (hours >= 1000) {
 				return `${stripTrailingZeros(hours / 1000, 1)}k hrs`;
 			}
@@ -57,7 +63,7 @@ function formatMetricValue(value: bigint, type: MetricType): string {
 			return `${num} B`;
 		}
 		case "operations": {
-			const units = num / 4096;
+			const units = num / 4000;
 			if (units >= 1_000_000_000) {
 				return `${stripTrailingZeros(units / 1_000_000_000, 2)}B ops`;
 			}

--- a/frontend/src/content/billing.ts
+++ b/frontend/src/content/billing.ts
@@ -1,5 +1,4 @@
 import type { Rivet } from "@rivet-gg/cloud";
-import { bigBytes } from "@/utils/bytes";
 
 const ACTOR_AWAKE_PRICE_PER_SECOND =
 	0.05 /
@@ -51,22 +50,26 @@ type BilledMetrics = Extract<
 	| "kv_write"
 	| "gateway_egress"
 >;
+const GB = 1_000_000_000n;
+const TB = 1_000_000_000_000n;
+const KB = 1_000n;
+
 export const BILLING = {
 	included: {
 		free: {
-			kv_read: 200_000_000n * bigBytes.KiB(4n), // 200M 4KB units
-			kv_write: 5_000_000n * bigBytes.KiB(4n), // 5M 4KB units
-			gateway_egress: bigBytes.GiB(100n), // 100 GB
-			kv_storage_used: bigBytes.GiB(5n), // 5 GB
+			kv_read: 200_000_000n * (4n * KB), // 200M 4KB units
+			kv_write: 5_000_000n * (4n * KB), // 5M 4KB units
+			gateway_egress: 100n * GB, // 100 GB
+			kv_storage_used: 5n * GB, // 5 GB
 			actor_awake: BigInt(
 				5_00 /* $5 to cents */ / ACTOR_AWAKE_PRICE_PER_SECOND,
 			),
 		},
 		pro: {
-			kv_read: 25_000_000_000n * bigBytes.KiB(4n), // 25B 4KB units
-			kv_write: 50_000_000n * bigBytes.KiB(4n), // 50M 4KB units
-			gateway_egress: bigBytes.TiB(1n), // 1 TB
-			kv_storage_used: bigBytes.GiB(5n), // 5 GB
+			kv_read: 25_000_000_000n * (4n * KB), // 25B 4KB units
+			kv_write: 50_000_000n * (4n * KB), // 50M 4KB units
+			gateway_egress: 1n * TB, // 1 TB
+			kv_storage_used: 5n * GB, // 5 GB
 			actor_awake: BigInt(
 				20_00 /* $20 to cents */ / ACTOR_AWAKE_PRICE_PER_SECOND,
 			),


### PR DESCRIPTION
# Description

This change improves the billing usage display by adding support for billion and million hour formatting in the usage card, and standardizes byte unit calculations by replacing the `bigBytes` utility with inline constants. The operations metric calculation has been adjusted from 4096 to 4000 units for more accurate billing representation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes