### PR TITLE
fix(rivetkit-swift): avoid double percent-encoding paths in URLUtils

### DIFF
--- a/rivetkit-swift/Sources/RivetKitClient/URLUtils.swift
+++ b/rivetkit-swift/Sources/RivetKitClient/URLUtils.swift
@@ -36,7 +36,12 @@ enum URLUtils {
         }
 
         var components = URLComponents(url: baseUrl, resolvingAgainstBaseURL: false)
-        components?.path = fullPath
+        // `fullPath` is built from already percent-encoded segments (see
+        // buildActorGatewayUrl and the action callers in RemoteManager), so use
+        // percentEncodedPath here. Assigning to .path would re-encode `%` and
+        // turn `%3A` into `%253A`, which breaks /gateway/{actorId} routing for
+        // actor IDs that contain `:` (e.g. Cloudflare Workers).
+        components?.percentEncodedPath = fullPath
         components?.percentEncodedQuery = queryParts.isEmpty ? nil : queryParts.joined(separator: "&")
         components?.fragment = nil
 

--- a/rivetkit-swift/Sources/RivetKitClient/URLUtils.swift
+++ b/rivetkit-swift/Sources/RivetKitClient/URLUtils.swift
@@ -36,11 +36,8 @@ enum URLUtils {
         }
 
         var components = URLComponents(url: baseUrl, resolvingAgainstBaseURL: false)
-        // `fullPath` is built from already percent-encoded segments (see
-        // buildActorGatewayUrl and the action callers in RemoteManager), so use
-        // percentEncodedPath here. Assigning to .path would re-encode `%` and
-        // turn `%3A` into `%253A`, which breaks /gateway/{actorId} routing for
-        // actor IDs that contain `:` (e.g. Cloudflare Workers).
+        // fullPath is already percent-encoded (see buildActorGatewayUrl); .path would
+        // re-encode `%` and break actor IDs containing `:` (e.g. Cloudflare Workers).
         components?.percentEncodedPath = fullPath
         components?.percentEncodedQuery = queryParts.isEmpty ? nil : queryParts.joined(separator: "&")
         components?.fragment = nil


### PR DESCRIPTION
> Re-filing [rivet-dev/rivetkit-swift#1](https://github.com/rivet-dev/rivetkit-swift/pull/1) against the monorepo

`combineUrlPath` builds `fullPath` from already-encoded segments (`buildActorGatewayUrl` runs `addingPercentEncoding(...)` on the actor ID, and the action helpers in `RemoteManager` do the same on path-injected IDs/keys), then assigns it to `URLComponents.path`, which runs another encoding pass and turns `%3A` into `%253A`.

This is invisible for backends whose actor IDs are URL-safe (file-system driver hex hash, engine UUIDs, etc.), so it slipped through. But `@rivetkit/cloudflare-workers` formats actor IDs as `${durableObjectId}:${generation}`, so `:` → `%3A` → `%253A`. After the round-trip the worker decodes one layer and `parseActorId` throws `Invalid actor ID format: ...e3704%3A0`, the WebSocket handshake fails, and the SwiftUI client enters a reconnect loop.

Repro:

1. `wrangler dev` a `@rivetkit/cloudflare-workers` registry exposing any actor.
2. Point a SwiftUI client at `http://127.0.0.1:8787/api/rivet` and trigger an action.
3. `PUT /actors` succeeds (no encoded segment in the path), then `/gateway/{actorId}/connect` 500s with `Invalid actor ID format`. Patched build connects normally and events flow.

The plain API paths (`/metadata`, `/actors`, `?namespace=...`) have nothing to re-encode, so they're unaffected by the switch to `percentEncodedPath`. I didn't add a unit test because `URLUtils` is internal and the existing tests run against a `TestServer` — happy to add `@testable` coverage if you'd prefer.